### PR TITLE
feat: add dialog integration support for FormCraft forms

### DIFF
--- a/FormCraft.DemoBlazorApp/Components/Dialogs/EditFormDialog.razor
+++ b/FormCraft.DemoBlazorApp/Components/Dialogs/EditFormDialog.razor
@@ -1,0 +1,20 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-2" />
+            Edit Product
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText Class="mb-4">Edit the product details below:</MudText>
+        <FormCraftComponent
+            TModel="ProductModel" 
+            Model="@Model" 
+            Configuration="@_formConfig"
+            ShowSubmitButton="false" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@Submit" Variant="Variant.Filled">Save Changes</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/FormCraft.DemoBlazorApp/Components/Dialogs/EditFormDialog.razor.cs
+++ b/FormCraft.DemoBlazorApp/Components/Dialogs/EditFormDialog.razor.cs
@@ -1,0 +1,50 @@
+using FormCraft.DemoBlazorApp.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FormCraft.DemoBlazorApp.Components.Dialogs;
+
+public partial class EditFormDialog
+{
+    private IFormConfiguration<ProductModel> _formConfig = null!;
+
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = null!;
+    
+    [Parameter]
+    public ProductModel Model { get; set; } = new();
+    
+    protected override void OnInitialized()
+    {
+        _formConfig = FormBuilder<ProductModel>
+            .Create()
+            .AddField(x => x.Name, field => field
+                .WithLabel("Product Name")
+                .Required())
+            .AddField(x => x.Description, field => field
+                .WithLabel("Description")
+                .AsTextArea(lines: 4)
+                .Required())
+            .AddField(x => x.Price, field => field
+                .WithLabel("Price")
+                .WithPlaceholder("0.00")
+                .Required())
+            .AddField(x => x.Category, field => field
+                .WithLabel("Category")
+                .WithPlaceholder("Select a category")
+                .Required())
+            .AddField(x => x.IsAvailable, field => field
+                .WithLabel("Available for Sale"))
+            .Build();
+    }
+
+    private void Submit()
+    {
+        MudDialog.Close(DialogResult.Ok(Model));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+}

--- a/FormCraft.DemoBlazorApp/Components/Dialogs/SimpleFormDialog.razor
+++ b/FormCraft.DemoBlazorApp/Components/Dialogs/SimpleFormDialog.razor
@@ -1,0 +1,19 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="mr-2" />
+            New Contact
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <FormCraftComponent
+            TModel="ContactModel" 
+            Model="@Model" 
+            Configuration="@_formConfig"
+            ShowSubmitButton="false" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="@Submit" Variant="Variant.Filled">Create Contact</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/FormCraft.DemoBlazorApp/Components/Dialogs/SimpleFormDialog.razor.cs
+++ b/FormCraft.DemoBlazorApp/Components/Dialogs/SimpleFormDialog.razor.cs
@@ -1,0 +1,53 @@
+using FormCraft.DemoBlazorApp.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FormCraft.DemoBlazorApp.Components.Dialogs;
+
+public partial class SimpleFormDialog
+{
+    private IFormConfiguration<ContactModel> _formConfig = null!;
+
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = null!;
+    
+    [Parameter]
+    public ContactModel Model { get; set; } = new();
+
+    protected override void OnInitialized()
+    {
+        _formConfig = FormBuilder<ContactModel>
+            .Create()
+            .AddField(x => x.FirstName, field => field
+                .WithLabel("First Name")
+                .WithPlaceholder("Enter first name")
+                .Required())
+            .AddField(x => x.LastName, field => field
+                .WithLabel("Last Name")
+                .WithPlaceholder("Enter last name")
+                .Required())
+            .AddField(x => x.Email, field => field
+                .WithLabel("Email")
+                .WithPlaceholder("Enter email address")
+                .Required())
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithPlaceholder("Enter phone number (optional)"))
+            .AddField(x => x.Message, field => field
+                .WithLabel("Message")
+                .WithPlaceholder("Any additional notes...")
+                .AsTextArea(lines: 3))
+            .Build();
+    }
+
+    private void Submit()
+    {
+        // In a real application, you would validate the form here
+        MudDialog.Close(DialogResult.Ok(Model));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+}

--- a/FormCraft.DemoBlazorApp/Components/Layout/MainLayout.razor
+++ b/FormCraft.DemoBlazorApp/Components/Layout/MainLayout.razor
@@ -96,6 +96,9 @@
                 <MudNavLink Href="fluent-validation-demo" Icon="@Icons.Material.Filled.CheckCircle">
                     FluentValidation Demo
                 </MudNavLink>
+                <MudNavLink Href="dialog-demo" Icon="@Icons.Material.Filled.OpenInNew">
+                    Dialog Integration
+                </MudNavLink>
             </MudNavGroup>
             
             <MudNavGroup Title="Documentation" Icon="@Icons.Material.Filled.MenuBook" Expanded="true">

--- a/FormCraft.DemoBlazorApp/Components/Pages/DialogDemo.razor
+++ b/FormCraft.DemoBlazorApp/Components/Pages/DialogDemo.razor
@@ -1,0 +1,78 @@
+@page "/dialog-demo"
+@inject IDialogService DialogService
+
+<PageTitle>Dialog Integration Demo</PageTitle>
+
+<DemoPageLayout
+    Title="Dialog Integration"
+    Icon="@Icons.Material.Filled.OpenInNew"
+    Description="Use FormCraft forms inside MudBlazor dialogs for consistent form experiences in modal contexts. Create, edit, and interact with forms in dialog windows."
+    FormDemoIcon="@Icons.Material.Filled.Window">
+    <FormDemoContent>
+        <MudGrid>
+            <!-- Simple Dialog Example -->
+            <MudItem xs="12" md="6">
+                <MudPaper Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">
+                        <MudIcon Icon="@Icons.Material.Filled.AddBox" Class="mr-2" />
+                        Simple Form Dialog
+                    </MudText>
+                    <MudText Typo="Typo.body2" Class="mb-3">
+                        Demonstrates a basic form in a dialog for creating new records.
+                    </MudText>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenSimpleDialog">
+                        Open Contact Form
+                    </MudButton>
+                    
+                    @if (!string.IsNullOrEmpty(_simpleDialogResult))
+                    {
+                        <MudAlert Severity="Severity.Success" Class="mt-4">
+                            @_simpleDialogResult
+                        </MudAlert>
+                    }
+                </MudPaper>
+            </MudItem>
+
+            <!-- Edit Dialog Example -->
+            <MudItem xs="12" md="6">
+                <MudPaper Class="pa-4">
+                    <MudText Typo="Typo.h6" GutterBottom="true">
+                        <MudIcon Icon="@Icons.Material.Filled.Edit" Class="mr-2" />
+                        Edit Form Dialog
+                    </MudText>
+                    <MudText Typo="Typo.body2" Class="mb-3">
+                        Shows how to pre-populate a form with existing data for editing.
+                    </MudText>
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="OpenEditDialog">
+                        Edit Product
+                    </MudButton>
+                    
+                    @if (!string.IsNullOrEmpty(_editDialogResult))
+                    {
+                        <MudAlert Severity="Severity.Info" Class="mt-4">
+                            @_editDialogResult
+                        </MudAlert>
+                    }
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    </FormDemoContent>
+    
+    <CodeExampleContent>
+        <MudText Typo="Typo.h6" GutterBottom="true">Dialog Component Example</MudText>
+        <MudText Typo="Typo.body2" Class="mb-3">
+            Here's how to create a dialog component with FormCraft:
+        </MudText>
+        <CodeExample Code="@_dialogExample" />
+        
+        <MudText Typo="Typo.h6" Class="mt-6" GutterBottom="true">Usage Example</MudText>
+        <MudText Typo="Typo.body2" Class="mb-3">
+            How to open and handle dialog results:
+        </MudText>
+        <CodeExample Code="@_usageExample" />
+    </CodeExampleContent>
+    
+    <GuidelinesContent>
+        <FormGuidelines Guidelines="@_guidelines" Title="Dialog Integration Best Practices" />
+    </GuidelinesContent>
+</DemoPageLayout>

--- a/FormCraft.DemoBlazorApp/Components/Pages/DialogDemo.razor.cs
+++ b/FormCraft.DemoBlazorApp/Components/Pages/DialogDemo.razor.cs
@@ -1,0 +1,142 @@
+using FormCraft.DemoBlazorApp.Components.Dialogs;
+using FormCraft.DemoBlazorApp.Components.Shared;
+using FormCraft.DemoBlazorApp.Models;
+using MudBlazor;
+
+namespace FormCraft.DemoBlazorApp.Components.Pages;
+
+public partial class DialogDemo
+{
+    private string _simpleDialogResult = string.Empty;
+    private string _editDialogResult = string.Empty;
+
+    private readonly DialogOptions _options = new()
+    {
+        MaxWidth = MaxWidth.Small,
+        FullWidth = true
+    };
+    
+    private readonly List<FormGuidelines.GuidelineItem> _guidelines = new()
+    {
+        new() { Icon = Icons.Material.Filled.Window, Text = "Use FormCraft forms seamlessly within MudBlazor dialogs" },
+        new() { Icon = Icons.Material.Filled.DataObject, Text = "Pass model data to dialogs using DialogParameters" },
+        new() { Icon = Icons.Material.Filled.CallReceived, Text = "Handle dialog results with proper null checking" },
+        new() { Icon = Icons.Material.Filled.Settings, Text = "Configure dialog options for size and behavior" },
+        new() { Icon = Icons.Material.Filled.Cancel, Text = "Always provide cancel functionality in dialogs" },
+        new() { Icon = Icons.Material.Filled.CheckCircle, Text = "Validate forms before closing dialogs" }
+    };
+    
+    private async Task OpenSimpleDialog()
+    {
+        var parameters = new DialogParameters
+        {
+            { "Model", new ContactModel() }
+        };
+
+        var dialog = await DialogService.ShowAsync<SimpleFormDialog>("New Contact", parameters, _options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: ContactModel contact })
+        {
+            _simpleDialogResult = $"Contact created: {contact.FirstName} {contact.LastName} ({contact.Email})";
+        }
+    }
+
+    private async Task OpenEditDialog()
+    {
+        var product = new ProductModel
+        {
+            Name = "Laptop Pro X1",
+            Description = "High-performance laptop with cutting-edge features",
+            Price = 1299.99m,
+            Category = "Electronics",
+            IsAvailable = true
+        };
+
+        var parameters = new DialogParameters
+        {
+            { "Model", product }
+        };
+
+        var dialog = await DialogService.ShowAsync<EditFormDialog>("Edit Product", parameters, _options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: ProductModel editedProduct })
+        {
+            _editDialogResult = $"Product updated: {editedProduct.Name} - ${editedProduct.Price:F2}";
+        }
+    }
+
+    private const string _dialogExample = @"@using FormCraft
+@using MudBlazor
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo=""Typo.h6"">
+            <MudIcon Icon=""@Icons.Material.Filled.PersonAdd"" Class=""mr-2"" />
+            New Contact
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <FormCraftComponent
+            TModel=""ContactModel"" 
+            Model=""@Model"" 
+            Configuration=""@_formConfig""
+            ShowSubmitButton=""false"" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick=""Cancel"">Cancel</MudButton>
+        <MudButton Color=""Color.Primary"" OnClick=""Submit"" Variant=""Variant.Filled"">
+            Save
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] public IMudDialogInstance MudDialog { get; set; } = null!;
+    [Parameter] public ContactModel Model { get; set; } = new();
+    
+    private IFormConfiguration<ContactModel> _formConfig = null!;
+
+    protected override void OnInitialized()
+    {
+        _formConfig = FormBuilder<ContactModel>
+            .Create()
+            .AddField(x => x.FirstName, field => field
+                .WithLabel(""First Name"")
+                .Required())
+            .AddField(x => x.Email, field => field
+                .WithLabel(""Email"")
+                .Required())
+            .AddField(x => x.Message, field => field
+                .WithLabel(""Message"")
+                .AsTextArea(lines: 3))
+            .Build();
+    }
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(Model));
+    private void Cancel() => MudDialog.Cancel();
+}";
+
+    private const string _usageExample = @"@inject IDialogService DialogService
+
+private async Task OpenDialog()
+{
+    var parameters = new DialogParameters
+    {
+        { ""Model"", new ContactModel() }
+    };
+
+    var dialog = await DialogService.ShowAsync<ContactFormDialog>(
+        ""New Contact"", 
+        parameters);
+    
+    var result = await dialog.Result;
+
+    if (!result.Canceled && result.Data is ContactModel contact)
+    {
+        // Process the submitted data
+        await SaveContact(contact);
+    }
+}";
+}

--- a/FormCraft.DemoBlazorApp/Models/EmployeeModel.cs
+++ b/FormCraft.DemoBlazorApp/Models/EmployeeModel.cs
@@ -20,4 +20,5 @@ public class EmployeeModel
     
     // Additional
     public string? Biography { get; set; }
+    public string? Notes { get; set; }
 }

--- a/FormCraft.DemoBlazorApp/Models/ProductModel.cs
+++ b/FormCraft.DemoBlazorApp/Models/ProductModel.cs
@@ -12,6 +12,7 @@ public class ProductModel
     public int Rating { get; set; } = 3;
     public double Volume { get; set; } = 50.0;
     public bool InStock { get; set; } = true;
+    public bool IsAvailable { get; set; } = true;
     public string Category { get; set; } = "";
     public DateTime ReleaseDate { get; set; } = DateTime.Today;
 }

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -195,6 +195,15 @@ public partial class FormCraftComponent<TModel>
         builder.AddAttribute(3, "ValueChanged",
             EventCallback.Factory.Create<T>(this, 
                 newValue => UpdateFieldValue(field.FieldName, newValue)));
+        builder.AddAttribute(4, "Immediate", true);
+        
+        // Add culture and pattern to ensure proper decimal display
+        builder.AddAttribute(5, "Culture", System.Globalization.CultureInfo.InvariantCulture);
+        if (typeof(T) == typeof(decimal))
+        {
+            builder.AddAttribute(6, "Pattern", "[0-9]+([.,][0-9]+)?");
+        }
+        
         builder.CloseComponent();
     }
 


### PR DESCRIPTION
- Add DialogDemo page showcasing FormCraft forms in MudBlazor dialogs
- Create SimpleFormDialog for creating new records
- Create EditFormDialog for editing existing data
- Add numeric field culture support for proper decimal display
- Update MainLayout to include Dialog Integration navigation link
- Add IsAvailable property to ProductModel
- Add Notes property to EmployeeModel