### PR TITLE
Handle boxed field types in renderer

### DIFF
--- a/FormCraft.UnitTests/Rendering/FieldRendererServiceTests.cs
+++ b/FormCraft.UnitTests/Rendering/FieldRendererServiceTests.cs
@@ -242,9 +242,156 @@ public class FieldRendererServiceTests
         // Should return unsupported field type message
     }
 
+    [Fact]
+    public void RenderField_Should_Detect_Correct_Type_For_Simple_MemberExpression()
+    {
+        // Arrange
+        var model = new TestModel { Name = "Test" };
+        var field = new FieldConfiguration<TestModel, string?>(x => x.Name);
+        var wrapper = new FieldConfigurationWrapper<TestModel, string?>(field);
+        Type? detectedType = null;
+
+        var mockRenderer = A.Fake<IFieldRenderer>();
+        A.CallTo(() => mockRenderer.CanRender(A<Type>._, A<IFieldConfiguration<object, object>>._))
+            .ReturnsLazily((Type type, IFieldConfiguration<object, object> _) =>
+            {
+                detectedType = type;
+                return true;
+            });
+        A.CallTo(() => mockRenderer.Render(A<IFieldRenderContext<TestModel>>._))
+            .Returns(builder => builder.AddContent(0, "Test"));
+
+        var service = new FieldRendererService(new[] { mockRenderer }, _serviceProvider);
+        var onValueChanged = EventCallback.Factory.Create<object?>(this, _ => { });
+        var onDependencyChanged = EventCallback.Factory.Create(this, () => { });
+
+        // Act
+        service.RenderField(model, wrapper, onValueChanged, onDependencyChanged);
+
+        // Assert
+        // The GetActualFieldType method in FieldRendererService handles UnaryExpression
+        // and returns the underlying property type
+        detectedType.ShouldBe(typeof(string));
+    }
+
+
+    [Fact]
+    public void RenderField_Should_Detect_Correct_Type_For_Value_Type_MemberExpression()
+    {
+        // Arrange
+        var model = new TestModel { Value = 42 };
+        var field = new FieldConfiguration<TestModel, int>(x => x.Value);
+        var wrapper = new FieldConfigurationWrapper<TestModel, int>(field);
+        Type? detectedType = null;
+
+        var mockRenderer = A.Fake<IFieldRenderer>();
+        A.CallTo(() => mockRenderer.CanRender(A<Type>._, A<IFieldConfiguration<object, object>>._))
+            .ReturnsLazily((Type type, IFieldConfiguration<object, object> _) =>
+            {
+                detectedType = type;
+                return true;
+            });
+        A.CallTo(() => mockRenderer.Render(A<IFieldRenderContext<TestModel>>._))
+            .Returns(builder => builder.AddContent(0, "Test"));
+
+        var service = new FieldRendererService(new[] { mockRenderer }, _serviceProvider);
+        var onValueChanged = EventCallback.Factory.Create<object?>(this, _ => { });
+        var onDependencyChanged = EventCallback.Factory.Create(this, () => { });
+
+        // Act
+        service.RenderField(model, wrapper, onValueChanged, onDependencyChanged);
+
+        // Assert
+        // The GetActualFieldType method detects int from the UnaryExpression
+        detectedType.ShouldBe(typeof(int));
+    }
+
+    [Fact]
+    public void RenderField_Should_Detect_Correct_Type_For_Nullable_Type()
+    {
+        // Arrange
+        var model = new TestModel { NullableValue = 42 };
+        var field = new FieldConfiguration<TestModel, int?>(x => x.NullableValue);
+        var wrapper = new FieldConfigurationWrapper<TestModel, int?>(field);
+        Type? detectedType = null;
+
+        var mockRenderer = A.Fake<IFieldRenderer>();
+        A.CallTo(() => mockRenderer.CanRender(A<Type>._, A<IFieldConfiguration<object, object>>._))
+            .ReturnsLazily((Type type, IFieldConfiguration<object, object> _) =>
+            {
+                detectedType = type;
+                return true;
+            });
+        A.CallTo(() => mockRenderer.Render(A<IFieldRenderContext<TestModel>>._))
+            .Returns(builder => builder.AddContent(0, "Test"));
+
+        var service = new FieldRendererService(new[] { mockRenderer }, _serviceProvider);
+        var onValueChanged = EventCallback.Factory.Create<object?>(this, _ => { });
+        var onDependencyChanged = EventCallback.Factory.Create(this, () => { });
+
+        // Act
+        service.RenderField(model, wrapper, onValueChanged, onDependencyChanged);
+
+        // Assert
+        detectedType.ShouldBe(typeof(int?));
+    }
+
+
+    [Fact]
+    public void RenderField_Should_Use_Correct_ActualFieldType_In_Context()
+    {
+        // Arrange
+        var model = new TestModel { DateCreated = DateTime.Now };
+        var field = new FieldConfiguration<TestModel, DateTime>(x => x.DateCreated);
+        var wrapper = new FieldConfigurationWrapper<TestModel, DateTime>(field);
+        IFieldRenderContext<TestModel>? capturedContext = null;
+
+        var mockRenderer = A.Fake<IFieldRenderer>();
+        A.CallTo(() => mockRenderer.CanRender(typeof(DateTime), A<IFieldConfiguration<object, object>>._))
+            .Returns(true);
+        A.CallTo(() => mockRenderer.Render(A<IFieldRenderContext<TestModel>>._))
+            .ReturnsLazily((IFieldRenderContext<TestModel> ctx) =>
+            {
+                capturedContext = ctx;
+                return builder => builder.AddContent(0, "Test");
+            });
+
+        var service = new FieldRendererService(new[] { mockRenderer }, _serviceProvider);
+        var onValueChanged = EventCallback.Factory.Create<object?>(this, _ => { });
+        var onDependencyChanged = EventCallback.Factory.Create(this, () => { });
+
+        // Act
+        service.RenderField(model, wrapper, onValueChanged, onDependencyChanged);
+
+        // Assert
+        capturedContext.ShouldNotBeNull();
+        capturedContext.ActualFieldType.ShouldBe(typeof(DateTime));
+    }
+
+
+    public enum TestEnum
+    {
+        Active,
+        Inactive,
+        Pending
+    }
+
+    public class NestedModel
+    {
+        public string NestedProperty { get; set; } = string.Empty;
+    }
+
     public class TestModel
     {
         public string? Name { get; set; }
         public int Value { get; set; }
+        public int? NullableValue { get; set; }
+        public DateTime DateCreated { get; set; }
+        public DateTime? DateModified { get; set; }
+        public TestEnum Status { get; set; }
+        public bool IsActive { get; set; }
+        public decimal Price { get; set; }
+        public List<string> Tags { get; set; } = new();
+        public NestedModel NestedModel { get; set; } = new();
     }
 }

--- a/FormCraft/Forms/Rendering/FieldRendererService.cs
+++ b/FormCraft/Forms/Rendering/FieldRendererService.cs
@@ -118,23 +118,19 @@ public class FieldRendererService : IFieldRendererService
 
         var expressionBody = field.ValueExpression.Body;
 
-        if (expressionBody is MemberExpression memberExpression)
+        return expressionBody switch
         {
-            if (memberExpression.Member is PropertyInfo propertyInfo)
+            MemberExpression
             {
-                return propertyInfo.PropertyType;
-            }
-        }
-
-        if (expressionBody is UnaryExpression unaryExpression &&
-            (unaryExpression.NodeType == ExpressionType.Convert || unaryExpression.NodeType == ExpressionType.ConvertChecked) &&
-            unaryExpression.Operand is MemberExpression unaryMember &&
-            unaryMember.Member is PropertyInfo unaryPropertyInfo)
-        {
-            return unaryPropertyInfo.PropertyType;
-        }
-
-        return expressionBody.Type;
+                Member: PropertyInfo propertyInfo
+            } => propertyInfo.PropertyType,
+            UnaryExpression
+            {
+                NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked,
+                Operand: MemberExpression { Member: PropertyInfo unaryPropertyInfo }
+            } => unaryPropertyInfo.PropertyType,
+            _ => expressionBody.Type
+        };
     }
 
     private static object GetCurrentValue<TModel>(TModel model, IFieldConfiguration<TModel, object> field)


### PR DESCRIPTION
## Summary
- inspect field expressions for MemberExpression and boxed UnaryExpression to detect property types
- return actual property type rather than expression body type

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895ced379d4832a938648943e70a8ea