### PR TITLE
chore(deps): update Microsoft.AspNetCore.Components packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,6 @@
     <PackageVersion Include="bunit" Version="1.40.0" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
@@ -38,9 +37,9 @@
   
   <!-- .NET 8.0 packages -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.18" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.18" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
@@ -49,12 +48,12 @@
   
   <!-- .NET 9.0 packages -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates several NuGet package versions in the `Directory.Packages.props` file to keep dependencies current and remove legacy test package usage. The most important changes are grouped below by theme.

**Test package updates:**

* Removed the legacy `xunit` v2 test package in favor of using only `xunit.v3`. This helps ensure consistency and avoids conflicts between major versions.

**.NET 8.0 dependency updates:**

* Updated `Microsoft.AspNetCore.Components.Web`, `Microsoft.AspNetCore.Components.WebAssembly`, and `Microsoft.AspNetCore.Components.WebAssembly.DevServer` to version 8.0.19 to pull in the latest bug fixes and improvements.

**.NET 9.0 dependency updates:**

* Updated `Microsoft.AspNetCore.Components.Web`, `Microsoft.AspNetCore.Components.WebAssembly`, and `Microsoft.AspNetCore.Components.WebAssembly.DevServer` to version 9.0.8.
* Updated `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Http`, and `Microsoft.Extensions.Configuration.Abstractions` to version 9.0.8 for improved compatibility and support.