### PR TITLE
feat: build forms from model attributes

### DIFF
--- a/FormCraft.UnitTests/Extensions/AttributeFormBuilderExtensionsTests.cs
+++ b/FormCraft.UnitTests/Extensions/AttributeFormBuilderExtensionsTests.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using Shouldly;
+
+namespace FormCraft.UnitTests.Extensions;
+
+public class AttributeFormBuilderExtensionsTests
+{
+    private class TestModel
+    {
+        [Required]
+        [TextField("First Name", "Enter first name")]
+        [MinLength(2)]
+        public string FirstName { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void AddFieldsFromAttributes_Should_Create_Field_From_Annotations()
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddFieldsFromAttributes()
+            .Build();
+
+        config.Fields.Count.ShouldBe(1);
+        var wrapper = config.Fields[0] as FieldConfigurationWrapper<TestModel, string>;
+        wrapper.ShouldNotBeNull();
+        var field = wrapper!.TypedConfiguration;
+
+        field.Label.ShouldBe("First Name");
+        field.Placeholder.ShouldBe("Enter first name");
+        field.IsRequired.ShouldBeTrue();
+        field.Validators.ShouldContain(v => v is RequiredValidator<TestModel, string>);
+        field.Validators.ShouldContain(v => v is CustomValidator<TestModel, string>);
+    }
+}

--- a/FormCraft/Forms/Attributes/TextFieldAttribute.cs
+++ b/FormCraft/Forms/Attributes/TextFieldAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace FormCraft;
+
+/// <summary>
+/// Specifies that a string property should be rendered as a text field
+/// when generating a form from model attributes.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class TextFieldAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the label to display for the field.
+    /// </summary>
+    public string Label { get; }
+
+    /// <summary>
+    /// Gets the optional placeholder text for the field.
+    /// </summary>
+    public string? Placeholder { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextFieldAttribute"/> class.
+    /// </summary>
+    /// <param name="label">The label to display for the field.</param>
+    /// <param name="placeholder">Optional placeholder text.</param>
+    public TextFieldAttribute(string label, string? placeholder = null)
+    {
+        Label = label;
+        Placeholder = placeholder;
+    }
+}

--- a/FormCraft/Forms/Extensions/AttributeFormBuilderExtensions.cs
+++ b/FormCraft/Forms/Extensions/AttributeFormBuilderExtensions.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FormCraft;
+
+/// <summary>
+/// Extension methods for <see cref="FormBuilder{TModel}"/> that allow
+/// configuring fields based on attributes applied to model properties.
+/// </summary>
+public static class AttributeFormBuilderExtensions
+{
+    /// <summary>
+    /// Scans <typeparamref name="TModel"/> for properties decorated with
+    /// form field attributes and adds corresponding fields to the builder.
+    /// Currently supports <see cref="TextFieldAttribute"/> for string
+    /// properties and common validation attributes like
+    /// <see cref="RequiredAttribute"/>, <see cref="MinLengthAttribute"/>,
+    /// and <see cref="MaxLengthAttribute"/>.
+    /// </summary>
+    /// <typeparam name="TModel">The model type containing the annotated properties.</typeparam>
+    /// <param name="builder">The form builder to configure.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    public static FormBuilder<TModel> AddFieldsFromAttributes<TModel>(this FormBuilder<TModel> builder)
+        where TModel : new()
+    {
+        foreach (var prop in typeof(TModel).GetProperties())
+        {
+            var textAttr = prop.GetCustomAttribute<TextFieldAttribute>();
+            if (textAttr != null && prop.PropertyType == typeof(string))
+            {
+                var parameter = Expression.Parameter(typeof(TModel), "x");
+                var property = Expression.Property(parameter, prop);
+                var lambda = Expression.Lambda<Func<TModel, string>>(property, parameter);
+
+                builder.AddField(lambda, field =>
+                {
+                    field.WithLabel(textAttr.Label);
+                    if (!string.IsNullOrEmpty(textAttr.Placeholder))
+                        field.WithPlaceholder(textAttr.Placeholder);
+
+                    var required = prop.GetCustomAttribute<RequiredAttribute>();
+                    if (required != null)
+                        field.Required(required.ErrorMessage ?? $"{textAttr.Label} is required");
+
+                    var min = prop.GetCustomAttribute<MinLengthAttribute>();
+                    if (min != null)
+                        field.WithMinLength(min.Length, min.ErrorMessage ?? $"Must be at least {min.Length} characters");
+
+                    var max = prop.GetCustomAttribute<MaxLengthAttribute>();
+                    if (max != null)
+                        field.WithMaxLength(max.Length, max.ErrorMessage ?? $"Must be no more than {max.Length} characters");
+                });
+            }
+        }
+
+        return builder;
+    }
+}

--- a/FormCraft/README.md
+++ b/FormCraft/README.md
@@ -35,10 +35,25 @@ var configuration = FormBuilder<MyModel>.Create()
     .Build();
 ```
 
+You can also configure fields using attributes on your model:
+
+```csharp
+public class MyModel
+{
+    [Required]
+    [TextField("Full Name", "Enter your name")]
+    public string Name { get; set; } = string.Empty;
+}
+
+var configuration = FormBuilder<MyModel>.Create()
+    .AddFieldsFromAttributes()
+    .Build();
+```
+
 4. Render the form:
 ```razor
-<FormCraftComponent TModel="MyModel" 
-                   Model="@myModel" 
+<FormCraftComponent TModel="MyModel"
+                   Model="@myModel"
                    Configuration="@configuration"
                    OnValidSubmit="@HandleSubmit"
                    ShowSubmitButton="true" />

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ public class UserRegistration
 }
 ```
 
+Alternatively, you can configure fields directly on your model using attributes:
+
+```csharp
+public class ContactModel
+{
+    [Required]
+    [TextField("First Name", "Enter your first name")]
+    [MinLength(2)]
+    public string FirstName { get; set; } = string.Empty;
+}
+
+var config = FormBuilder<ContactModel>.Create()
+    .AddFieldsFromAttributes()
+    .Build();
+```
+
 ## 🎨 Examples
 
 ### Dynamic Field Dependencies


### PR DESCRIPTION
## Summary
- add `TextFieldAttribute` for annotating model properties
- allow `FormBuilder` to generate fields from model annotations via `AddFieldsFromAttributes`
- document attribute-based configuration and cover with unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895ce4e009c832a94a341a5073e2a32