### PR TITLE
chore: update nuget dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,14 +6,14 @@
   <!-- Framework-agnostic packages -->
   <ItemGroup>
     <!-- UI Framework packages -->
-    <PackageVersion Include="MudBlazor" Version="8.11.0" />
+    <PackageVersion Include="MudBlazor" Version="8.12.0" />
     
     <!-- Testing packages -->
     <PackageVersion Include="bunit" Version="1.40.0" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageVersion Include="xunit.v3" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -27,19 +27,19 @@
     
     <!-- Code quality -->
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
-    <PackageVersion Include="Markdig" Version="0.41.3" />
+    <PackageVersion Include="Markdig" Version="0.42.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     
     <!-- Versioning -->
-    <PackageVersion Include="GitVersion.MsBuild" Version="6.3.0" />
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.4.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
   </ItemGroup>
   
   <!-- .NET 8.0 packages -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.19" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.20" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
@@ -48,12 +48,12 @@
   
   <!-- .NET 9.0 packages -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- bump MudBlazor, xUnit packages, Markdig, and GitVersion.MsBuild to their latest stable releases
- update .NET 8/9 Blazor and Microsoft.Extensions package references to the newest patch levels

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d67ead61f8832a9753379bb993412e