### PR TITLE
fix: Update global.json to use .NET 10.0.100 with latestFeature rollForward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.103",
-    "rollForward": "latestMinor",
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Problem
GitHub Pages deployment was failing with:
```
Requested SDK version: 10.0.103
Install the [10.0.103] .NET SDK or update [global.json] to match an installed SDK.
```

GitHub Actions runners only have .NET SDK 10.0.102 installed, not 10.0.103.

## Solution
Updated `global.json` to:
- Use `10.0.100` as base version
- Set `rollForward` to `latestFeature` (more flexible than `latestMinor`)

This allows any 10.0.x SDK version to be used, fixing the deployment issue.

## Testing
- ✅ Commit builds successfully
- 🔄 Will verify GitHub Pages deployment once merged

---
🤖 Auto-fix created by Garry
Related: FormCraft documentation deployment failures