### PR TITLE
docs: update CHANGELOG with recent dependency upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Updated MudBlazor to v9.3.0 for latest features and improvements
+- Updated coverlet.collector to v8.0.0 for improved test coverage reporting
+- Updated bUnit to v2.0.5 for enhanced Blazor component testing
+
 ## [2.5.0] - 2025-08-08
 
 ### ♻️ Refactor


### PR DESCRIPTION
Updates CHANGELOG.md to reflect the recently merged Renovate PRs:
- MudBlazor v9.3.0
- coverlet.collector v8.0.0  
- bUnit v2.0.5

Keeping changelog up-to-date for better project transparency.