### PR TITLE
feat: add password input type support for MudBlazor text fields

### DIFF
--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -182,21 +182,52 @@ public partial class FormCraftComponent<TModel>
         builder.AddAttribute(3, "ValueChanged",
             EventCallback.Factory.Create<string>(this,
                 newValue => UpdateFieldValue(field.FieldName, newValue)));
-        
+
         // Add Lines attribute for text area support
         if (field.AdditionalAttributes.TryGetValue("Lines", out var linesObj) && linesObj is int lines)
         {
             builder.AddAttribute(10, "Lines", lines);
         }
-        
+
         // Add MaxLength attribute if present
         if (field.AdditionalAttributes.TryGetValue("MaxLength", out var maxLengthObj) && maxLengthObj is int maxLength)
         {
             builder.AddAttribute(11, "MaxLength", maxLength);
         }
-        
+
         builder.AddAttribute(12, "Immediate", true);
+
+        // Add InputType attribute if present
+        if (field.InputType != null)
+        {
+            builder.AddAttribute(13, "InputType", GetInputType(field.InputType));
+        }
+
+        // Add Adornment attributes for password toggle support
+        if (field.AdditionalAttributes.TryGetValue("Adornment", out var adornmentObj) && adornmentObj is Adornment adornment)
+        {
+            builder.AddAttribute(14, "Adornment", adornment);
+        }
+
+        if (field.AdditionalAttributes.TryGetValue("AdornmentIcon", out var adornmentIconObj) && adornmentIconObj is string adornmentIcon)
+        {
+            builder.AddAttribute(15, "AdornmentIcon", adornmentIcon);
+        }
+
         builder.CloseComponent();
+    }
+
+    private static InputType GetInputType(string inputType)
+    {
+        return inputType.ToLowerInvariant() switch
+        {
+            "email" => InputType.Email,
+            "password" => InputType.Password,
+            "tel" or "telephone" => InputType.Telephone,
+            "url" => InputType.Url,
+            "search" => InputType.Search,
+            _ => InputType.Text
+        };
     }
 
     private void RenderNumericField<T>(RenderTreeBuilder builder, IFieldConfiguration<TModel, object> field, T value) 

--- a/FormCraft.UnitTests/Builders/FieldBuilderTests.cs
+++ b/FormCraft.UnitTests/Builders/FieldBuilderTests.cs
@@ -347,6 +347,34 @@ public class FieldBuilderTests
     }
 
     [Fact]
+    public void WithInputType_Should_Set_InputType_To_Password()
+    {
+        // Arrange & Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Name, field => field
+                .WithInputType("password"))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "Name");
+        field.InputType.ShouldBe("password");
+    }
+
+    [Fact]
+    public void WithInputType_Should_Set_InputType_To_Email()
+    {
+        // Arrange & Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Email, field => field
+                .WithInputType("email"))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "Email");
+        field.InputType.ShouldBe("email");
+    }
+
+    [Fact]
     public void Multiple_Fluent_Calls_Should_Chain_Correctly()
     {
         // Arrange & Act

--- a/FormCraft.UnitTests/Extensions/FluentFormBuilderExtensionsTests.cs
+++ b/FormCraft.UnitTests/Extensions/FluentFormBuilderExtensionsTests.cs
@@ -227,6 +227,7 @@ public class FluentFormBuilderExtensionsTests
         var field = config.Fields.First(f => f.FieldName == "Password");
         field.Label.ShouldBe("Password");
         field.IsRequired.ShouldBeTrue();
+        field.InputType.ShouldBe("password");
         field.Validators.Count.ShouldBe(3); // Required + MinLength + Special chars
     }
 

--- a/FormCraft/Forms/Extensions/FluentFormBuilderExtensions.cs
+++ b/FormCraft/Forms/Extensions/FluentFormBuilderExtensions.cs
@@ -312,9 +312,10 @@ public static class FluentFormBuilderExtensions
         int minLength = 8,
         bool requireSpecialChars = true) where TModel : new()
     {
-        return builder.AddField(expression, field => 
+        return builder.AddField(expression, field =>
         {
             field.WithLabel(label)
+                 .WithInputType("password")
                  .Required($"{label} is required")
                  .WithMinLength(minLength, $"Must be at least {minLength} characters");
 


### PR DESCRIPTION
## Summary
- Fix `WithInputType("password")` not rendering as a password field in MudBlazor — the `RenderTextField` method in `FormCraftComponent` now passes the `InputType` from field configuration to `MudTextField`, mapping string values to MudBlazor's `InputType` enum
- Update `AddPasswordField` convenience method to automatically set `WithInputType("password")` so password fields are masked by default
- Add adornment attribute passthrough support for future show/hide toggle icons

## Changes
- **`FormCraftComponent.razor.cs`** — Added `InputType` mapping in `RenderTextField` (with `GetInputType` helper method that maps `password`, `email`, `tel`, `url`, `search` to MudBlazor enums), plus `Adornment`/`AdornmentIcon` attribute passthrough
- **`FluentFormBuilderExtensions.cs`** — Added `.WithInputType("password")` call inside `AddPasswordField`
- **`FieldBuilderTests.cs`** — Added 2 new tests for `WithInputType` (password and email)
- **`FluentFormBuilderExtensionsTests.cs`** — Updated existing password test to assert `InputType` is set

## Testing
- All 555 existing tests pass
- 2 new unit tests verify `WithInputType` sets the correct value on field configuration
- Existing `AddPasswordField` test updated to verify `InputType` is `"password"`

Fixes #55