### PR TITLE
fix: support non-string value types in MudBlazor select renderer

### DIFF
--- a/FormCraft.UnitTests/Extensions/FieldBuilderExtensionsTests.cs
+++ b/FormCraft.UnitTests/Extensions/FieldBuilderExtensionsTests.cs
@@ -71,6 +71,55 @@ public class FieldBuilderExtensionsTests
     }
 
     [Fact]
+    public void WithOptions_Should_Set_Int_Options_Attribute()
+    {
+        // Arrange & Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Rating, field => field
+                .WithOptions(
+                    (1, "Low"),
+                    (2, "Medium"),
+                    (3, "High")))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "Rating");
+        field.AdditionalAttributes.ShouldContainKey("Options");
+
+        var options = (field.AdditionalAttributes["Options"] as IEnumerable<SelectOption<int>>)?.ToList();
+        options.ShouldNotBeNull();
+        options.Count.ShouldBe(3);
+        options.ShouldContain(o => o.Value == 1 && o.Label == "Low");
+        options.ShouldContain(o => o.Value == 2 && o.Label == "Medium");
+        options.ShouldContain(o => o.Value == 3 && o.Label == "High");
+    }
+
+    [Fact]
+    public void WithOptions_Should_Preserve_Int_Value_Types()
+    {
+        // Arrange & Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Age, field => field
+                .WithOptions(
+                    (18, "Eighteen"),
+                    (25, "Twenty-Five"),
+                    (65, "Sixty-Five")))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "Age");
+        field.AdditionalAttributes.ShouldContainKey("Options");
+
+        var options = (field.AdditionalAttributes["Options"] as IEnumerable<SelectOption<int>>)?.ToList();
+        options.ShouldNotBeNull();
+        options.Count.ShouldBe(3);
+
+        // Verify the values are actual ints, not strings
+        options[0].Value.ShouldBeOfType<int>();
+        options[0].Value.ShouldBe(18);
+    }
+
+    [Fact]
     public void AsMultiSelect_Should_Set_MultiSelectOptions_Attribute()
     {
         // Arrange & Act


### PR DESCRIPTION
## Summary
- Fixed `MudSelect` and `MudSelectItem` components being hardcoded to `string` type parameter, causing non-string select values (e.g., `int`, `enum`) to always return their default value (0 for int)
- Made `RenderSelectField` and `RenderSelectOptions` generic on the actual model property type using reflection-based generic method dispatch
- Added type conversion safety in `UpdateFieldValue` for edge cases

## Changes
- **`FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs`**: Replaced `RenderSelectField` with a reflection-based dispatcher that calls `RenderSelectFieldGeneric<TValue>` using the actual property type. Made `RenderSelectOptions<TValue>` generic so `MudSelectItem<TValue>` matches the real value type. Added `Convert.ChangeType` fallback in `UpdateFieldValue`.
- **`FormCraft.UnitTests/Extensions/FieldBuilderExtensionsTests.cs`**: Added two tests verifying that `WithOptions` correctly stores `SelectOption<int>` with preserved int value types.

## Test plan
- [x] All 555 existing + new unit tests pass (was 553)
- [x] New test: `WithOptions_Should_Set_Int_Options_Attribute` verifies int-typed options are stored correctly
- [x] New test: `WithOptions_Should_Preserve_Int_Value_Types` verifies option values remain `int`, not `string`
- [x] Solution builds successfully across all target frameworks (net8.0, net9.0, net10.0)

Fixes #61