### PR TITLE
fix: ensure field labels render correctly in MudBlazor dialogs

### DIFF
--- a/FormCraft.ForMudBlazor/Features/CustomFields/MudBlazorColorPickerComponent.razor
+++ b/FormCraft.ForMudBlazor/Features/CustomFields/MudBlazorColorPickerComponent.razor
@@ -12,6 +12,7 @@
     Disabled="@IsDisabled"
     Variant="Variant.Outlined"
     Margin="Margin.Dense"
+    ShrinkLabel="true"
     ColorPickerMode="ColorPickerMode.RGB"
     PickerVariant="PickerVariant.Dialog"
     AnchorOrigin="Origin.BottomCenter"/>

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -297,7 +297,8 @@ public partial class FormCraftComponent<TModel>
         builder.AddAttribute(startIndex++, "ReadOnly", field.IsReadOnly);
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);
         builder.AddAttribute(startIndex++, "Variant", Variant.Outlined);
-        builder.AddAttribute(startIndex, "Margin", Margin.Dense);
+        builder.AddAttribute(startIndex++, "Margin", Margin.Dense);
+        builder.AddAttribute(startIndex, "ShrinkLabel", true);
     }
 
     private async Task UpdateFieldValue(string fieldName, object? value)

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
@@ -13,6 +13,7 @@
     Disabled="@IsDisabled"
     Variant="Variant.Outlined"
     Margin="Margin.Dense"
+    ShrinkLabel="true"
     DateFormat="@Format"
     Editable="true"
     MinDate="@MinDate"

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
@@ -18,4 +18,5 @@
     Step="@(Step ?? GetDefaultStep())"
     Variant="Variant.Outlined"
     Margin="Margin.Dense"
+    ShrinkLabel="true"
     Immediate="true" />

--- a/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorSelectFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorSelectFieldComponent.razor
@@ -13,7 +13,8 @@
     ReadOnly="@IsReadOnly"
     Disabled="@IsDisabled"
     Variant="Variant.Outlined"
-    Margin="Margin.Dense">
+    Margin="Margin.Dense"
+    ShrinkLabel="true">
     @foreach (SelectOption<TValue> option in Options)
     {
         <MudSelectItem T="TValue" Value="@option.Value">

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
@@ -18,4 +18,5 @@
     Mask="@GetMask()"
     Variant="Variant.Outlined"
     Margin="Margin.Dense"
+    ShrinkLabel="true"
     Immediate="true" />


### PR DESCRIPTION
## Summary

- Adds `ShrinkLabel="true"` to all MudBlazor input components used by FormCraft, fixing label clipping when forms are rendered inside `MudDialog`
- The root cause is a known MudBlazor issue ([MudBlazor/MudBlazor#9497](https://github.com/MudBlazor/MudBlazor/issues/9497)) where `Margin.Dense` + `Variant.Outlined` inside dialog content causes `overflow:auto` to clip the floating label
- Setting `ShrinkLabel=true` forces labels to always render in the shrunk (above-border) position, avoiding the clipping

## Changes

- `FormCraftComponent.razor.cs`: Added `ShrinkLabel=true` to `AddCommonFieldAttributes` (the RenderTreeBuilder-based rendering path used by all standard field types)
- `MudBlazorTextFieldComponent.razor`: Added `ShrinkLabel="true"`
- `MudBlazorNumericFieldComponent.razor`: Added `ShrinkLabel="true"`
- `MudBlazorSelectFieldComponent.razor`: Added `ShrinkLabel="true"`
- `MudBlazorDateTimeFieldComponent.razor`: Added `ShrinkLabel="true"`
- `MudBlazorColorPickerComponent.razor`: Added `ShrinkLabel="true"`

Components not affected (labels render differently, not as floating input labels):
- `MudBlazorBooleanFieldComponent` (uses `MudSwitch` with inline label)
- `MudBlazorFileUploadFieldComponent` (uses `MudText` above the upload area)
- `MudBlazorSliderComponent` (uses `MudText` above the slider)
- `MudBlazorRatingComponent` (uses `MudText` above the rating)

## Testing

- [x] All 553 existing unit tests pass
- [x] Build succeeds with no new errors
- [ ] Manual verification: render FormCraft form inside `MudDialog` and confirm labels are visible

Fixes #31