### PR TITLE
feat: add autocomplete and lookup field types for large datasets

### DIFF
--- a/FormCraft.ForMudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/FormCraft.ForMudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -39,6 +39,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFieldRenderer, MudBlazorSelectFieldRenderer>();
         services.AddScoped<IFieldRenderer, MudBlazorFileUploadFieldRenderer>();
         services.AddScoped<IFieldRenderer, MudBlazorMultipleFileUploadRenderer>();
+        services.AddScoped<IFieldRenderer, MudBlazorAutocompleteFieldRenderer>();
+        services.AddScoped<IFieldRenderer, MudBlazorLookupFieldRenderer>();
         // Note: MudBlazorColorPickerRenderer and MudBlazorRatingRenderer are custom renderers,
         // not IFieldRenderer implementations. They should be used via WithCustomRenderer().
         

--- a/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor
@@ -1,0 +1,23 @@
+@namespace FormCraft.ForMudBlazor
+@typeparam TModel
+@typeparam TValue
+@inherits FieldComponentBase<TModel, TValue>
+
+<MudAutocomplete
+    T="TValue"
+    Label="@Label"
+    @bind-Value="@CurrentValue"
+    SearchFunc="@SearchAsync"
+    ToStringFunc="@_toStringFunc"
+    Placeholder="@Placeholder"
+    HelperText="@HelpText"
+    ReadOnly="@IsReadOnly"
+    Disabled="@IsDisabled"
+    Variant="Variant.Outlined"
+    Margin="Margin.Dense"
+    ShrinkLabel="true"
+    DebounceInterval="@_debounceMs"
+    MinCharacters="@_minCharacters"
+    ResetValueOnEmptyText="true"
+    CoerceText="false"
+    Dense="true" />

--- a/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor.cs
@@ -1,0 +1,87 @@
+namespace FormCraft.ForMudBlazor;
+
+public partial class MudBlazorAutocompleteFieldComponent<TModel, TValue>
+{
+    private Func<string, CancellationToken, Task<IEnumerable<SelectOption<TValue>>>>? _searchFunc;
+    private object? _optionProvider;
+    private int _debounceMs = 300;
+    private int _minCharacters = 1;
+    private Func<TValue, string> _toStringFunc = v => v?.ToString() ?? string.Empty;
+
+    /// <summary>
+    /// Cached lookup from display string back to TValue for MudAutocomplete results.
+    /// </summary>
+    private readonly Dictionary<string, TValue> _valueLookup = new();
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        _searchFunc = GetAttribute<Func<string, CancellationToken, Task<IEnumerable<SelectOption<TValue>>>>>("AutocompleteSearchFunc");
+        _optionProvider = GetAttribute<object>("AutocompleteOptionProvider");
+        _debounceMs = GetAttribute("AutocompleteDebounceMs", 300);
+        _minCharacters = GetAttribute("AutocompleteMinCharacters", 1);
+
+        var customToString = GetAttribute<Func<TValue, string>>("AutocompleteToStringFunc");
+        if (customToString != null)
+        {
+            _toStringFunc = customToString;
+        }
+    }
+
+    private async Task<IEnumerable<TValue>> SearchAsync(string searchText, CancellationToken cancellationToken)
+    {
+        IEnumerable<SelectOption<TValue>> options;
+
+        if (_searchFunc != null)
+        {
+            options = await _searchFunc(searchText ?? string.Empty, cancellationToken);
+        }
+        else if (_optionProvider != null)
+        {
+            // Use reflection to call SearchAsync on the IOptionProvider<TModel, TValue>
+            var providerType = typeof(IOptionProvider<,>).MakeGenericType(typeof(TModel), typeof(TValue));
+            var searchMethod = providerType.GetMethod("SearchAsync");
+            if (searchMethod != null)
+            {
+                var task = (Task<IEnumerable<SelectOption<TValue>>>)searchMethod.Invoke(
+                    _optionProvider,
+                    new object?[] { searchText ?? string.Empty, Context.Model, cancellationToken })!;
+                options = await task;
+            }
+            else
+            {
+                return Enumerable.Empty<TValue>();
+            }
+        }
+        else
+        {
+            return Enumerable.Empty<TValue>();
+        }
+
+        var optionsList = options.ToList();
+
+        // Build the display-to-value lookup and set up ToString
+        _valueLookup.Clear();
+        foreach (var option in optionsList)
+        {
+            var displayStr = _toStringFunc(option.Value);
+            _valueLookup[displayStr] = option.Value;
+        }
+
+        // If no custom toString was provided, use label-based display
+        var customToString = GetAttribute<Func<TValue, string>>("AutocompleteToStringFunc");
+        if (customToString == null)
+        {
+            // Build a value-to-label map for display
+            var labelMap = optionsList.ToDictionary(o => o.Value!, o => o.Label);
+            _toStringFunc = v =>
+            {
+                if (v == null) return string.Empty;
+                return labelMap.TryGetValue(v, out var label) ? label : v.ToString() ?? string.Empty;
+            };
+        }
+
+        return optionsList.Select(o => o.Value);
+    }
+}

--- a/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldRenderer.cs
+++ b/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldRenderer.cs
@@ -1,0 +1,18 @@
+namespace FormCraft.ForMudBlazor;
+
+/// <summary>
+/// MudBlazor implementation of the autocomplete field renderer.
+/// </summary>
+public class MudBlazorAutocompleteFieldRenderer : FieldRendererBase
+{
+    /// <inheritdoc />
+    protected override Type ComponentType => typeof(MudBlazorAutocompleteFieldComponent<,>);
+
+    /// <inheritdoc />
+    public override bool CanRender(Type fieldType, IFieldConfiguration<object, object> field)
+    {
+        // This renderer handles fields with AutocompleteSearchFunc or AutocompleteOptionProvider
+        return field.AdditionalAttributes.ContainsKey("AutocompleteSearchFunc") ||
+               field.AdditionalAttributes.ContainsKey("AutocompleteOptionProvider");
+    }
+}

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupDialog.razor
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupDialog.razor
@@ -1,0 +1,76 @@
+@namespace FormCraft.ForMudBlazor
+@using MudBlazor
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Search" Class="mr-2" />
+            @FieldLabel
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTextField
+            T="string"
+            @bind-Value="_searchText"
+            Placeholder="Search..."
+            Adornment="Adornment.Start"
+            AdornmentIcon="@Icons.Material.Filled.Search"
+            Immediate="true"
+            DebounceInterval="300"
+            Variant="Variant.Outlined"
+            Margin="Margin.Dense"
+            Class="mb-4"
+            TextChanged="OnSearchTextChanged" />
+
+        <MudTable
+            T="object"
+            ServerData="LoadServerData"
+            @ref="_table"
+            Dense="true"
+            Hover="true"
+            Striped="true"
+            RowClassFunc="@((item, _) => item == _selectedItem ? "selected" : "")"
+            OnRowClick="OnRowClicked"
+            Loading="@_loading"
+            LoadingProgressColor="Color.Primary">
+            <HeaderContent>
+                @if (_columnDefinitions.Any())
+                {
+                    @foreach (var col in _columnDefinitions)
+                    {
+                        <MudTh>@col.Title</MudTh>
+                    }
+                }
+                else
+                {
+                    <MudTh>Value</MudTh>
+                }
+            </HeaderContent>
+            <RowTemplate>
+                @if (_columnDefinitions.Any())
+                {
+                    @foreach (var col in _columnDefinitions)
+                    {
+                        <MudTd>@col.GetValue(context)</MudTd>
+                    }
+                }
+                else
+                {
+                    <MudTd>@GetDisplayText(context)</MudTd>
+                }
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudText Typo="Typo.body1">No matching records found.</MudText>
+            </NoRecordsContent>
+            <PagerContent>
+                <MudTablePager />
+            </PagerContent>
+        </MudTable>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" Disabled="@(_selectedItem == null)" OnClick="Submit">
+            Select
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupDialog.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupDialog.razor.cs
@@ -1,0 +1,194 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FormCraft.ForMudBlazor;
+
+/// <summary>
+/// A dialog component that displays a searchable, paginated table for lookup field selection.
+/// </summary>
+public partial class MudBlazorLookupDialog : ComponentBase
+{
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    /// <summary>
+    /// The async data provider delegate (typed as object to handle generic TItem).
+    /// </summary>
+    [Parameter]
+    public object DataProvider { get; set; } = default!;
+
+    /// <summary>
+    /// The value selector delegate.
+    /// </summary>
+    [Parameter]
+    public object ValueSelector { get; set; } = default!;
+
+    /// <summary>
+    /// The display selector delegate.
+    /// </summary>
+    [Parameter]
+    public object DisplaySelector { get; set; } = default!;
+
+    /// <summary>
+    /// The column definitions (as object to handle generic LookupColumn list).
+    /// </summary>
+    [Parameter]
+    public object? Columns { get; set; }
+
+    /// <summary>
+    /// The label for the field.
+    /// </summary>
+    [Parameter]
+    public string FieldLabel { get; set; } = "Select";
+
+    private MudTable<object> _table = default!;
+    private string _searchText = string.Empty;
+    private object? _selectedItem;
+    private bool _loading;
+    private List<ColumnDef> _columnDefinitions = new();
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        ExtractColumnDefinitions();
+    }
+
+    private void ExtractColumnDefinitions()
+    {
+        if (Columns == null) return;
+
+        // The columns parameter is a List<LookupColumn<TItem>> stored as object.
+        // We use reflection to extract column info.
+        var columnsType = Columns.GetType();
+        if (!columnsType.IsGenericType) return;
+
+        var enumerableInterface = columnsType.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        if (enumerableInterface == null) return;
+
+        foreach (var col in (System.Collections.IEnumerable)Columns)
+        {
+            var colType = col.GetType();
+            var titleProp = colType.GetProperty("Title");
+            var valueSelectorProp = colType.GetProperty("ValueSelector");
+
+            if (titleProp != null && valueSelectorProp != null)
+            {
+                var title = titleProp.GetValue(col)?.ToString() ?? "";
+                var valueFunc = valueSelectorProp.GetValue(col);
+
+                _columnDefinitions.Add(new ColumnDef
+                {
+                    Title = title,
+                    ValueFunc = valueFunc as Delegate
+                });
+            }
+        }
+    }
+
+    private async Task<TableData<object>> LoadServerData(TableState state, CancellationToken cancellationToken)
+    {
+        _loading = true;
+
+        try
+        {
+            var query = new LookupQuery
+            {
+                SearchText = _searchText,
+                Page = state.Page,
+                PageSize = state.PageSize,
+                SortField = state.SortLabel,
+                SortDescending = state.SortDirection == SortDirection.Descending
+            };
+
+            // Invoke the data provider delegate
+            var task = ((Delegate)DataProvider).DynamicInvoke(query) as Task;
+            if (task == null) return new TableData<object> { Items = Array.Empty<object>(), TotalItems = 0 };
+
+            await task;
+
+            // Get the result from the completed task
+            var resultProp = task.GetType().GetProperty("Result");
+            var result = resultProp?.GetValue(task);
+            if (result == null) return new TableData<object> { Items = Array.Empty<object>(), TotalItems = 0 };
+
+            // Extract Items and TotalCount from LookupResult<TItem>
+            var itemsProp = result.GetType().GetProperty("Items");
+            var totalCountProp = result.GetType().GetProperty("TotalCount");
+
+            var items = itemsProp?.GetValue(result) as System.Collections.IEnumerable;
+            var totalCount = totalCountProp?.GetValue(result) is int count ? count : 0;
+
+            var objectItems = items?.Cast<object>().ToList() ?? new List<object>();
+
+            return new TableData<object>
+            {
+                Items = objectItems,
+                TotalItems = totalCount
+            };
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private string GetDisplayText(object item)
+    {
+        try
+        {
+            var result = ((Delegate)DisplaySelector).DynamicInvoke(item);
+            return result?.ToString() ?? string.Empty;
+        }
+        catch
+        {
+            return item.ToString() ?? string.Empty;
+        }
+    }
+
+    private async Task OnSearchTextChanged(string text)
+    {
+        _searchText = text;
+        _selectedItem = null;
+        await _table.ReloadServerData();
+    }
+
+    private void OnRowClicked(TableRowClickEventArgs<object> args)
+    {
+        _selectedItem = args.Item;
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    private void Submit()
+    {
+        if (_selectedItem != null)
+        {
+            MudDialog.Close(DialogResult.Ok(_selectedItem));
+        }
+    }
+
+    /// <summary>
+    /// Internal column definition used for rendering.
+    /// </summary>
+    private class ColumnDef
+    {
+        public string Title { get; set; } = string.Empty;
+        public Delegate? ValueFunc { get; set; }
+
+        public object? GetValue(object item)
+        {
+            try
+            {
+                return ValueFunc?.DynamicInvoke(item);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor
@@ -1,0 +1,20 @@
+@namespace FormCraft.ForMudBlazor
+@typeparam TModel
+@typeparam TValue
+@inherits FieldComponentBase<TModel, TValue>
+
+<MudTextField
+    T="string"
+    Label="@Label"
+    Value="@_displayText"
+    Placeholder="@Placeholder"
+    HelperText="@HelpText"
+    ReadOnly="true"
+    Disabled="@IsDisabled"
+    Variant="Variant.Outlined"
+    Margin="Margin.Dense"
+    ShrinkLabel="true"
+    Adornment="Adornment.End"
+    AdornmentIcon="@Icons.Material.Filled.Search"
+    OnAdornmentClick="@OpenLookupDialog"
+    AdornmentAriaLabel="Open lookup" />

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FormCraft.ForMudBlazor;
+
+public partial class MudBlazorLookupFieldComponent<TModel, TValue>
+{
+    [Inject]
+    private IDialogService DialogService { get; set; } = default!;
+
+    private string _displayText = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        UpdateDisplayText();
+    }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        UpdateDisplayText();
+    }
+
+    private void UpdateDisplayText()
+    {
+        // Try to get the display selector and use it to show current value
+        var displaySelector = GetAttribute<object>("LookupDisplaySelector");
+        if (displaySelector != null && CurrentValue != null)
+        {
+            // We can't directly call the display selector since it takes TItem, not TValue.
+            // The display text is stored after selection. If the field has a current value but
+            // no stored display text, show the value's ToString.
+            if (string.IsNullOrEmpty(_displayText))
+            {
+                _displayText = CurrentValue?.ToString() ?? string.Empty;
+            }
+        }
+    }
+
+    private async Task OpenLookupDialog()
+    {
+        if (IsReadOnly || IsDisabled)
+            return;
+
+        var dataProvider = GetAttribute<object>("LookupDataProvider");
+        var valueSelector = GetAttribute<object>("LookupValueSelector");
+        var displaySelector = GetAttribute<object>("LookupDisplaySelector");
+        var columns = GetAttribute<object>("LookupColumns");
+        var onItemSelected = GetAttribute<object>("LookupOnItemSelected");
+
+        if (dataProvider == null || valueSelector == null || displaySelector == null)
+            return;
+
+        var parameters = new DialogParameters
+        {
+            { "DataProvider", dataProvider },
+            { "ValueSelector", valueSelector },
+            { "DisplaySelector", displaySelector },
+            { "Columns", columns },
+            { "FieldLabel", Label ?? "Select" }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
+            CloseButton = true,
+            CloseOnEscapeKey = true
+        };
+
+        var dialog = await DialogService.ShowAsync<MudBlazorLookupDialog>(
+            Label ?? "Lookup",
+            parameters,
+            options);
+
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: not null })
+        {
+            // result.Data is the selected item (as object)
+            var selectedItem = result.Data;
+
+            // Extract value using the value selector
+            try
+            {
+                var value = ((Delegate)valueSelector).DynamicInvoke(selectedItem);
+                if (value is TValue typedValue)
+                {
+                    CurrentValue = typedValue;
+                }
+
+                // Extract display text
+                var display = ((Delegate)displaySelector).DynamicInvoke(selectedItem);
+                _displayText = display?.ToString() ?? string.Empty;
+
+                // Invoke onItemSelected callback for multi-field mapping
+                if (onItemSelected != null)
+                {
+                    ((Delegate)onItemSelected).DynamicInvoke(Context.Model, selectedItem);
+                }
+
+                StateHasChanged();
+            }
+            catch
+            {
+                // Silently handle type mismatches
+            }
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldRenderer.cs
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldRenderer.cs
@@ -1,0 +1,17 @@
+namespace FormCraft.ForMudBlazor;
+
+/// <summary>
+/// MudBlazor implementation of the lookup table field renderer.
+/// </summary>
+public class MudBlazorLookupFieldRenderer : FieldRendererBase
+{
+    /// <inheritdoc />
+    protected override Type ComponentType => typeof(MudBlazorLookupFieldComponent<,>);
+
+    /// <inheritdoc />
+    public override bool CanRender(Type fieldType, IFieldConfiguration<object, object> field)
+    {
+        // This renderer handles fields with LookupDataProvider in AdditionalAttributes
+        return field.AdditionalAttributes.ContainsKey("LookupDataProvider");
+    }
+}

--- a/FormCraft.UnitTests/Extensions/AutocompleteFieldBuilderTests.cs
+++ b/FormCraft.UnitTests/Extensions/AutocompleteFieldBuilderTests.cs
@@ -1,0 +1,208 @@
+namespace FormCraft.UnitTests.Extensions;
+
+public class AutocompleteFieldBuilderTests
+{
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Set_SearchFunc_Attribute()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteSearchFunc");
+        field.AdditionalAttributes["AutocompleteSearchFunc"].ShouldBeSameAs(searchFunc);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Set_Default_DebounceMs()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteDebounceMs");
+        field.AdditionalAttributes["AutocompleteDebounceMs"].ShouldBe(300);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Set_Custom_DebounceMs()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc, debounceMs: 500))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes["AutocompleteDebounceMs"].ShouldBe(500);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Set_Custom_MinCharacters()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc, minCharacters: 3))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteMinCharacters");
+        field.AdditionalAttributes["AutocompleteMinCharacters"].ShouldBe(3);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Set_ToStringFunc_When_Provided()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+        Func<string, string> toStringFunc = v => $"City: {v}";
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc, toStringFunc: toStringFunc))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteToStringFunc");
+        field.AdditionalAttributes["AutocompleteToStringFunc"].ShouldBeSameAs(toStringFunc);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithSearchFunc_Should_Not_Set_ToStringFunc_When_Null()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(searchFunc))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldNotContainKey("AutocompleteToStringFunc");
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithOptionProvider_Should_Set_OptionProvider_Attribute()
+    {
+        // Arrange
+        var optionProvider = A.Fake<IOptionProvider<TestModel, string>>();
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(optionProvider))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteOptionProvider");
+        field.AdditionalAttributes["AutocompleteOptionProvider"].ShouldBeSameAs(optionProvider);
+    }
+
+    [Fact]
+    public void AsAutocomplete_WithOptionProvider_Should_Set_Default_Settings()
+    {
+        // Arrange
+        var optionProvider = A.Fake<IOptionProvider<TestModel, string>>();
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .AsAutocomplete(optionProvider))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.AdditionalAttributes["AutocompleteDebounceMs"].ShouldBe(300);
+        field.AdditionalAttributes["AutocompleteMinCharacters"].ShouldBe(1);
+        field.AdditionalAttributes.ShouldNotContainKey("AutocompleteToStringFunc");
+    }
+
+    [Fact]
+    public void AsAutocomplete_Should_Support_Int_Value_Type()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<int>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<int>>>(
+                new List<SelectOption<int>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsAutocomplete(searchFunc))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteSearchFunc");
+    }
+
+    [Fact]
+    public void AsAutocomplete_Should_Be_Chainable()
+    {
+        // Arrange
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<string>>>> searchFunc =
+            (text, ct) => Task.FromResult<IEnumerable<SelectOption<string>>>(
+                new List<SelectOption<string>>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, field => field
+                .WithLabel("City")
+                .AsAutocomplete(searchFunc)
+                .WithHelpText("Start typing to search"))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "City");
+        field.Label.ShouldBe("City");
+        field.HelpText.ShouldBe("Start typing to search");
+        field.AdditionalAttributes.ShouldContainKey("AutocompleteSearchFunc");
+    }
+
+    public class TestModel
+    {
+        public string City { get; set; } = string.Empty;
+        public int CityId { get; set; }
+    }
+}

--- a/FormCraft.UnitTests/Extensions/LookupFieldBuilderTests.cs
+++ b/FormCraft.UnitTests/Extensions/LookupFieldBuilderTests.cs
@@ -1,0 +1,242 @@
+namespace FormCraft.UnitTests.Extensions;
+
+public class LookupFieldBuilderTests
+{
+    [Fact]
+    public void AsLookup_Should_Set_DataProvider_Attribute()
+    {
+        // Arrange
+        Func<LookupQuery, Task<LookupResult<CityDto>>> dataProvider =
+            query => Task.FromResult(new LookupResult<CityDto>());
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: dataProvider,
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("LookupDataProvider");
+        field.AdditionalAttributes["LookupDataProvider"].ShouldBeSameAs(dataProvider);
+    }
+
+    [Fact]
+    public void AsLookup_Should_Set_ValueSelector_Attribute()
+    {
+        // Arrange
+        Func<CityDto, int> valueSelector = city => city.Id;
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: valueSelector,
+                    displaySelector: city => city.Name))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("LookupValueSelector");
+        field.AdditionalAttributes["LookupValueSelector"].ShouldBeSameAs(valueSelector);
+    }
+
+    [Fact]
+    public void AsLookup_Should_Set_DisplaySelector_Attribute()
+    {
+        // Arrange
+        Func<CityDto, string> displaySelector = city => city.Name;
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: displaySelector))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("LookupDisplaySelector");
+        field.AdditionalAttributes["LookupDisplaySelector"].ShouldBeSameAs(displaySelector);
+    }
+
+    [Fact]
+    public void AsLookup_Should_Set_Columns_When_Configured()
+    {
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name,
+                    configureColumns: cols =>
+                    {
+                        cols.Add(new LookupColumn<CityDto> { Title = "Name", ValueSelector = c => c.Name });
+                        cols.Add(new LookupColumn<CityDto> { Title = "Country", ValueSelector = c => c.Country });
+                    }))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("LookupColumns");
+
+        var columns = field.AdditionalAttributes["LookupColumns"] as List<LookupColumn<CityDto>>;
+        columns.ShouldNotBeNull();
+        columns.Count.ShouldBe(2);
+        columns[0].Title.ShouldBe("Name");
+        columns[1].Title.ShouldBe("Country");
+    }
+
+    [Fact]
+    public void AsLookup_Should_Not_Set_Columns_When_Not_Configured()
+    {
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldNotContainKey("LookupColumns");
+    }
+
+    [Fact]
+    public void AsLookup_Should_Set_OnItemSelected_When_Provided()
+    {
+        // Arrange
+        Action<TestModel, CityDto> onItemSelected = (model, city) => model.CityName = city.Name;
+
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name,
+                    onItemSelected: onItemSelected))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldContainKey("LookupOnItemSelected");
+        field.AdditionalAttributes["LookupOnItemSelected"].ShouldBeSameAs(onItemSelected);
+    }
+
+    [Fact]
+    public void AsLookup_Should_Not_Set_OnItemSelected_When_Null()
+    {
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.AdditionalAttributes.ShouldNotContainKey("LookupOnItemSelected");
+    }
+
+    [Fact]
+    public void AsLookup_Should_Be_Chainable()
+    {
+        // Act
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, field => field
+                .WithLabel("City")
+                .AsLookup(
+                    dataProvider: query => Task.FromResult(new LookupResult<CityDto>()),
+                    valueSelector: city => city.Id,
+                    displaySelector: city => city.Name)
+                .WithHelpText("Click search to find a city"))
+            .Build();
+
+        // Assert
+        var field = config.Fields.First(f => f.FieldName == "CityId");
+        field.Label.ShouldBe("City");
+        field.HelpText.ShouldBe("Click search to find a city");
+        field.AdditionalAttributes.ShouldContainKey("LookupDataProvider");
+    }
+
+    [Fact]
+    public void AsLookup_Column_ValueSelector_Should_Extract_Values()
+    {
+        // Arrange
+        var city = new CityDto { Id = 1, Name = "Paris", Country = "France" };
+        var column = new LookupColumn<CityDto>
+        {
+            Title = "Name",
+            ValueSelector = c => c.Name
+        };
+
+        // Act
+        var result = column.ValueSelector(city);
+
+        // Assert
+        result.ShouldBe("Paris");
+    }
+
+    [Fact]
+    public void LookupQuery_Should_Have_Default_Values()
+    {
+        // Act
+        var query = new LookupQuery();
+
+        // Assert
+        query.SearchText.ShouldBe(string.Empty);
+        query.Page.ShouldBe(0);
+        query.PageSize.ShouldBe(10);
+        query.SortField.ShouldBeNull();
+        query.SortDescending.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LookupResult_Should_Have_Default_Values()
+    {
+        // Act
+        var result = new LookupResult<CityDto>();
+
+        // Assert
+        result.Items.ShouldBeEmpty();
+        result.TotalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LookupColumn_Should_Have_Default_Values()
+    {
+        // Act
+        var column = new LookupColumn<CityDto>();
+
+        // Assert
+        column.Title.ShouldBe(string.Empty);
+        column.Sortable.ShouldBeTrue();
+        column.Filterable.ShouldBeTrue();
+        column.ValueSelector.ShouldNotBeNull();
+    }
+
+    public class TestModel
+    {
+        public int CityId { get; set; }
+        public string CityName { get; set; } = string.Empty;
+    }
+
+    public class CityDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft/Forms/Abstractions/IOptionProvider.cs
+++ b/FormCraft/Forms/Abstractions/IOptionProvider.cs
@@ -1,0 +1,21 @@
+namespace FormCraft;
+
+/// <summary>
+/// Provides async search-based options for autocomplete and lookup fields.
+/// </summary>
+/// <typeparam name="TModel">The model type that the form binds to.</typeparam>
+/// <typeparam name="TValue">The type of the option value.</typeparam>
+public interface IOptionProvider<in TModel, TValue>
+{
+    /// <summary>
+    /// Searches for options matching the given text.
+    /// </summary>
+    /// <param name="searchText">The text to search for.</param>
+    /// <param name="model">The current model instance for context-aware searching.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A collection of matching options.</returns>
+    Task<IEnumerable<SelectOption<TValue>>> SearchAsync(
+        string searchText,
+        TModel model,
+        CancellationToken cancellationToken = default);
+}

--- a/FormCraft/Forms/Core/LookupColumn.cs
+++ b/FormCraft/Forms/Core/LookupColumn.cs
@@ -1,0 +1,28 @@
+namespace FormCraft;
+
+/// <summary>
+/// Defines a column in a lookup table dialog.
+/// </summary>
+/// <typeparam name="TItem">The type of the lookup item.</typeparam>
+public class LookupColumn<TItem>
+{
+    /// <summary>
+    /// Gets or sets the column header title.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the function that extracts the column value from an item.
+    /// </summary>
+    public Func<TItem, object?> ValueSelector { get; set; } = _ => null;
+
+    /// <summary>
+    /// Gets or sets whether the column is sortable.
+    /// </summary>
+    public bool Sortable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the column is filterable.
+    /// </summary>
+    public bool Filterable { get; set; } = true;
+}

--- a/FormCraft/Forms/Core/LookupQuery.cs
+++ b/FormCraft/Forms/Core/LookupQuery.cs
@@ -1,0 +1,32 @@
+namespace FormCraft;
+
+/// <summary>
+/// Query parameters for lookup table data provider.
+/// </summary>
+public class LookupQuery
+{
+    /// <summary>
+    /// Gets or sets the search text to filter results.
+    /// </summary>
+    public string SearchText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the zero-based page index.
+    /// </summary>
+    public int Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of items per page.
+    /// </summary>
+    public int PageSize { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the field name to sort by, or null for default ordering.
+    /// </summary>
+    public string? SortField { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to sort in descending order.
+    /// </summary>
+    public bool SortDescending { get; set; }
+}

--- a/FormCraft/Forms/Core/LookupResult.cs
+++ b/FormCraft/Forms/Core/LookupResult.cs
@@ -1,0 +1,18 @@
+namespace FormCraft;
+
+/// <summary>
+/// Represents a page of lookup results with total count for pagination.
+/// </summary>
+/// <typeparam name="TItem">The type of the lookup item.</typeparam>
+public class LookupResult<TItem>
+{
+    /// <summary>
+    /// Gets or sets the items in the current page.
+    /// </summary>
+    public IEnumerable<TItem> Items { get; set; } = Enumerable.Empty<TItem>();
+
+    /// <summary>
+    /// Gets or sets the total number of items matching the query.
+    /// </summary>
+    public int TotalCount { get; set; }
+}

--- a/FormCraft/Forms/Extensions/FieldBuilderExtensions.cs
+++ b/FormCraft/Forms/Extensions/FieldBuilderExtensions.cs
@@ -349,6 +349,80 @@ public static class FieldBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Configures the field as an autocomplete with async search using a search function.
+    /// </summary>
+    /// <typeparam name="TModel">The model type that the form binds to.</typeparam>
+    /// <typeparam name="TValue">The type of the field value.</typeparam>
+    /// <param name="builder">The FieldBuilder instance.</param>
+    /// <param name="searchFunc">An async function that returns matching options for the given search text.</param>
+    /// <param name="debounceMs">Debounce delay in milliseconds before triggering search (default: 300).</param>
+    /// <param name="minCharacters">Minimum number of characters before triggering search (default: 1).</param>
+    /// <param name="toStringFunc">Optional function to convert a value to its display string.</param>
+    /// <returns>The FieldBuilder instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// .AddField(x => x.City)
+    ///     .AsAutocomplete(
+    ///         searchFunc: async (text, ct) => cities
+    ///             .Where(c => c.Name.Contains(text, StringComparison.OrdinalIgnoreCase))
+    ///             .Select(c => new SelectOption&lt;string&gt;(c.Name, c.Name)),
+    ///         debounceMs: 300,
+    ///         minCharacters: 2)
+    /// </code>
+    /// </example>
+    public static FieldBuilder<TModel, TValue> AsAutocomplete<TModel, TValue>(
+        this FieldBuilder<TModel, TValue> builder,
+        Func<string, CancellationToken, Task<IEnumerable<SelectOption<TValue>>>> searchFunc,
+        int debounceMs = 300,
+        int minCharacters = 1,
+        Func<TValue, string>? toStringFunc = null)
+        where TModel : new()
+    {
+        builder.WithAttribute("AutocompleteSearchFunc", searchFunc);
+        builder.WithAttribute("AutocompleteDebounceMs", debounceMs);
+        builder.WithAttribute("AutocompleteMinCharacters", minCharacters);
+        if (toStringFunc != null)
+            builder.WithAttribute("AutocompleteToStringFunc", toStringFunc);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the field as an autocomplete with async search using an IOptionProvider.
+    /// </summary>
+    /// <typeparam name="TModel">The model type that the form binds to.</typeparam>
+    /// <typeparam name="TValue">The type of the field value.</typeparam>
+    /// <param name="builder">The FieldBuilder instance.</param>
+    /// <param name="optionProvider">An option provider that supplies search results based on model context.</param>
+    /// <param name="debounceMs">Debounce delay in milliseconds before triggering search (default: 300).</param>
+    /// <param name="minCharacters">Minimum number of characters before triggering search (default: 1).</param>
+    /// <param name="toStringFunc">Optional function to convert a value to its display string.</param>
+    /// <returns>The FieldBuilder instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// .AddField(x => x.City)
+    ///     .AsAutocomplete(
+    ///         optionProvider: new CityOptionProvider(),
+    ///         debounceMs: 300,
+    ///         minCharacters: 2)
+    /// </code>
+    /// </example>
+    public static FieldBuilder<TModel, TValue> AsAutocomplete<TModel, TValue>(
+        this FieldBuilder<TModel, TValue> builder,
+        IOptionProvider<TModel, TValue> optionProvider,
+        int debounceMs = 300,
+        int minCharacters = 1,
+        Func<TValue, string>? toStringFunc = null)
+        where TModel : new()
+    {
+        builder.WithAttribute("AutocompleteOptionProvider", optionProvider);
+        builder.WithAttribute("AutocompleteDebounceMs", debounceMs);
+        builder.WithAttribute("AutocompleteMinCharacters", minCharacters);
+        if (toStringFunc != null)
+            builder.WithAttribute("AutocompleteToStringFunc", toStringFunc);
+        return builder;
+    }
+
     private static bool IsValidEmail(string email)
     {
         if (string.IsNullOrWhiteSpace(email))


### PR DESCRIPTION
## Summary

Adds two new field types for handling large datasets (100-10K+ rows) that are impractical with static dropdown lists.

Fixes #27

## Changes

### Core Abstractions (FormCraft/)
- `IOptionProvider<TModel, TValue>` — async search-based option provider interface
- `LookupColumn<TItem>` — column definition for lookup table dialogs
- `LookupQuery` / `LookupResult<TItem>` — query/result models for server-side pagination
- `AsAutocomplete()` extensions on FieldBuilder for searchable fields (supports both search functions and IOptionProvider)

### Autocomplete Field (FormCraft.ForMudBlazor/)
- `MudBlazorAutocompleteFieldComponent` — uses MudAutocomplete with server-side search, configurable debounce and min characters
- `MudBlazorAutocompleteFieldRenderer` — renderer that activates when AutocompleteSearchFunc or AutocompleteOptionProvider attributes are present

### Lookup Field (FormCraft.ForMudBlazor/)
- `MudBlazorLookupFieldComponent` — text field with search icon that opens a MudDialog containing MudTable with pagination, sorting, and filtering
- `MudBlazorLookupDialog` — reusable dialog component with server-side data, search bar, row selection
- `AsLookup()` extension with column configuration, value/display selectors, and field mapping callback
- `MudBlazorLookupFieldRenderer` — renderer that activates when LookupDataProvider attribute is present

### Tests
- 10 unit tests for AsAutocomplete() builder extensions (search func, option provider, debounce, min chars, toString, chaining)
- 11 unit tests for AsLookup() builder extensions (data provider, selectors, columns, onItemSelected, defaults, chaining)

## Testing
- All 579 existing tests pass (0 failures)
- 21 new unit tests verify builder extension configuration
- Build succeeds with 0 warnings and 0 errors

## Discovered Issues
- Phase C (async cascading refresh for DependsOn) is not included — the current sync IFieldDependency interface would need an async variant. Recommend as follow-up issue.