### PR TITLE
fix: add missing WithInputType("password") in AddPasswordField

### DIFF
--- a/FormCraft/Forms/Extensions/FluentFormBuilderExtensions.cs
+++ b/FormCraft/Forms/Extensions/FluentFormBuilderExtensions.cs
@@ -283,6 +283,7 @@ public static class FluentFormBuilderExtensions
             return builder.AddField(expression, field =>
             {
                 field.WithLabel(label)
+                    .WithInputType("password")
                     .Required($"{label} is required")
                     .WithMinLength(minLength, $"Must be at least {minLength} characters");
 


### PR DESCRIPTION
## Summary
- The `AddPasswordField` extension method in `FluentFormBuilderExtensions.cs` was missing `.WithInputType("password")` in its method chain, causing the `InputType` property to not be set to `"password"`.
- This fix was already applied on the `develop` branch (commit 90d4102) but was never merged to `main`, causing CI test failures on `main`.

## Test plan
- [x] All 667 tests pass locally (608 unit tests + 59 MudBlazor tests, 0 failures)
- [x] The `AddPasswordField` test asserting `field.InputType.ShouldBe("password")` now passes