### PR TITLE
ci: publish to NuGet via Trusted Publishing, not a long-lived key

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write # request the GitHub OIDC token for NuGet Trusted Publishing
 
 jobs:
   ubuntu-latest:
@@ -35,10 +36,30 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', '**/*.csproj') }}
+      # Trusted Publishing: exchanges the OIDC token for a NuGet key valid ~1 hour, so no long-lived
+      # secret is stored. Nuke reads it from the NUGET_API_KEY environment variable exactly as
+      # before, so build/Build.cs is unchanged — it neither knows nor cares that the key expires.
+      #
+      # Gated on a version tag, mirroring the build's own gate: Continuous triggers PublishIfNeeded,
+      # which is OnlyWhenStatic(IsOnVersionTag() && IsServerBuild) before it reaches Publish's
+      # Requires(NuGetApiKey). So a push to main/dev and every pull_request run leave the key unset
+      # today, and must keep doing so — minting a key on a pull request would both be pointless and
+      # fail outright for a fork, which cannot obtain this repository's OIDC token.
+      #
+      # Requires a Trusted Publishing policy on nuget.org for the FormCraft and
+      # FormCraft.ForMudBlazor packages, naming this repository and continuous.yml, plus the
+      # NUGET_USER secret (the nuget.org profile name).
+      - name: NuGet login (OIDC -> short-lived key)
+        id: nuget-login
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: 'Run: Continuous'
         run: ./build.cmd Continuous
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v7

--- a/build/README.md
+++ b/build/README.md
@@ -138,7 +138,11 @@ scoop install git-cliff
 
 ### Environment Variables
 
-- `NUGET_API_KEY`: Required for publishing to NuGet.org
+- `NUGET_API_KEY`: Required for publishing to NuGet.org. In CI this is **not** a stored secret —
+  `continuous.yml` obtains a key valid about an hour from NuGet
+  [Trusted Publishing](https://learn.microsoft.com/nuget/nuget-org/trusted-publishing) via GitHub's
+  OIDC token, and passes it in through this same variable, so the build needs no change. Only a
+  local, manual publish uses a real API key you supply yourself.
 
 ### Parameters
 


### PR DESCRIPTION
`continuous.yml` passed a long-lived `NUGET_API_KEY` into the Nuke build. It now uses **Trusted Publishing**: GitHub's OIDC token is exchanged for a NuGet key valid ~1 hour, passed through the same `NUGET_API_KEY` variable. The only remaining secret is `NUGET_USER` — the nuget.org profile name, not a credential.

**`build/Build.cs` is unchanged.** Nuke reads an environment variable; it neither knows nor cares that the key expires.

### The gate matters here, so I matched the build's own

The login step runs only on a version tag. That mirrors what the build already does: `Continuous` triggers `PublishIfNeeded`, which is `OnlyWhenStatic(IsOnVersionTag() && IsServerBuild)` before it ever reaches `Publish`'s `Requires(NuGetApiKey)`. Pushes to `main`/`dev` and every `pull_request` run leave the key unset today and must keep doing so — minting one on a pull request would be pointless, and would **fail outright for a fork**, which cannot obtain this repository's OIDC token.

### Heads-up: this repo's CI is already red, for an unrelated reason

The last three runs fail on `NU1902` — `AngleSharp 1.4.0` has a known moderate-severity advisory ([GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg)) and the build treats it as an error. This PR does not address that and **will not go green until AngleSharp is bumped**. I left it alone rather than mixing a dependency bump into a credentials change; happy to do it as a separate PR.

### Required before the next release

1. Register a Trusted Publishing policy on nuget.org for `FormCraft` **and** `FormCraft.ForMudBlazor`, naming `phmatray/FormCraft` and `continuous.yml`.
2. Set the `NUGET_USER` secret.
3. Cut one release, confirm both packages appear, **then** delete `NUGET_API_KEY`.