### PR TITLE
chore: target net8.0;net10.0 and fix the AngleSharp advisory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <!-- Framework-agnostic packages -->
   <ItemGroup>
+    <!-- Epinglee directement : bunit tire AngleSharp 1.4.0, vulnerable (GHSA-pgww-w46g-26qg). -->
+    <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <!-- UI Framework packages -->
     <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <!-- Testing packages -->

--- a/FormCraft.ForMudBlazor.UnitTests/FormCraft.ForMudBlazor.UnitTests.csproj
+++ b/FormCraft.ForMudBlazor.UnitTests/FormCraft.ForMudBlazor.UnitTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
+    <PackageReference Include="AngleSharp" />
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/FormCraft.ForMudBlazor/FormCraft.ForMudBlazor.csproj
+++ b/FormCraft.ForMudBlazor/FormCraft.ForMudBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/FormCraft.UnitTests/FormCraft.UnitTests.csproj
+++ b/FormCraft.UnitTests/FormCraft.UnitTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
+    <PackageReference Include="AngleSharp" />
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/FormCraft/FormCraft.csproj
+++ b/FormCraft/FormCraft.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Retire la jambe **net9.0** (hors support depuis le 12/05/2026) en conservant **net8.0** (LTS jusqu'au 10/11/2026) pour ne casser aucun consommateur du package (10 463 telechargements).

Corrige au passage le build, **rouge avant cette PR** : `NU1902` sur `AngleSharp` 1.4.0 tire transitivement par bunit ([GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg)), avec l'audit NuGet en erreur. Epingle en 1.5.2 via CPM.

**Verdict de l'oracle local** : `RED` -> `GREEN` (solution complete).