### PR TITLE
feat(mudblazor): make ShrinkLabel configurable per field and per form (#177)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionShrinkLabelTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionShrinkLabelTests.cs
@@ -1,0 +1,96 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that collection item fields honor the configurable ShrinkLabel (#177). These
+/// render through CollectionFieldComponent's imperative RenderTreeBuilder path, which
+/// resolves presentation attributes in AddCommonFieldAttributes rather than through
+/// MudBlazorFieldComponentBase — so it needs its own resolver and its own coverage.
+/// </summary>
+public class CollectionShrinkLabelTests : MudBlazorTestBase
+{
+    [Fact]
+    public void ItemField_Should_Default_To_ShrinkLabel_True()
+    {
+        // Arrange & Act
+        var component = RenderOrderForm(BuildConfiguration(itemShrinkLabel: null));
+
+        // Assert - unchanged from before #177
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ItemField_Should_Honor_FieldLevel_WithShrinkLabel()
+    {
+        // Arrange & Act
+        var component = RenderOrderForm(BuildConfiguration(itemShrinkLabel: false));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ItemField_Should_Honor_FormLevel_DefaultShrinkLabel()
+    {
+        // Arrange & Act - the cascade has to reach into the collection component too
+        var component = RenderOrderForm(
+            BuildConfiguration(itemShrinkLabel: null), defaultShrinkLabel: false);
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ItemField_FieldLevel_Should_Override_FormLevel()
+    {
+        // Arrange & Act
+        var component = RenderOrderForm(
+            BuildConfiguration(itemShrinkLabel: true), defaultShrinkLabel: false);
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
+    }
+
+    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
+        IFormConfiguration<OrderModel> config, bool? defaultShrinkLabel = null)
+    {
+        var model = new OrderModel { Items = { new OrderItem { ProductName = "Widget" } } };
+
+        return Render<FormCraftComponent<OrderModel>>(parameters =>
+        {
+            parameters.Add(p => p.Model, model);
+            parameters.Add(p => p.Configuration, config);
+            if (defaultShrinkLabel is { } shrink)
+            {
+                parameters.Add(p => p.DefaultShrinkLabel, shrink);
+            }
+        });
+    }
+
+    private static IFormConfiguration<OrderModel> BuildConfiguration(bool? itemShrinkLabel)
+    {
+        return FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field =>
+                    {
+                        field.WithLabel("Product");
+                        if (itemShrinkLabel is { } shrink)
+                        {
+                            field.WithShrinkLabel(shrink);
+                        }
+                    })))
+            .Build();
+    }
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -313,6 +313,30 @@ public class ShrinkLabelConfigurationTests : MudBlazorTestBase
             .Instance.ShrinkLabel.ShouldBe(expected);
     }
 
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void LovField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        // The LOV field was the one variant-aware component that never set ShrinkLabel at
+        // all, so it rendered with MudBlazor's false while its 11 siblings pinned the label.
+        // Its input always shows text (DisplayText, else the "Click to select..."
+        // placeholder), which an unshrunk label would sit on top of.
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.CityId, f => ApplyShrinkLabel(
+                f.WithLabel("City").AsLov<TestModel, int, CityDto>(lov => lov
+                    .WithDataSource(() => new[] { new CityDto { Id = 1, Name = "Paris" } })
+                    .WithKey(c => c.Id)
+                    // Cast required: WithDisplay has both Expression<Func<>> and Func<>
+                    // overloads, so a bare lambda is ambiguous (CS0121).
+                    .WithDisplay((Expression<Func<CityDto, string>>)(c => c.Name))),
+                fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudTextField<string>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
     /// <summary>
     /// Applies <c>.WithShrinkLabel(value)</c> only when the case supplies one, so the
     /// "null" case exercises the genuinely-unconfigured path rather than an explicit true.

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -318,10 +318,12 @@ public class ShrinkLabelConfigurationTests : MudBlazorTestBase
     [InlineData(false, false)]
     public void LovField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
     {
-        // The LOV field was the one variant-aware component that never set ShrinkLabel at
-        // all, so it rendered with MudBlazor's false while its 11 siblings pinned the label.
-        // Its input always shows text (DisplayText, else the "Click to select..."
-        // placeholder), which an unshrunk label would sit on top of.
+        // The LOV field was the one variant-aware component that never passed ShrinkLabel at
+        // all; it now does, for consistency with its 11 siblings. This asserts the value
+        // reaching the component only. It does NOT imply a visible change: the LOV input
+        // always supplies a "Click to select..." placeholder, and MudBlazor's placeholder
+        // rule pins the label on its own — see ShrinkLabelRenderingTests, which measures the
+        // rendered outcome and shows it is identical with and without this setting.
         var config = FormBuilder<TestModel>.Create()
             .AddField(x => x.CityId, f => ApplyShrinkLabel(
                 f.WithLabel("City").AsLov<TestModel, int, CityDto>(lov => lov

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -153,8 +153,238 @@ public class ShrinkLabelConfigurationTests : MudBlazorTestBase
         component.Instance.DefaultShrinkLabel.ShouldBeTrue();
     }
 
+    /// <summary>
+    /// Renders the form next to a MudPopoverProvider, which the picker components require.
+    /// </summary>
+    private IRenderedComponent<FormCraftComponent<TestModel>> RenderForm(
+        IFormConfiguration<TestModel> config, bool? defaultShrinkLabel = null)
+    {
+        var model = new TestModel();
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<FormCraftComponent<TestModel>>(1);
+            builder.AddComponentParameter(2, "Model", model);
+            builder.AddComponentParameter(3, "Configuration", config);
+            if (defaultShrinkLabel is { } shrink)
+            {
+                builder.AddComponentParameter(4, "DefaultShrinkLabel", shrink);
+            }
+            builder.CloseComponent();
+        });
+
+        return cut.FindComponent<FormCraftComponent<TestModel>>();
+    }
+
+    // Each component gets a Theory rather than one Fact asserting both states: a bUnit
+    // context accepts only ONE MudPopoverProvider, so two renders in a single test throw
+    // "already a subscriber to ... 'mud-overlay-to-popover-provider'". One render per test.
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void NumericField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Age, f => ApplyShrinkLabel(f.WithLabel("Age"), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudNumericField<int>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void NullableNumericField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.OptionalAge, f => ApplyShrinkLabel(f.WithLabel("Optional Age"), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudNumericField<int?>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void SelectField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Country, f => ApplyShrinkLabel(
+                f.WithLabel("Country").WithOptions(("US", "United States"), ("BE", "Belgium")),
+                fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudSelect<string>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void MultiSelectField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Categories, f => ApplyShrinkLabel(
+                f.WithLabel("Categories").AsMultiSelect(("tech", "Technology"), ("health", "Healthcare")),
+                fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudSelect<string>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void DateTimeField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.BirthDate, f => ApplyShrinkLabel(f.WithLabel("Birth Date"), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudDatePicker>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void DateOnlyField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.StartDate, f => ApplyShrinkLabel(f.WithLabel("Start Date"), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudDatePicker>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void TimeOnlyField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.StartTime, f => ApplyShrinkLabel(f.WithLabel("Start Time"), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudTimePicker>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void AutocompleteField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.City, f => ApplyShrinkLabel(
+                f.WithLabel("City").AsAutocomplete(SearchCitiesAsync), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudAutocomplete<string>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void LookupField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        RenderForm(BuildLookupConfig(fieldLevel)).FindComponent<MudTextField<string>>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(false, false)]
+    public void ColorPickerField_Should_Honor_ShrinkLabel(bool? fieldLevel, bool expected)
+    {
+        var config = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Color, f => ApplyShrinkLabel(
+                f.WithLabel("Color").AsColorPicker(), fieldLevel))
+            .Build();
+
+        RenderForm(config).FindComponent<MudColorPicker>()
+            .Instance.ShrinkLabel.ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// Applies <c>.WithShrinkLabel(value)</c> only when the case supplies one, so the
+    /// "null" case exercises the genuinely-unconfigured path rather than an explicit true.
+    /// </summary>
+    private static void ApplyShrinkLabel<TValue>(FieldBuilder<TestModel, TValue> builder, bool? value)
+    {
+        if (value is { } shrinkLabel)
+        {
+            builder.WithShrinkLabel(shrinkLabel);
+        }
+    }
+
+    [Fact]
+    public void DefaultShrinkLabel_False_Should_Reach_Pickers_And_Selects()
+    {
+        // Arrange - the form-level default must cross the cascade into every component,
+        // not just the ones with a field-level attribute.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.BirthDate, f => f.WithLabel("Birth Date"))
+            .AddField(x => x.Country, f => f
+                .WithLabel("Country")
+                .WithOptions(("US", "United States")))
+            .Build();
+
+        // Act
+        var component = RenderForm(config, defaultShrinkLabel: false);
+
+        // Assert
+        component.FindComponent<MudDatePicker>().Instance.ShrinkLabel.ShouldBeFalse();
+        component.FindComponent<MudSelect<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    private static Task<IEnumerable<SelectOption<string>>> SearchCitiesAsync(
+        string text, CancellationToken cancellationToken)
+        => Task.FromResult<IEnumerable<SelectOption<string>>>(
+            [new SelectOption<string> { Value = "Paris", Label = "Paris" }]);
+
+    private static IFormConfiguration<TestModel> BuildLookupConfig(bool? shrinkLabel)
+        => FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.CityId, f => ApplyShrinkLabel(
+                f.WithLabel("City")
+                    .AsLookup<TestModel, int, CityDto>(
+                        dataProvider: _ => Task.FromResult(new LookupResult<CityDto>
+                        {
+                            Items = [new CityDto { Id = 1, Name = "Paris" }],
+                            TotalCount = 1
+                        }),
+                        valueSelector: c => c.Id,
+                        displaySelector: c => c.Name),
+                shrinkLabel))
+            .Build();
+
+    private class CityDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+        public int? OptionalAge { get; set; }
+        public string Country { get; set; } = string.Empty;
+        public IEnumerable<string> Categories { get; set; } = [];
+        public DateTime BirthDate { get; set; }
+        public DateOnly StartDate { get; set; }
+        public TimeOnly StartTime { get; set; }
+        public string City { get; set; } = string.Empty;
+        public int CityId { get; set; }
+        public string Color { get; set; } = string.Empty;
     }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -1,0 +1,77 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests for the configurable MudBlazor ShrinkLabel (#177): the .WithShrinkLabel(...)
+/// field extension, the form-level FormCraftComponent.DefaultShrinkLabel parameter, and
+/// the precedence between them. Follow-up to the configurable Variant (#146) — with
+/// Variant.Text a permanently shrunk label has nothing to anchor to, so consumers need
+/// to be able to let it float.
+/// </summary>
+public class ShrinkLabelConfigurationTests : MudBlazorTestBase
+{
+    [Fact]
+    public void TextField_Should_Default_To_ShrinkLabel_True()
+    {
+        // Arrange
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field.WithLabel("Name"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert - unchanged from v3.1.0: the label stays pinned unless asked otherwise
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WithShrinkLabel_False_Should_Apply_To_TextField()
+    {
+        // Arrange
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field
+                .WithLabel("Name")
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WithShrinkLabel_Should_Default_Its_Argument_To_True()
+    {
+        // Arrange - the parameterless call mirrors AsPassword(enableVisibilityToggle: true)
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field
+                .WithLabel("Name")
+                .WithShrinkLabel())
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
+    }
+
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -70,6 +70,89 @@ public class ShrinkLabelConfigurationTests : MudBlazorTestBase
         component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
     }
 
+    [Fact]
+    public void DefaultShrinkLabel_False_Should_Apply_To_Fields_Without_Explicit_Setting()
+    {
+        // Arrange
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field.WithLabel("Name"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config)
+            .Add(p => p.DefaultShrinkLabel, false));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FieldLevel_False_Should_Override_FormLevel_True()
+    {
+        // Arrange
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field
+                .WithLabel("Name")
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act - form says true (the default), field says false
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config)
+            .Add(p => p.DefaultShrinkLabel, true));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FieldLevel_True_Should_Override_FormLevel_False()
+    {
+        // Arrange - the other direction, which a null-coalescing bug would silently break
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field
+                .WithLabel("Name")
+                .WithShrinkLabel(true))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config)
+            .Add(p => p.DefaultShrinkLabel, false));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.ShrinkLabel.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DefaultShrinkLabel_Should_Default_To_True()
+    {
+        // Arrange - a form that never mentions ShrinkLabel keeps the v3.1.0 rendering
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, field => field.WithLabel("Name"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Instance.DefaultShrinkLabel.ShouldBeTrue();
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = string.Empty;

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelRenderingTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelRenderingTests.cs
@@ -1,0 +1,140 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Rendering-level coverage for the configurable ShrinkLabel (#177).
+/// <para>
+/// ShrinkLabelConfigurationTests asserts the value FormCraft passes *into* the MudBlazor
+/// component. That is necessary but not sufficient: MudBlazor ORs ShrinkLabel together with
+/// several other conditions before emitting the "mud-shrink" class, so a field can receive
+/// ShrinkLabel=false and still render a pinned label. These tests assert the rendered
+/// outcome instead, and pin down exactly when the setting is and is not observable.
+/// </para>
+/// </summary>
+public class ShrinkLabelRenderingTests : MudBlazorTestBase
+{
+    private const string ShrinkClass = "mud-shrink";
+
+    [Fact]
+    public void WithShrinkLabel_False_Should_Unpin_The_Label_When_No_Placeholder()
+    {
+        // Arrange - the scenario #177 was filed for: Variant.Text with a floating label
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Name")
+                .WithVariant(Variant.Text)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(p => p
+            .Add(c => c.Model, new TestModel())
+            .Add(c => c.Configuration, config));
+
+        // Assert
+        component.Markup.ShouldNotContain(ShrinkClass);
+    }
+
+    [Fact]
+    public void Default_Should_Keep_The_Label_Pinned()
+    {
+        // Arrange
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(p => p
+            .Add(c => c.Model, new TestModel())
+            .Add(c => c.Configuration, config));
+
+        // Assert
+        component.Markup.ShouldContain(ShrinkClass);
+    }
+
+    [Fact]
+    public void WithShrinkLabel_False_Should_Not_Unpin_The_Label_When_A_Placeholder_Is_Set()
+    {
+        // Arrange - MudBlazor's MudInput ORs ShrinkLabel with the presence of a placeholder,
+        // a start adornment and a non-empty value, so ShrinkLabel=false cannot win against
+        // any of them. Documented on WithShrinkLabel and in the README; asserted here so the
+        // limitation is a known, tested fact rather than a surprise in the field.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Name")
+                .WithPlaceholder("john@example.com")
+                .WithVariant(Variant.Text)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(p => p
+            .Add(c => c.Model, new TestModel())
+            .Add(c => c.Configuration, config));
+
+        // Assert
+        component.Markup.ShouldContain(ShrinkClass);
+    }
+
+    [Fact]
+    public void WithShrinkLabel_False_Should_Not_Unpin_The_Label_When_The_Field_Has_A_Value()
+    {
+        // Arrange - a populated field always shows its label shrunk, whatever ShrinkLabel says
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Name")
+                .WithVariant(Variant.Text)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(p => p
+            .Add(c => c.Model, new TestModel { Name = "Philippe" })
+            .Add(c => c.Configuration, config));
+
+        // Assert
+        component.Markup.ShouldContain(ShrinkClass);
+    }
+
+    [Fact]
+    public void LovField_Label_Is_Always_Pinned_Regardless_Of_ShrinkLabel()
+    {
+        // Arrange - the LOV input hardcodes Placeholder="@(Placeholder ?? "Click to select...")",
+        // which is never empty, so MudBlazor's placeholder rule pins the label on its own and
+        // ShrinkLabel cannot influence the rendering either way. Asserted so nobody documents
+        // a LOV-visible ShrinkLabel behaviour that does not exist.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.CityId, f => f
+                .WithLabel("City")
+                .AsLov<TestModel, int, CityDto>(lov => lov
+                    .WithDataSource(() => new[] { new CityDto { Id = 1, Name = "Paris" } })
+                    .WithKey(c => c.Id)
+                    .WithDisplay((Expression<Func<CityDto, string>>)(c => c.Name)))
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(p => p
+            .Add(c => c.Model, new TestModel())
+            .Add(c => c.Configuration, config));
+
+        // Assert - pinned despite ShrinkLabel=false
+        component.Markup.ShouldContain(ShrinkClass);
+    }
+
+    private class CityDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int CityId { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
+++ b/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
@@ -139,6 +139,38 @@ public static class MudBlazorFieldBuilderExtensions
     }
 
     /// <summary>
+    /// Sets MudBlazor's <c>ShrinkLabel</c> for the field's input, overriding the form-level
+    /// default (see <c>FormCraftComponent&lt;TModel&gt;.DefaultShrinkLabel</c>). When neither
+    /// is configured, fields render with <c>ShrinkLabel="true"</c> — the label stays in its
+    /// shrunk position above the input.
+    /// </summary>
+    /// <remarks>
+    /// Pass <c>false</c> when using <see cref="MudBlazor.Variant.Text"/>: that variant has no
+    /// border for a shrunk label to sit in, so the label should float up from inside the input
+    /// on focus instead of being permanently pinned above it.
+    /// </remarks>
+    /// <typeparam name="TModel">The model type that the form binds to.</typeparam>
+    /// <typeparam name="TValue">The type of the field value.</typeparam>
+    /// <param name="builder">The FieldBuilder instance.</param>
+    /// <param name="shrinkLabel">Whether the label stays shrunk (default: true).</param>
+    /// <returns>The FieldBuilder instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// .AddField(x => x.Name, field => field
+    ///     .WithLabel("Name")
+    ///     .WithVariant(Variant.Text)
+    ///     .WithShrinkLabel(false))
+    /// </code>
+    /// </example>
+    public static FieldBuilder<TModel, TValue> WithShrinkLabel<TModel, TValue>(
+        this FieldBuilder<TModel, TValue> builder,
+        bool shrinkLabel = true)
+        where TModel : new()
+    {
+        return builder.WithAttribute("ShrinkLabel", shrinkLabel);
+    }
+
+    /// <summary>
     /// Adds an adornment (icon or text) to a text field.
     /// </summary>
     /// <typeparam name="TModel">The model type that the form binds to.</typeparam>

--- a/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
+++ b/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
@@ -145,9 +145,19 @@ public static class MudBlazorFieldBuilderExtensions
     /// shrunk position above the input.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Pass <c>false</c> when using <see cref="MudBlazor.Variant.Text"/>: that variant has no
     /// border for a shrunk label to sit in, so the label should float up from inside the input
     /// on focus instead of being permanently pinned above it.
+    /// </para>
+    /// <para>
+    /// <b>Setting this to <c>false</c> only has a visible effect on an empty field with no
+    /// placeholder and no start adornment.</b> MudBlazor combines <c>ShrinkLabel</c> with those
+    /// conditions using OR, so a field that has a value, a placeholder (see
+    /// <c>WithPlaceholder</c>) or a start adornment (see <c>WithAdornment</c>) keeps its label
+    /// pinned regardless. This is MudBlazor's behaviour, not FormCraft's — to get a floating
+    /// label on a <see cref="MudBlazor.Variant.Text"/> field, leave its placeholder unset.
+    /// </para>
     /// </remarks>
     /// <typeparam name="TModel">The model type that the form binds to.</typeparam>
     /// <typeparam name="TValue">The type of the field value.</typeparam>

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -41,6 +41,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
     public Variant? FormDefaultVariant { get; set; }
 
     /// <summary>
+    /// Gets or sets the form-level default ShrinkLabel cascaded by <see cref="FormCraftComponent{TModel}"/>.
+    /// Used as a fallback for item fields that do not configure their own "ShrinkLabel" attribute.
+    /// </summary>
+    [CascadingParameter(Name = FormCraftCascadingValues.DefaultShrinkLabel)]
+    public bool? FormDefaultShrinkLabel { get; set; }
+
+    /// <summary>
     /// Gets or sets the parent form's EditContext, cascaded from the surrounding EditForm.
     /// When present, item field changes raise <see cref="EditContext.NotifyFieldChanged(in FieldIdentifier)"/>
     /// with a nested field identifier (e.g. <c>Items[0].ProductName</c>) on the root model, so
@@ -268,7 +275,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);
         builder.AddAttribute(startIndex++, "Variant", GetItemFieldVariant(field));
         builder.AddAttribute(startIndex++, "Margin", Margin.Dense);
-        builder.AddAttribute(startIndex, "ShrinkLabel", true);
+        builder.AddAttribute(startIndex, "ShrinkLabel", GetItemFieldShrinkLabel(field));
     }
 
     /// <summary>
@@ -283,5 +290,19 @@ public partial class CollectionFieldComponent<TModel, TItem>
         }
 
         return FormDefaultVariant ?? Variant.Outlined;
+    }
+
+    /// <summary>
+    /// Resolves ShrinkLabel for an item field: the field-level "ShrinkLabel" attribute when
+    /// present, otherwise the cascaded form-level default, otherwise true.
+    /// </summary>
+    private bool GetItemFieldShrinkLabel(IFieldConfiguration<TItem, object> field)
+    {
+        if (field.AdditionalAttributes.TryGetValue("ShrinkLabel", out var value) && value is bool shrinkLabel)
+        {
+            return shrinkLabel;
+        }
+
+        return FormDefaultShrinkLabel ?? true;
     }
 }

--- a/FormCraft.ForMudBlazor/Features/CustomFields/MudBlazorColorPickerComponent.razor
+++ b/FormCraft.ForMudBlazor/Features/CustomFields/MudBlazorColorPickerComponent.razor
@@ -12,7 +12,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     ColorPickerMode="ColorPickerMode.RGB"
     PickerVariant="PickerVariant.Dialog"
     AnchorOrigin="Origin.BottomCenter"/>

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
@@ -10,6 +10,7 @@
 }
 
 <CascadingValue TValue="Variant?" Name="@FormCraftCascadingValues.DefaultVariant" Value="@DefaultVariant">
+<CascadingValue TValue="bool?" Name="@FormCraftCascadingValues.DefaultShrinkLabel" Value="@DefaultShrinkLabel">
 <EditForm EditContext="@_editContext" OnSubmit="@HandleSubmit">
     <DynamicFormValidator TModel="TModel" Configuration="@Configuration" @ref="_validator" />
     
@@ -112,6 +113,7 @@
         </MudButton>
     }
 </EditForm>
+</CascadingValue>
 </CascadingValue>
 
 @if (AfterForm != null)

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -58,9 +58,17 @@ public partial class FormCraftComponent<TModel>
     /// Defaults to <c>true</c>, which keeps each label pinned above its input.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Set this to <c>false</c> alongside <see cref="DefaultVariant"/> =
     /// <see cref="Variant.Text"/>: that variant draws no border for a shrunk label to sit
     /// in, so the label should float up from inside the input on focus instead.
+    /// </para>
+    /// <para>
+    /// <b><c>false</c> only has a visible effect on empty fields with no placeholder and no
+    /// start adornment.</b> MudBlazor ORs <c>ShrinkLabel</c> with those conditions, so fields
+    /// that have a value, a placeholder or a start adornment keep their label pinned
+    /// regardless. Fields configured with a placeholder are unaffected by this parameter.
+    /// </para>
     /// </remarks>
     [Parameter]
     public bool DefaultShrinkLabel { get; set; } = true;

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -53,6 +53,19 @@ public partial class FormCraftComponent<TModel>
     public Variant DefaultVariant { get; set; } = Variant.Outlined;
 
     /// <summary>
+    /// Default value for MudBlazor's <c>ShrinkLabel</c> on every rendered input field.
+    /// Individual fields override it via the <c>.WithShrinkLabel(...)</c> builder extension.
+    /// Defaults to <c>true</c>, which keeps each label pinned above its input.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <c>false</c> alongside <see cref="DefaultVariant"/> =
+    /// <see cref="Variant.Text"/>: that variant draws no border for a shrunk label to sit
+    /// in, so the label should float up from inside the input on focus instead.
+    /// </remarks>
+    [Parameter]
+    public bool DefaultShrinkLabel { get; set; } = true;
+
+    /// <summary>
     /// Stable identifier used for security enforcement (rate limiting and audit log
     /// entries) configured via <c>WithSecurity()</c>. Set this to a per-user or
     /// per-session value (e.g. user id, circuit id, IP address) so limits are not

--- a/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/AutocompleteField/MudBlazorAutocompleteFieldComponent.razor
@@ -15,7 +15,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     DebounceInterval="@_debounceMs"
     MinCharacters="@_minCharacters"
     ResetValueOnEmptyText="true"

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateOnlyFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateOnlyFieldComponent.razor
@@ -12,7 +12,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     DateFormat="@Format"
     Editable="true"
     MinDate="@MinDate"

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
@@ -13,7 +13,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     DateFormat="@Format"
     Editable="true"
     MinDate="@MinDate"

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorTimeOnlyFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorTimeOnlyFieldComponent.razor
@@ -12,6 +12,6 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Editable="true"
     Clearable="@ShowClearButton" />

--- a/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/LookupField/MudBlazorLookupFieldComponent.razor
@@ -13,7 +13,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Adornment="Adornment.End"
     AdornmentIcon="@Icons.Material.Filled.Search"
     OnAdornmentClick="@OpenLookupDialog"

--- a/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor
@@ -16,6 +16,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Adornment="Adornment.End"
     AdornmentIcon="@AdornmentIcon"
     AdornmentColor="Color.Primary"

--- a/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor
@@ -6,6 +6,10 @@
 @inject IDialogService DialogService
 @inject IServiceProvider ServiceProvider
 
+@* ShrinkLabel is passed for consistency with the other input components, but it cannot
+   change this field's rendering: the Placeholder below is never empty, and MudBlazor ORs
+   a non-empty placeholder into its own shrink decision. The label is therefore always
+   pinned here, whatever ShrinkLabel says. Pinned by ShrinkLabelRenderingTests. *@
 <MudTextField
     T="string"
     Label="@Label"

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -15,6 +15,13 @@ public static class FormCraftCascadingValues
     /// <c>.WithVariant(...)</c> (the "Variant" additional attribute).
     /// </summary>
     public const string DefaultVariant = "FormCraftDefaultVariant";
+
+    /// <summary>
+    /// Name of the cascading <see cref="bool"/> that provides the form-level default
+    /// for MudBlazor's <c>ShrinkLabel</c>. Individual fields override it via
+    /// <c>.WithShrinkLabel(...)</c> (the "ShrinkLabel" additional attribute).
+    /// </summary>
+    public const string DefaultShrinkLabel = "FormCraftDefaultShrinkLabel";
 }
 
 /// <summary>
@@ -35,10 +42,33 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     public Variant? FormDefaultVariant { get; set; }
 
     /// <summary>
+    /// Gets or sets the form-level default <c>ShrinkLabel</c> cascaded by
+    /// <see cref="FormCraftComponent{TModel}"/>. Used as a fallback when the field does
+    /// not configure its own "ShrinkLabel" additional attribute.
+    /// </summary>
+    [CascadingParameter(Name = FormCraftCascadingValues.DefaultShrinkLabel)]
+    public bool? FormDefaultShrinkLabel { get; set; }
+
+    /// <summary>
     /// Gets the variant to apply to the MudBlazor input: the field-level "Variant"
     /// additional attribute (set via <c>.WithVariant(...)</c>) when present, otherwise
     /// the cascaded form-level default, otherwise <see cref="Variant.Outlined"/>.
     /// </summary>
     protected Variant EffectiveVariant =>
         GetAttribute<Variant?>("Variant") ?? FormDefaultVariant ?? Variant.Outlined;
+
+    /// <summary>
+    /// Gets whether the MudBlazor input's label should stay in its shrunk position: the
+    /// field-level "ShrinkLabel" additional attribute (set via
+    /// <c>.WithShrinkLabel(...)</c>) when present, otherwise the cascaded form-level
+    /// default, otherwise <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// The <c>true</c> fallback preserves the rendering FormCraft has always produced,
+    /// which suits <see cref="Variant.Outlined"/> and <see cref="Variant.Filled"/>.
+    /// <see cref="Variant.Text"/> usually wants <c>false</c> so the label floats from
+    /// inside the input on focus, since there is no border to anchor a shrunk label to.
+    /// </remarks>
+    protected bool EffectiveShrinkLabel =>
+        GetAttribute<bool?>("ShrinkLabel") ?? FormDefaultShrinkLabel ?? true;
 }

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
@@ -19,5 +19,5 @@
     Culture="@Culture"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Immediate="true" />

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
@@ -19,5 +19,5 @@
     Culture="@Culture"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Immediate="true" />

--- a/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorMultiSelectFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorMultiSelectFieldComponent.razor
@@ -15,7 +15,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true">
+    ShrinkLabel="@EffectiveShrinkLabel">
     @foreach (SelectOption<TItem> option in Options)
     {
         <MudSelectItem T="TItem" Value="@option.Value">

--- a/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorSelectFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/SelectField/MudBlazorSelectFieldComponent.razor
@@ -15,7 +15,7 @@
     Disabled="@IsDisabled"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true">
+    ShrinkLabel="@EffectiveShrinkLabel">
     @foreach (SelectOption<TValue> option in Options)
     {
         <MudSelectItem T="TValue" Value="@option.Value">

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
@@ -22,5 +22,5 @@
     OnAdornmentClick="@HandleAdornmentClick"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
-    ShrinkLabel="true"
+    ShrinkLabel="@EffectiveShrinkLabel"
     Immediate="true" />

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 - 📤 File upload capabilities
 - 🎨 Real-time form generation
 
+## 🎉 Unreleased
+
+- **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so existing forms are unchanged (#177)
+  - One visual change: LOV fields were the only variant-aware component that never set `ShrinkLabel`, so their label started floating while every sibling pinned it. They are now aligned (label pinned) — opt out with `.WithShrinkLabel(false)`.
+
 ## 🎉 What's New in v3.1.0
 
 v3.1.0 implements every issue that was open after v3.0 — all features, no breaking changes. [Full changelog →](https://github.com/phmatray/FormCraft/releases/tag/v3.1.0)
@@ -541,6 +546,35 @@ var formConfig = FormBuilder<UserModel>
         .AddField(x => x.Address))
     .Build();
 ```
+
+### Input Appearance — Variant and ShrinkLabel
+
+Both MudBlazor presentation properties are configurable per field, with a form-level default. Field-level always wins; unconfigured fields render `Variant.Outlined` with `ShrinkLabel="true"`.
+
+```csharp
+// Form-level defaults for every field
+<FormCraftComponent TModel="UserModel"
+                    Model="@model"
+                    Configuration="@formConfig"
+                    DefaultVariant="Variant.Text"
+                    DefaultShrinkLabel="false" />
+```
+
+```csharp
+// Per-field override — a Filled search box among otherwise Text inputs
+var formConfig = FormBuilder<UserModel>
+    .Create()
+    .AddField(x => x.Query, field => field
+        .WithLabel("Search")
+        .WithVariant(Variant.Filled)
+        .WithShrinkLabel(true))
+    .Build();
+```
+
+> [!TIP]
+> `Variant.Text` usually wants `ShrinkLabel="false"`. That variant draws no border, so there is nothing for a permanently shrunk label to sit in — letting it float up from inside the input on focus is what makes `Text` look right. The two properties stay independent so you can still pin a label on a `Text` input if that is what you want.
+
+Honored by text, numeric, date/time pickers, select, multi-select, autocomplete, lookup, LOV, color picker and collection-item fields.
 
 ### Security Features (v2.0.0+)
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
-- **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so existing forms are unchanged (#177)
-  - One visual change: LOV fields were the only variant-aware component that never set `ShrinkLabel`, so their label started floating while every sibling pinned it. They are now aligned (label pinned) — opt out with `.WithShrinkLabel(false)`.
+- **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
+  - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.
 
 ## 🎉 What's New in v3.1.0
 
@@ -574,7 +574,10 @@ var formConfig = FormBuilder<UserModel>
 > [!TIP]
 > `Variant.Text` usually wants `ShrinkLabel="false"`. That variant draws no border, so there is nothing for a permanently shrunk label to sit in — letting it float up from inside the input on focus is what makes `Text` look right. The two properties stay independent so you can still pin a label on a `Text` input if that is what you want.
 
-Honored by text, numeric, date/time pickers, select, multi-select, autocomplete, lookup, LOV, color picker and collection-item fields.
+> [!IMPORTANT]
+> **`ShrinkLabel="false"` only shows up on an empty field with no placeholder and no start adornment.** MudBlazor decides the shrunk state by OR-ing `ShrinkLabel` with "has a value", "has a placeholder" and "has a start adornment" — so on a field configured with `.WithPlaceholder(...)` or `.WithAdornment(...)`, the label stays pinned no matter what you pass here. This is MudBlazor's rule, not FormCraft's. If you want the label to float on a `Variant.Text` field, leave its placeholder unset and let the label do that job.
+
+`Variant` is honored by text, numeric, date/time pickers, select, multi-select, autocomplete, lookup, LOV, color picker and collection-item fields. `ShrinkLabel` reaches all of the same components, subject to the rule above — note that LOV fields always supply their own `"Click to select..."` placeholder, so their label is always pinned.
 
 ### Security Features (v2.0.0+)
 


### PR DESCRIPTION
Implements #177.

Closes #177.

Follow-up to #146: `ShrinkLabel="true"` is hardcoded at 12 sites, so `Variant.Text` renders a permanently-pinned label over a borderless input. This makes it configurable through the same channel `Variant` already uses — field-level `.WithShrinkLabel(bool)` over form-level `DefaultShrinkLabel`, resolving to `true` when unset so no existing form changes appearance.

```csharp
// per field
.AddField(x => x.Name, field => field
    .WithLabel("Name")
    .WithVariant(Variant.Text)
    .WithShrinkLabel(false))     // label floats on focus/value

// or for the whole form
<FormCraftComponent TModel="MyModel" Model="@model" Configuration="@config"
                    DefaultVariant="Variant.Text"
                    DefaultShrinkLabel="false" />
```

### Plan
- [x] Task 1: Field-level `.WithShrinkLabel(...)`, honored by the text field
- [x] Task 2: Form-level `DefaultShrinkLabel` + precedence
- [x] Task 3: Roll out to the remaining 10 `.razor` components
- [x] Task 4: Collection item fields (`RenderTreeBuilder` path)
- [x] Task 5: Decide the LOV field's `ShrinkLabel` (flagged — behavior change)
- [x] Task 6: Documentation

## Known limitation — `ShrinkLabel="false"` is not always observable

Worth reading before reviewing, because it bounds what this PR actually delivers.

MudBlazor does not use `ShrinkLabel` as the last word. `MudInput` decides the `mud-shrink` class by OR-ing it with several other conditions:

```csharp
HasNativeHtmlPlaceholder() || !string.IsNullOrEmpty(ReadText) ||
Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || ShrinkLabel
```

So `.WithShrinkLabel(false)` is only **visible** on an empty field with no placeholder and no start adornment. A field configured with `.WithPlaceholder(...)` keeps its label pinned whatever you pass.

This is MudBlazor's rule, not something this PR can fix without silently discarding the user's placeholder — so it is **documented** instead: on `WithShrinkLabel`, on `DefaultShrinkLabel`, and as an `[!IMPORTANT]` callout in the README next to the usage example. `ShrinkLabelRenderingTests` asserts the rendered `mud-shrink` class in both directions so the boundary is a tested fact rather than folklore.

## Correction: the LOV field has **no** visual change

An earlier revision of this description and of the README claimed LOV labels "started floating while every sibling pinned it" and were "now aligned". **That was wrong**, and the code review caught it.

Measured by reverting the one-line change and re-running the rendering test against the base commit: LOV labels were **already pinned** before this PR, because the LOV input always supplies its own `"Click to select..."` placeholder and MudBlazor's placeholder rule shrinks the label on its own. The rendering is byte-identical with and without the change.

The `ShrinkLabel="@EffectiveShrinkLabel"` pass-through is **kept** — it makes the component consistent with its 11 siblings and stops a future reader from "fixing" the asymmetry again — but it is now marked in the razor as unable to affect that component's rendering, and `ShrinkLabelRenderingTests.LovField_Label_Is_Always_Pinned_Regardless_Of_ShrinkLabel` locks that in.

**Net result: this PR changes no existing form's appearance at all.** The default resolves to `true` everywhere, and the two pre-existing parity assertions (`RenderPipelineParityTests.cs:237` and `:257`, both `ShrinkLabel.ShouldBeTrue()`) stay green **unmodified** — they are the back-compat guard.

## Follow-ups

Found while working, deliberately **not** fixed here to keep this PR scoped:

- **`LovBuilder.WithDisplay` cannot be called with a bare lambda.** It declares both `WithDisplay(Expression<Func<TItem, string>>)` and `WithDisplay(Func<TItem, string>)`, so `lov.WithDisplay(c => c.Name)` fails with `CS0121: the call is ambiguous` — the natural call site, and the exact form used in the library's own XML-doc examples. Callers must write `(Expression<Func<CityDto, string>>)(c => c.Name)`, which the tests here do with a comment explaining why. Fixing it means renaming one overload or dropping the `Func<>` one (a breaking change), so it wants its own issue.
- **Consider whether a `Variant.Text` field should suppress a placeholder.** Given the OR rule above, a placeholder and a floating label are mutually exclusive in MudBlazor. FormCraft could surface that trade-off explicitly rather than letting `ShrinkLabel` quietly lose. Deliberately out of scope here — it changes rendering for existing forms.
