### PR TITLE
fix(lov): let WithDisplay and WithKey accept a plain lambda (#180)

### DIFF
--- a/FormCraft.DemoBlazorApp/Components/Pages/LovFieldDemo.razor.cs
+++ b/FormCraft.DemoBlazorApp/Components/Pages/LovFieldDemo.razor.cs
@@ -104,7 +104,7 @@ public partial class LovFieldDemo
                     .AsLov<OrderFormModel, int?, CustomerModel>(lov => lov
                         .WithDataSource(() => _customers)
                         .WithKey(c => c.Id)
-                        .WithDisplay((Func<CustomerModel, string>)(c => $"{c.Code} - {c.Name}"))
+                        .WithDisplay(c => $"{c.Code} - {c.Name}")
                         .AddColumn(c => c.Code, "Code", col => col.Width("100px"))
                         .AddColumn(c => c.Name, "Company Name", col => col.Width("200px"))
                         .AddColumn(c => c.City, "City")
@@ -209,7 +209,7 @@ public partial class LovFieldDemo
             .AsLov<OrderFormModel, int?, CustomerModel>(lov => lov
                 .WithDataSource(() => customers)
                 .WithKey(c => c.Id)
-                .WithDisplay((Func<CustomerModel, string>)(c => $"{c.Code} - {c.Name}"))
+                .WithDisplay(c => $"{c.Code} - {c.Name}")
 
                 // Configure table columns with width and formatting
                 .AddColumn(c => c.Code, "Code", col => col.Width("100px"))

--- a/FormCraft.DemoBlazorApp/Components/Pages/MasterDetailDemo.razor.cs
+++ b/FormCraft.DemoBlazorApp/Components/Pages/MasterDetailDemo.razor.cs
@@ -100,7 +100,7 @@ public partial class MasterDetailDemo
                     .AsLov<InvoiceFormModel, int?, CustomerModel>(lov => lov
                         .WithDataSource(() => _customers)
                         .WithKey(c => c.Id)
-                        .WithDisplay((Func<CustomerModel, string>)(c => $"{c.Code} - {c.Name}"))
+                        .WithDisplay(c => $"{c.Code} - {c.Name}")
                         .AddColumn(c => c.Code, "Code", col => col.Width("100px"))
                         .AddColumn(c => c.Name, "Company Name", col => col.Width("200px"))
                         .AddColumn(c => c.City, "City")
@@ -253,7 +253,7 @@ public partial class MasterDetailDemo
                 .AsLov<InvoiceFormModel, int?, CustomerModel>(lov => lov
                     .WithDataSource(() => customers)
                     .WithKey(c => c.Id)
-                    .WithDisplay((Func<CustomerModel, string>)(c => $"{c.Code} - {c.Name}"))
+                    .WithDisplay(c => $"{c.Code} - {c.Name}")
                     .AddColumn(c => c.Code, "Code")
                     .AddColumn(c => c.Name, "Company Name")
                     .AddColumn(c => c.City, "City")

--- a/FormCraft.ForMudBlazor.UnitTests/Components/SpecializedRendererDispatchTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/SpecializedRendererDispatchTests.cs
@@ -27,7 +27,7 @@ public class SpecializedRendererDispatchTests : MudBlazorTestBase
                 .WithLabel("Customer")
                 .AsLov<OrderModel, int?, Customer>(lov => lov
                     .WithKey(c => (int?)c.Id)
-                    .WithDisplay((Expression<Func<Customer, string>>)(c => c.Name))
+                    .WithDisplay(c => c.Name)
                     .WithDataSource(() => new List<Customer> { new() { Id = 1, Name = "ACME" } })
                     .AddColumn(c => c.Name, "Name")))
             .Build();

--- a/FormCraft.ForMudBlazor.UnitTests/Components/SpecializedRendererDispatchTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/SpecializedRendererDispatchTests.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using FormCraft.ForMudBlazor.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelConfigurationTests.cs
@@ -329,9 +329,7 @@ public class ShrinkLabelConfigurationTests : MudBlazorTestBase
                 f.WithLabel("City").AsLov<TestModel, int, CityDto>(lov => lov
                     .WithDataSource(() => new[] { new CityDto { Id = 1, Name = "Paris" } })
                     .WithKey(c => c.Id)
-                    // Cast required: WithDisplay has both Expression<Func<>> and Func<>
-                    // overloads, so a bare lambda is ambiguous (CS0121).
-                    .WithDisplay((Expression<Func<CityDto, string>>)(c => c.Name))),
+                    .WithDisplay(c => c.Name)),
                 fieldLevel))
             .Build();
 

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelRenderingTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelRenderingTests.cs
@@ -113,7 +113,7 @@ public class ShrinkLabelRenderingTests : MudBlazorTestBase
                 .AsLov<TestModel, int, CityDto>(lov => lov
                     .WithDataSource(() => new[] { new CityDto { Id = 1, Name = "Paris" } })
                     .WithKey(c => c.Id)
-                    .WithDisplay((Expression<Func<CityDto, string>>)(c => c.Name)))
+                    .WithDisplay(c => c.Name))
                 .WithShrinkLabel(false))
             .Build();
 

--- a/FormCraft.UnitTests/Documentation/DocumentationSamplesTests.cs
+++ b/FormCraft.UnitTests/Documentation/DocumentationSamplesTests.cs
@@ -392,6 +392,47 @@ public class DocumentationSamplesTests
 
     #endregion
 
+    #region README - LOV WithDisplay (Unreleased)
+
+    [Fact]
+    public void Readme_LovWithDisplay_Sample_Should_Build()
+    {
+        // Mirrors README.md "Unreleased > LovBuilder.WithDisplay ... removed".
+        // The sample's whole point is that these two lines COMPILE without a cast, so the
+        // value of this test is the compile, not the assertion — which is exactly the drift
+        // this class exists to catch (#180: the docs showed a form that did not compile).
+        var formConfig = FormBuilder<LovSampleModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .AsLov<LovSampleModel, int, LovSampleCustomer>(lov => lov
+                    .WithDataSource(() => [new LovSampleCustomer { Id = 1, Code = "ACM", Name = "Acme" }])
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => c.Name)))                  // simple property
+            .AddField(x => x.VendorId, field => field
+                .AsLov<LovSampleModel, int, LovSampleCustomer>(lov => lov
+                    .WithDataSource(() => [new LovSampleCustomer { Id = 2, Code = "GLB", Name = "Globex" }])
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => $"{c.Code} - {c.Name}")))  // complex formatting
+            .Build();
+
+        formConfig.Fields.Count.ShouldBe(2);
+    }
+
+    private class LovSampleModel
+    {
+        public int CustomerId { get; set; }
+        public int VendorId { get; set; }
+    }
+
+    private class LovSampleCustomer
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+
+    #endregion
+
     #region README - Security Features
 
     [Fact]

--- a/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
+++ b/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
@@ -26,10 +26,10 @@ public class LovBuilderDisplayTests
                     .WithDisplay(c => c.Name)))
             .Build();
 
-        // Assert
+        // Assert - both rows, so a selector wired to the wrong item cannot pass
         var lovConfig = GetLovConfiguration(config);
-        lovConfig.DisplaySelector.ShouldNotBeNull();
         lovConfig.DisplaySelector(Customers[0]).ShouldBe("Acme");
+        lovConfig.DisplaySelector(Customers[1]).ShouldBe("Globex");
     }
 
     [Fact]
@@ -49,6 +49,24 @@ public class LovBuilderDisplayTests
         // Assert
         var lovConfig = GetLovConfiguration(config);
         lovConfig.DisplaySelector(Customers[0]).ShouldBe("ACM - Acme");
+        lovConfig.DisplaySelector(Customers[1]).ShouldBe("GLB - Globex");
+    }
+
+    [Fact]
+    public void WithDisplay_Should_Reject_Null()
+    {
+        // Arrange - DisplaySelector is non-nullable and ships a safe default; letting null
+        // through would replace it and only surface as a NullReferenceException at render time.
+        var builder = FormBuilder<OrderModel>.Create();
+        Func<CustomerDto, string> displayFunc = null!;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => builder
+            .AddField(x => x.CustomerId, field => field
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(c => c.Id)
+                    .WithDisplay(displayFunc))));
     }
 
     [Fact]
@@ -79,11 +97,16 @@ public class LovBuilderDisplayTests
         new() { Id = 2, Code = "GLB", Name = "Globex" }
     ];
 
-    private static LovConfiguration<CustomerDto, int> GetLovConfiguration(
+    /// <summary>
+    /// Casts to the ILovConfiguration interface the renderer actually consumes
+    /// (MudBlazorLovFieldComponent reads the attribute as ILovConfiguration), not the concrete
+    /// type — so swapping the stored implementation would not turn these into InvalidCastException.
+    /// </summary>
+    private static ILovConfiguration<CustomerDto, int> GetLovConfiguration(
         IFormConfiguration<OrderModel> config)
     {
         var field = config.Fields.Single(f => f.FieldName == nameof(OrderModel.CustomerId));
-        return (LovConfiguration<CustomerDto, int>)field.AdditionalAttributes["LovConfiguration"];
+        return (ILovConfiguration<CustomerDto, int>)field.AdditionalAttributes["LovConfiguration"];
     }
 
     private class OrderModel

--- a/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
+++ b/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
@@ -89,6 +89,64 @@ public class LovBuilderDisplayTests
         lovConfig.DisplaySelector(Customers[0]).ShouldBe("Acme (ACM)");
     }
 
+    [Fact]
+    public void WithKey_Should_Accept_A_Bare_Lambda()
+    {
+        // Arrange & Act - WithKey carried the same redundant-Expression shape; it now has a Func
+        // overload with resolution priority, so a lambda binds without compiling an expression tree
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => c.Name)))
+            .Build();
+
+        // Assert
+        var lovConfig = GetLovConfiguration(config);
+        lovConfig.ValueSelector(Customers[0]).ShouldBe(1);
+        lovConfig.ValueSelector(Customers[1]).ShouldBe(2);
+    }
+
+    [Fact]
+    public void WithKey_Should_Reject_Null()
+    {
+        var builder = FormBuilder<OrderModel>.Create();
+        Func<CustomerDto, int> keySelector = null!;
+
+        Should.Throw<ArgumentNullException>(() => builder
+            .AddField(x => x.CustomerId, field => field
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(keySelector)
+                    .WithDisplay(c => c.Name))));
+    }
+
+    [Fact]
+    public void Obsolete_Expression_Overloads_Should_Still_Work()
+    {
+        // The Expression overloads are deprecated, not gone — existing callers must keep
+        // working until v4.0.0. This is the back-compat guard for that promise.
+        Expression<Func<CustomerDto, string>> display = c => c.Name;
+        Expression<Func<CustomerDto, int>> key = c => c.Id;
+
+#pragma warning disable CS0618 // deliberately exercising the deprecated overloads
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(key)
+                    .WithDisplay(display)))
+            .Build();
+#pragma warning restore CS0618
+
+        var lovConfig = GetLovConfiguration(config);
+        lovConfig.DisplaySelector(Customers[0]).ShouldBe("Acme");
+        lovConfig.ValueSelector(Customers[0]).ShouldBe(1);
+    }
+
     private static string FormatCustomer(CustomerDto customer) => $"{customer.Name} ({customer.Code})";
 
     private static readonly CustomerDto[] Customers =

--- a/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
+++ b/FormCraft.UnitTests/Forms/Lov/LovBuilderDisplayTests.cs
@@ -1,0 +1,100 @@
+namespace FormCraft.UnitTests.Forms.Lov;
+
+/// <summary>
+/// Tests for <see cref="LovBuilder{TModel, TValue, TItem}"/>.WithDisplay (#180).
+/// <para>
+/// WithDisplay used to declare both an <c>Expression&lt;Func&lt;TItem, string&gt;&gt;</c> and a
+/// <c>Func&lt;TItem, string&gt;</c> overload. They did the same thing — the Expression one only
+/// called <c>.Compile()</c> before assigning to the same <c>Func</c> field — but a lambda converts
+/// to both, so the natural call failed with CS0121. These tests call it the natural way, with no
+/// cast, which is exactly what would not compile before the redundant overload was removed.
+/// </para>
+/// </summary>
+public class LovBuilderDisplayTests
+{
+    [Fact]
+    public void WithDisplay_Should_Accept_A_Bare_Lambda()
+    {
+        // Arrange & Act - no cast: this is the form the XML docs and demo Code Example tab show
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .WithLabel("Customer")
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => c.Name)))
+            .Build();
+
+        // Assert
+        var lovConfig = GetLovConfiguration(config);
+        lovConfig.DisplaySelector.ShouldNotBeNull();
+        lovConfig.DisplaySelector(Customers[0]).ShouldBe("Acme");
+    }
+
+    [Fact]
+    public void WithDisplay_Should_Accept_A_Complex_Formatting_Lambda()
+    {
+        // Arrange & Act - the "complex display formatting" case the XML docs advertise
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .WithLabel("Customer")
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => $"{c.Code} - {c.Name}")))
+            .Build();
+
+        // Assert
+        var lovConfig = GetLovConfiguration(config);
+        lovConfig.DisplaySelector(Customers[0]).ShouldBe("ACM - Acme");
+    }
+
+    [Fact]
+    public void WithDisplay_Should_Accept_A_Method_Group()
+    {
+        // Arrange & Act - a method group has no natural conversion to an expression tree, so this
+        // one compiled even before the fix; it guards against the survivor being the wrong overload
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.CustomerId, field => field
+                .WithLabel("Customer")
+                .AsLov<OrderModel, int, CustomerDto>(lov => lov
+                    .WithDataSource(() => Customers)
+                    .WithKey(c => c.Id)
+                    .WithDisplay(FormatCustomer)))
+            .Build();
+
+        // Assert
+        var lovConfig = GetLovConfiguration(config);
+        lovConfig.DisplaySelector(Customers[0]).ShouldBe("Acme (ACM)");
+    }
+
+    private static string FormatCustomer(CustomerDto customer) => $"{customer.Name} ({customer.Code})";
+
+    private static readonly CustomerDto[] Customers =
+    [
+        new() { Id = 1, Code = "ACM", Name = "Acme" },
+        new() { Id = 2, Code = "GLB", Name = "Globex" }
+    ];
+
+    private static LovConfiguration<CustomerDto, int> GetLovConfiguration(
+        IFormConfiguration<OrderModel> config)
+    {
+        var field = config.Fields.Single(f => f.FieldName == nameof(OrderModel.CustomerId));
+        return (LovConfiguration<CustomerDto, int>)field.AdditionalAttributes["LovConfiguration"];
+    }
+
+    private class OrderModel
+    {
+        public int CustomerId { get; set; }
+    }
+
+    private class CustomerDto
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft/Compatibility/OverloadResolutionPriorityAttribute.cs
+++ b/FormCraft/Compatibility/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,28 @@
+#if !NET9_0_OR_GREATER
+
+// The compiler recognizes this attribute by its fully-qualified name, so declaring it in-source
+// enables [OverloadResolutionPriority] on target frameworks whose BCL predates .NET 9 — the same
+// pattern the BCL documents for IsExternalInit. FormCraft multi-targets net8.0, and without this
+// the net8.0 leg would not compile the priority annotations in LovBuilder.
+//
+// Delete this file when net8.0 is dropped from <TargetFrameworks>.
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Specifies the priority of a member in overload resolution. When unspecified, the default
+/// priority is 0.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property,
+    AllowMultiple = false,
+    Inherited = false)]
+internal sealed class OverloadResolutionPriorityAttribute(int priority) : Attribute
+{
+    /// <summary>
+    /// Gets the priority of the member. Higher values are preferred during overload resolution.
+    /// </summary>
+    public int Priority => priority;
+}
+
+#endif

--- a/FormCraft/Forms/Lov/Builders/LovBuilder.cs
+++ b/FormCraft/Forms/Lov/Builders/LovBuilder.cs
@@ -103,22 +103,24 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
     }
 
     /// <summary>
-    /// Configures the function to generate display text for selected items.
+    /// Configures the function that generates the display text for selected items.
+    /// A simple property selector and complex formatting are both expressed the same way.
     /// </summary>
-    /// <param name="displayExpression">Expression to select the display property.</param>
+    /// <remarks>
+    /// This is deliberately the only overload. It previously had an
+    /// <c>Expression&lt;Func&lt;TItem, string&gt;&gt;</c> twin that merely called
+    /// <c>.Compile()</c> before assigning the very same delegate, which made every bare lambda
+    /// ambiguous (<c>CS0121</c>) — including the ones in this type's own examples. Nothing here
+    /// inspects the expression tree, so do not reintroduce it.
+    /// </remarks>
+    /// <param name="displayFunc">Function that returns the display text for an item.</param>
     /// <returns>The LovBuilder instance for method chaining.</returns>
-    public LovBuilder<TModel, TValue, TItem> WithDisplay(Expression<Func<TItem, string>> displayExpression)
-    {
-        _configuration.DisplaySelector = displayExpression.Compile();
-        return this;
-    }
-
-    /// <summary>
-    /// Configures the display text using a custom function.
-    /// Use this for complex display formatting.
-    /// </summary>
-    /// <param name="displayFunc">Function to generate display text.</param>
-    /// <returns>The LovBuilder instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// .WithDisplay(c => c.Name)                      // simple property
+    /// .WithDisplay(c => $"{c.Code} - {c.Name}")      // complex formatting
+    /// </code>
+    /// </example>
     public LovBuilder<TModel, TValue, TItem> WithDisplay(Func<TItem, string> displayFunc)
     {
         _configuration.DisplaySelector = displayFunc;

--- a/FormCraft/Forms/Lov/Builders/LovBuilder.cs
+++ b/FormCraft/Forms/Lov/Builders/LovBuilder.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 namespace FormCraft;
 
@@ -91,23 +92,54 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
 
     #region Value and Display Configuration
 
+    // Maintainer note (#180): WithKey carried the same redundancy as WithDisplay — it compiled
+    // the expression and never read the tree, paying an Expression.Compile() (a DynamicMethod
+    // emit, and the trimming-hostile path under Blazor WebAssembly) on every form build for no
+    // benefit. Same remedy: a Func overload that wins overload resolution, with the Expression
+    // form kept [Obsolete] until v4.0.0 so no consumer has to change a line today.
+
     /// <summary>
-    /// Configures the function to extract the value from a selected item.
+    /// Configures the function that extracts the value from a selected item.
     /// </summary>
-    /// <param name="keyExpression">Expression to select the key/value property.</param>
+    /// <param name="keySelector">Function that returns the key/value for an item.</param>
     /// <returns>The LovBuilder instance for method chaining.</returns>
-    public LovBuilder<TModel, TValue, TItem> WithKey(Expression<Func<TItem, TValue>> keyExpression)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keySelector"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// .WithKey(c => c.Id)
+    /// </code>
+    /// </example>
+    [OverloadResolutionPriority(1)]
+    public LovBuilder<TModel, TValue, TItem> WithKey(Func<TItem, TValue> keySelector)
     {
-        _configuration.ValueSelector = keyExpression.Compile();
+        ArgumentNullException.ThrowIfNull(keySelector);
+
+        _configuration.ValueSelector = keySelector;
         return this;
     }
 
-    // Maintainer note (#180): do NOT add an Expression<Func<TItem, string>> overload here.
-    // One existed and only called .Compile() before assigning the very same delegate this
-    // overload takes directly, so it added no capability while making an expression-bodied
-    // lambda ambiguous (CS0121) — including the calls in this type's own examples. Nothing
-    // reads the expression tree. The bare-lambda tests in LovBuilderDisplayTests fail to
-    // compile if it comes back, so the guard is mechanical, not just this comment.
+    /// <summary>
+    /// Configures the value selector using an expression. Obsolete: the expression is compiled
+    /// immediately and its tree is never read, so this adds nothing over passing a lambda.
+    /// </summary>
+    /// <param name="keyExpression">Expression to select the key/value property.</param>
+    /// <returns>The LovBuilder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyExpression"/> is null.</exception>
+    [Obsolete("Pass the lambda directly — .WithKey(c => c.Id). This overload compiles the " +
+              "expression and discards the tree, and is removed in v4.0.0.")]
+    public LovBuilder<TModel, TValue, TItem> WithKey(Expression<Func<TItem, TValue>> keyExpression)
+    {
+        ArgumentNullException.ThrowIfNull(keyExpression);
+
+        return WithKey(keyExpression.Compile());
+    }
+
+    // Maintainer note (#180): the Expression overload below is redundant — it only calls
+    // .Compile() and assigns the very same delegate the Func overload takes directly, and
+    // nothing ever reads the expression tree. Having both made an expression-bodied lambda
+    // ambiguous (CS0121), including the calls in this type's own examples.
+    // [OverloadResolutionPriority] resolves that in favour of the Func overload without
+    // removing public API; the Expression form is [Obsolete] and goes away in v4.0.0.
 
     /// <summary>
     /// Configures the function that generates the display text for selected items.
@@ -122,6 +154,7 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
     /// .WithDisplay(c => $"{c.Code} - {c.Name}")      // complex formatting
     /// </code>
     /// </example>
+    [OverloadResolutionPriority(1)]
     public LovBuilder<TModel, TValue, TItem> WithDisplay(Func<TItem, string> displayFunc)
     {
         // Guarded because DisplaySelector is non-nullable and ships a safe default; assigning
@@ -131,6 +164,22 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
 
         _configuration.DisplaySelector = displayFunc;
         return this;
+    }
+
+    /// <summary>
+    /// Configures the display text using an expression. Obsolete: the expression is compiled
+    /// immediately and its tree is never read, so this adds nothing over passing a lambda.
+    /// </summary>
+    /// <param name="displayExpression">Expression to select the display property.</param>
+    /// <returns>The LovBuilder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="displayExpression"/> is null.</exception>
+    [Obsolete("Pass the lambda directly — .WithDisplay(c => c.Name). This overload compiles the " +
+              "expression and discards the tree, and is removed in v4.0.0.")]
+    public LovBuilder<TModel, TValue, TItem> WithDisplay(Expression<Func<TItem, string>> displayExpression)
+    {
+        ArgumentNullException.ThrowIfNull(displayExpression);
+
+        return WithDisplay(displayExpression.Compile());
     }
 
     #endregion

--- a/FormCraft/Forms/Lov/Builders/LovBuilder.cs
+++ b/FormCraft/Forms/Lov/Builders/LovBuilder.cs
@@ -102,19 +102,20 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
         return this;
     }
 
+    // Maintainer note (#180): do NOT add an Expression<Func<TItem, string>> overload here.
+    // One existed and only called .Compile() before assigning the very same delegate this
+    // overload takes directly, so it added no capability while making an expression-bodied
+    // lambda ambiguous (CS0121) — including the calls in this type's own examples. Nothing
+    // reads the expression tree. The bare-lambda tests in LovBuilderDisplayTests fail to
+    // compile if it comes back, so the guard is mechanical, not just this comment.
+
     /// <summary>
     /// Configures the function that generates the display text for selected items.
     /// A simple property selector and complex formatting are both expressed the same way.
     /// </summary>
-    /// <remarks>
-    /// This is deliberately the only overload. It previously had an
-    /// <c>Expression&lt;Func&lt;TItem, string&gt;&gt;</c> twin that merely called
-    /// <c>.Compile()</c> before assigning the very same delegate, which made every bare lambda
-    /// ambiguous (<c>CS0121</c>) — including the ones in this type's own examples. Nothing here
-    /// inspects the expression tree, so do not reintroduce it.
-    /// </remarks>
     /// <param name="displayFunc">Function that returns the display text for an item.</param>
     /// <returns>The LovBuilder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="displayFunc"/> is null.</exception>
     /// <example>
     /// <code>
     /// .WithDisplay(c => c.Name)                      // simple property
@@ -123,6 +124,11 @@ public class LovBuilder<TModel, TValue, TItem> where TModel : new()
     /// </example>
     public LovBuilder<TModel, TValue, TItem> WithDisplay(Func<TItem, string> displayFunc)
     {
+        // Guarded because DisplaySelector is non-nullable and ships a safe default; assigning
+        // null here would replace it and surface as a NullReferenceException during render,
+        // far from this call site.
+        ArgumentNullException.ThrowIfNull(displayFunc);
+
         _configuration.DisplaySelector = displayFunc;
         return this;
     }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 - **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
   - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.
+- **⚠️ Breaking — `LovBuilder.WithDisplay(Expression<Func<TItem, string>>)` removed.** It was redundant: it only called `.Compile()` and assigned the same `Func<TItem, string>` the remaining overload takes directly. Having both made every bare lambda ambiguous (`CS0121`) — so `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile. It does now (#180)
+
+  ```csharp
+  .WithDisplay(c => c.Name)                   // simple property
+  .WithDisplay(c => $"{c.Code} - {c.Name}")   // complex formatting
+  ```
+
+  **Migration:** delete any `(Expression<Func<T, string>>)` or `(Func<T, string>)` cast you added to work around the ambiguity and pass the lambda directly. If you genuinely hold an `Expression<Func<T, string>>`, pass `expr.Compile()`.
 
 ## 🎉 What's New in v3.1.0
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 - **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
   - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.
-- **⚠️ Breaking (target: v4.0.0) — `LovBuilder.WithDisplay(Expression<Func<TItem, string>>)` removed.** It was redundant: it only called `.Compile()` and assigned the same `Func<TItem, string>` the remaining overload takes directly. Having both made an *expression-bodied* lambda ambiguous (`CS0121`) — so `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile. It does now (#180)
+- **`LovBuilder.WithDisplay` / `WithKey` accept a plain lambda again — no cast, no breaking change.** `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile: each method had an `Expression<Func<…>>` overload alongside a `Func<…>` one, and an expression-bodied lambda converts to both (`CS0121`). The `Func` overloads now carry `[OverloadResolutionPriority(1)]`, so a lambda binds to them unambiguously (#180)
 
   ```csharp
+  .WithKey(c => c.Id)
   .WithDisplay(c => c.Name)                   // simple property
   .WithDisplay(c => $"{c.Code} - {c.Name}")   // complex formatting
   ```
 
-  **Who needs to migrate:** only callers passing an `Expression<Func<T, string>>` — a variable of that type, or an `(Expression<Func<T, string>>)` cast added to work around the ambiguity. Pass the lambda directly, or `expr.Compile()` if you genuinely hold an expression.
+  **Nothing to migrate today.** Existing code — including `Expression<Func<…>>` variables and any cast added to work around the ambiguity — keeps compiling and behaving identically. Statement-bodied lambdas (`c => { return c.Name; }`) and method groups were never ambiguous and are untouched.
 
-  **Who does not:** statement-bodied lambdas (`c => { return c.Name; }`) and method groups were never ambiguous and are unaffected. A `(Func<T, string>)` cast still compiles unchanged — deleting it is optional tidy-up, not migration.
+  **Deprecation notice:** the `Expression<Func<…>>` overloads of `WithDisplay` and `WithKey` are now `[Obsolete]` and **will be removed in v4.0.0**. They only compiled the expression and discarded the tree, so they never did anything the lambda form does not — and under Blazor WebAssembly that `Expression.Compile()` is the trimming-hostile path. Pass a lambda, or `expr.Compile()` if you genuinely hold an expression.
 
 ## 🎉 What's New in v3.1.0
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,16 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 - **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
   - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.
-- **⚠️ Breaking — `LovBuilder.WithDisplay(Expression<Func<TItem, string>>)` removed.** It was redundant: it only called `.Compile()` and assigned the same `Func<TItem, string>` the remaining overload takes directly. Having both made every bare lambda ambiguous (`CS0121`) — so `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile. It does now (#180)
+- **⚠️ Breaking (target: v4.0.0) — `LovBuilder.WithDisplay(Expression<Func<TItem, string>>)` removed.** It was redundant: it only called `.Compile()` and assigned the same `Func<TItem, string>` the remaining overload takes directly. Having both made an *expression-bodied* lambda ambiguous (`CS0121`) — so `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile. It does now (#180)
 
   ```csharp
   .WithDisplay(c => c.Name)                   // simple property
   .WithDisplay(c => $"{c.Code} - {c.Name}")   // complex formatting
   ```
 
-  **Migration:** delete any `(Expression<Func<T, string>>)` or `(Func<T, string>)` cast you added to work around the ambiguity and pass the lambda directly. If you genuinely hold an `Expression<Func<T, string>>`, pass `expr.Compile()`.
+  **Who needs to migrate:** only callers passing an `Expression<Func<T, string>>` — a variable of that type, or an `(Expression<Func<T, string>>)` cast added to work around the ambiguity. Pass the lambda directly, or `expr.Compile()` if you genuinely hold an expression.
+
+  **Who does not:** statement-bodied lambdas (`c => { return c.Name; }`) and method groups were never ambiguous and are unaffected. A `(Func<T, string>)` cast still compiles unchanged — deleting it is optional tidy-up, not migration.
 
 ## 🎉 What's New in v3.1.0
 


### PR DESCRIPTION
Implements #180.

Closes #180.

`LovBuilder.WithDisplay` and `WithKey` each declared an `Expression<Func<…>>` overload alongside a `Func<…>` one that did the identical thing — the `Expression` form only called `.Compile()` and assigned the very same delegate, and nothing ever read the tree. An expression-bodied lambda converts to both, so the natural call failed:

```
error CS0121: The call is ambiguous between 'WithDisplay(Expression<Func<TItem, string>>)'
and 'WithDisplay(Func<TItem, string>)'
```

That is the exact form our own XML-doc examples and the demo's **Code Example tab** show, so the documented call did not compile. Seven call sites in this repo carried a workaround cast to get around it.

The `Func` overloads now carry `[OverloadResolutionPriority(1)]`, so a lambda binds to them unambiguously:

```csharp
.WithKey(c => c.Id)
.WithDisplay(c => c.Name)                   // simple property
.WithDisplay(c => $"{c.Code} - {c.Name}")   // complex formatting
```

## Not a breaking change

> [!NOTE]
> An earlier revision of this PR **removed** the `Expression` overloads, per the approach the issue recommended. Review pointed out that C# 13's `[OverloadResolutionPriority]` fixes the ambiguity with no API removal at all, and that was the better trade on a published package. The removal was reverted.

Existing code keeps compiling and behaving identically — including `Expression<Func<…>>` variables and any cast added to work around the ambiguity. Statement-bodied lambdas (`c => { return c.Name; }`) and method groups were never ambiguous and are untouched.

The `Expression` overloads are now `[Obsolete]`, delegate to the `Func` form, and are scheduled for removal in **v4.0.0**. `Obsolete_Expression_Overloads_Should_Still_Work` is the back-compat guard for that promise.

## `WithKey` is included

`WithKey` carried the identical redundancy — `Expression<Func<TItem, TValue>>`, `.Compile()`, tree discarded — costing an `Expression.Compile()` (a `DynamicMethod` emit, and the trimming-hostile path under Blazor WebAssembly) on every form build for no benefit. It gets the same treatment in this release, so the two sibling methods stay symmetric and only one deprecation cycle is needed.

## Notes

- **`net8.0` support:** `OverloadResolutionPriorityAttribute` ships in .NET 9+, so `FormCraft/Compatibility/OverloadResolutionPriorityAttribute.cs` declares it in-source for the `net8.0` leg — the pattern the BCL documents for `IsExternalInit`. Delete that file when `net8.0` is dropped.
- **Null guards** added to both `Func` overloads: `DisplaySelector`/`ValueSelector` are non-nullable with safe defaults, so assigning null would have replaced the default and surfaced as a `NullReferenceException` during render, far from the call site.
- **The documented samples are now verified.** `DocumentationSamplesTests` exists so "the documentation cannot silently drift away from the real public API again" — which is precisely the bug this PR fixes — so the new README sample is registered there.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors, on both `net8.0` and `net10.0`. The zero is load-bearing: `TreatWarningsAsErrors=true` means that if a bare lambda had bound to the `[Obsolete]` `Expression` overload, `CS0618` would have failed the build. It binds to the `Func` overload.
- `dotnet test -c Release` — **933 passing** (185 MudBlazor + 748 core), 1 pre-existing skip, 0 failures.

## Follow-ups

- **The `[OverloadResolutionPriority]` pattern may apply elsewhere.** This PR only audited `LovBuilder`, where `WithDataSource` (disambiguated by arity) and `AddColumn` (by parameter order) are fine. Other builders in the codebase were not surveyed for the same `Expression`/`Func` twin shape.
