### PR TITLE
feat(mudblazor): warn when ShrinkLabel=false cannot be honoured (#181)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticCollectorTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticCollectorTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Direct tests for <see cref="ShrinkLabelDiagnosticCollector"/> (#181). The aggregation logic
+/// has failure modes a component test cannot reach cheaply — fields that first render on a
+/// later pass, and a logging stack that throws — so it is exercised here in isolation.
+/// </summary>
+public class ShrinkLabelDiagnosticCollectorTests
+{
+    [Fact]
+    public void Should_Report_Fields_That_Appear_After_The_First_Flush()
+    {
+        // Arrange - a field revealed later by a visibility condition, an expanded group, or a
+        // newly added collection row reports on a subsequent pass. A one-shot latch would drop
+        // it silently, which is worse than the duplicate warning it avoids.
+        var logs = new CapturingLoggerProvider();
+        var services = BuildServices(logs);
+        var collector = new ShrinkLabelDiagnosticCollector();
+
+        collector.Report("Alpha", "Alpha", "a Placeholder");
+        collector.Flush(services);
+
+        // Act - Beta becomes visible on a later render
+        collector.Report("Beta", "Beta", "a Placeholder");
+        collector.Flush(services);
+
+        // Assert
+        logs.Warnings.Count.ShouldBe(2);
+        logs.Warnings[0].ShouldContain("Alpha");
+        logs.Warnings[1].ShouldContain("Beta");
+        logs.Warnings[1].ShouldNotContain("Alpha");
+    }
+
+    [Fact]
+    public void Should_Not_Repeat_A_Field_On_Later_Flushes()
+    {
+        // Arrange - re-renders are constant while a user types; the same conflict must not
+        // re-log each time.
+        var logs = new CapturingLoggerProvider();
+        var services = BuildServices(logs);
+        var collector = new ShrinkLabelDiagnosticCollector();
+        collector.Report("Alpha", "Alpha", "a Placeholder");
+
+        // Act
+        collector.Flush(services);
+        collector.Flush(services);
+        collector.Report("Alpha", "Alpha", "a Placeholder");
+        collector.Flush(services);
+
+        // Assert
+        logs.Warnings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_Resolving_The_Logger_Throws()
+    {
+        // Arrange - the diagnostic runs inside OnAfterRender, so an exception here would take
+        // the form down. A logging stack that throws must be swallowed.
+        var collector = new ShrinkLabelDiagnosticCollector();
+        collector.Report("Alpha", "Alpha", "a Placeholder");
+
+        // Act & Assert
+        Should.NotThrow(() => collector.Flush(new ThrowingServiceProvider()));
+    }
+
+    [Fact]
+    public void Should_Not_Throw_When_No_Services_Are_Available()
+    {
+        var collector = new ShrinkLabelDiagnosticCollector();
+        collector.Report("Alpha", "Alpha", "a Placeholder");
+
+        Should.NotThrow(() => collector.Flush(null));
+    }
+
+    private static IServiceProvider BuildServices(ILoggerProvider provider)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddProvider(provider));
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class ThrowingServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            throw new InvalidOperationException("Cannot access a disposed scope.");
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> _warnings = [];
+
+        public IReadOnlyList<string> Warnings => _warnings;
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_warnings);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger(List<string> warnings) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Warning)
+                {
+                    warnings.Add(formatter(state, exception));
+                }
+            }
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -261,6 +261,55 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         _logs.Warnings.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Should_Not_Warn_About_An_Adornment_On_A_Collection_Item_Field()
+    {
+        // Arrange - the collection render path never emits an Adornment attribute, so the
+        // adornment is dropped and ShrinkLabel=false IS honoured there. Warning would push the
+        // developer to remove a setting that was working.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field => field
+                        .WithLabel("Product")
+                        .WithAdornment(Icons.Material.Filled.Search, Adornment.Start)
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Count_Two_Fields_That_Share_A_Label()
+    {
+        // Arrange - grouped forms routinely repeat a label ("Name" under Billing and Shipping).
+        // Keying the collector on the label would merge them and report "1 field(s)", so the
+        // developer fixes one and believes they are done.
+        var config = FormBuilder<WideModel>
+            .Create()
+            .AddField(x => x.A, f => f.WithLabel("Name").WithPlaceholder("a").WithShrinkLabel(false))
+            .AddField(x => x.B, f => f.WithLabel("Name").WithPlaceholder("b").WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<WideModel>>(parameters => parameters
+            .Add(p => p.Model, new WideModel())
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("2 field(s)");
+    }
+
     private class OrderModel
     {
         public List<OrderItem> Items { get; set; } = new();

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -170,6 +170,68 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         _logs.Warnings.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Should_Warn_For_A_Collection_Item_Field()
+    {
+        // Arrange - collection item fields render through CollectionFieldComponent's imperative
+        // RenderTreeBuilder path, which resolves presentation attributes itself and so needs the
+        // diagnostic wired separately from the component path.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field => field
+                        .WithLabel("Product")
+                        .WithPlaceholder("e.g. Widget")
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Product");
+        warnings[0].ShouldContain("Placeholder");
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_A_Collection_Item_Field_Without_A_Conflict()
+    {
+        // Arrange
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field => field
+                        .WithLabel("Product")
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+
     private IRenderedComponent<FormCraftComponent<TestModel>> RenderFormWithPopover(
         IFormConfiguration<TestModel> config)
     {

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests the diagnostic that warns when <c>ShrinkLabel=false</c> cannot be honoured (#181).
+/// <para>
+/// MudBlazor ORs ShrinkLabel with has-value / has-placeholder / has-start-adornment before
+/// emitting the "mud-shrink" class, so the setting is silently inert on a field carrying a
+/// placeholder or a start adornment. These tests assert that FormCraft says so, and — just as
+/// important — that it stays quiet in the cases where the setting works or where the override
+/// is correct behaviour.
+/// </para>
+/// </summary>
+public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
+{
+    private readonly CapturingLoggerProvider _logs = new();
+
+    public ShrinkLabelDiagnosticsTests()
+    {
+        Services.AddLogging(builder => builder.AddProvider(_logs));
+    }
+
+    [Fact]
+    public void Should_Warn_When_ShrinkLabel_False_Meets_A_Placeholder()
+    {
+        // Arrange
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithPlaceholder("user@example.com")
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert - names the field, so a form of many fields points at the right one
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Email");
+        warnings[0].ShouldContain("Placeholder");
+    }
+
+    [Fact]
+    public void Should_Not_Warn_When_ShrinkLabel_False_Is_Honoured()
+    {
+        // Arrange - no placeholder, so the setting genuinely takes effect
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_Default_Configuration()
+    {
+        // Arrange - ShrinkLabel unset; there is no conflict to report
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithPlaceholder("user@example.com"))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    private IRenderedComponent<FormCraftComponent<TestModel>> RenderForm(
+        IFormConfiguration<TestModel> config, bool? defaultShrinkLabel = null)
+    {
+        return Render<FormCraftComponent<TestModel>>(parameters =>
+        {
+            parameters.Add(p => p.Model, new TestModel());
+            parameters.Add(p => p.Configuration, config);
+            if (defaultShrinkLabel is { } shrink)
+            {
+                parameters.Add(p => p.DefaultShrinkLabel, shrink);
+            }
+        });
+    }
+
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Minimal ILoggerProvider that records warning-level messages so tests can assert on
+    /// what a developer would actually see in their console.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> _warnings = [];
+
+        public IReadOnlyList<string> Warnings
+        {
+            get
+            {
+                lock (_warnings)
+                {
+                    return _warnings.ToList();
+                }
+            }
+        }
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+        public void Dispose()
+        {
+        }
+
+        private void Record(string message)
+        {
+            lock (_warnings)
+            {
+                _warnings.Add(message);
+            }
+        }
+
+        private sealed class CapturingLogger(CapturingLoggerProvider provider) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Warning)
+                {
+                    provider.Record(formatter(state, exception));
+                }
+            }
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -171,6 +171,45 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
     }
 
     [Fact]
+    public void Should_Aggregate_Into_One_Warning_For_A_Whole_Form()
+    {
+        // Arrange - DefaultShrinkLabel="false" on a form of placeholder-bearing fields is the
+        // realistic way to hit this at scale. One warning listing the fields is actionable;
+        // five identical ones are noise that trains developers to ignore the channel.
+        var config = FormBuilder<WideModel>
+            .Create()
+            .AddField(x => x.A, f => f.WithLabel("Alpha").WithPlaceholder("a"))
+            .AddField(x => x.B, f => f.WithLabel("Bravo").WithPlaceholder("b"))
+            .AddField(x => x.C, f => f.WithLabel("Charlie").WithPlaceholder("c"))
+            .AddField(x => x.D, f => f.WithLabel("Delta").WithPlaceholder("d"))
+            .AddField(x => x.E, f => f.WithLabel("Echo").WithPlaceholder("e"))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<WideModel>>(parameters => parameters
+            .Add(p => p.Model, new WideModel())
+            .Add(p => p.Configuration, config)
+            .Add(p => p.DefaultShrinkLabel, false));
+
+        // Assert - exactly one warning, naming every affected field
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        foreach (var field in new[] { "Alpha", "Bravo", "Charlie", "Delta", "Echo" })
+        {
+            warnings[0].ShouldContain(field);
+        }
+    }
+
+    private class WideModel
+    {
+        public string A { get; set; } = string.Empty;
+        public string B { get; set; } = string.Empty;
+        public string C { get; set; } = string.Empty;
+        public string D { get; set; } = string.Empty;
+        public string E { get; set; } = string.Empty;
+    }
+
+    [Fact]
     public void Should_Warn_For_A_Collection_Item_Field()
     {
         // Arrange - collection item fields render through CollectionFieldComponent's imperative

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -79,6 +79,119 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         _logs.Warnings.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Should_Warn_When_ShrinkLabel_False_Meets_A_Start_Adornment()
+    {
+        // Arrange - a start adornment occupies the same space a floating label needs
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithAdornment(Icons.Material.Filled.Email, Adornment.Start)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Email");
+        warnings[0].ShouldContain("Adornment");
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_An_End_Adornment()
+    {
+        // Arrange - only a START adornment competes with the label; End is harmless
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithAdornment(Icons.Material.Filled.Email, Adornment.End)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_When_The_Field_Merely_Has_A_Value()
+    {
+        // Arrange - a populated field MUST shrink its label or the two overlap. That override is
+        // correct behaviour, not a surprise, so warning about it would be noise on every filled form.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Email")
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, new TestModel { Name = "philippe@example.com" })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_A_Lov_Field()
+    {
+        // Arrange - the LOV input always supplies its own "Click to select..." placeholder, so its
+        // label can never float. Warning would fire on every LOV field of any form that sets
+        // DefaultShrinkLabel="false" — noise the developer cannot act on.
+        //
+        // An EXPLICIT placeholder is set here on purpose: without one the diagnostic is silent
+        // anyway, because it reads the configured placeholder and LOV's is a rendering fallback
+        // the configuration never sees. Only this form of the test actually exercises the opt-out.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.CityId, f => f
+                .WithLabel("City")
+                .WithPlaceholder("Pick a city")
+                .AsLov<TestModel, int, CityDto>(lov => lov
+                    .WithDataSource(() => new[] { new CityDto { Id = 1, Name = "Paris" } })
+                    .WithKey(c => c.Id)
+                    .WithDisplay(c => c.Name))
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderFormWithPopover(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    private IRenderedComponent<FormCraftComponent<TestModel>> RenderFormWithPopover(
+        IFormConfiguration<TestModel> config)
+    {
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<FormCraftComponent<TestModel>>(1);
+            builder.AddComponentParameter(2, "Model", new TestModel());
+            builder.AddComponentParameter(3, "Configuration", config);
+            builder.CloseComponent();
+        });
+
+        return cut.FindComponent<FormCraftComponent<TestModel>>();
+    }
+
+    private class CityDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
     private IRenderedComponent<FormCraftComponent<TestModel>> RenderForm(
         IFormConfiguration<TestModel> config, bool? defaultShrinkLabel = null)
     {
@@ -96,6 +209,7 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
     private class TestModel
     {
         public string Name { get; set; } = string.Empty;
+        public int CityId { get; set; }
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Diagnostics/ShrinkLabelDiagnosticCollector.cs
+++ b/FormCraft.ForMudBlazor/Diagnostics/ShrinkLabelDiagnosticCollector.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace FormCraft.ForMudBlazor;
@@ -15,52 +16,77 @@ namespace FormCraft.ForMudBlazor;
 /// </remarks>
 public sealed class ShrinkLabelDiagnosticCollector
 {
-    private readonly Dictionary<string, string> _conflicts = [];
-    private bool _flushed;
+    private readonly Dictionary<string, (string Label, string Conflict)> _conflicts = [];
+    private readonly HashSet<string> _logged = [];
 
     /// <summary>
-    /// Records that <paramref name="field"/> asked for a floating label it will not get.
-    /// Repeated reports for the same field collapse into one — a collection of 50 rows must not
-    /// list its item field 50 times.
+    /// Records that a field asked for a floating label it will not get.
     /// </summary>
-    /// <param name="field">The field's label, else its name.</param>
+    /// <param name="fieldName">
+    /// The field's name — the identity key. Labels are NOT used as the key: two fields can
+    /// legitimately share one (a "Name" in a Billing group and another in Shipping), and keying
+    /// on the label would silently merge them and under-report the count.
+    /// </param>
+    /// <param name="label">Display name for the message; falls back to the field name.</param>
     /// <param name="conflict">The property that overrides the setting, e.g. "a Placeholder".</param>
-    public void Report(string field, string conflict) => _conflicts[field] = conflict;
+    public void Report(string fieldName, string? label, string conflict) =>
+        _conflicts[fieldName] = (string.IsNullOrWhiteSpace(label) ? fieldName : label, conflict);
 
     /// <summary>
-    /// Emits one warning naming every reported field, then stops reporting for this form.
+    /// Emits one warning naming every field reported since the last flush.
     /// </summary>
     /// <remarks>
-    /// Flushes at most once: the conflict is a configuration fact, so re-reporting it on every
-    /// re-render would flood the console as the user types.
+    /// Each field is reported at most once for the lifetime of the form, but the collector is
+    /// NOT one-shot: fields that first render later — revealed by a visibility condition, an
+    /// expanded group, or a newly added collection row — are picked up by a subsequent flush.
+    /// A one-shot latch would drop them silently, which is worse than the noise it avoids.
     /// </remarks>
-    /// <param name="loggerFactory">Logger factory; when null the diagnostic degrades silently.</param>
-    public void Flush(ILoggerFactory? loggerFactory)
+    /// <param name="services">
+    /// Provider used to resolve an optional <see cref="ILoggerFactory"/>. Resolution happens
+    /// inside this method's exception guard, so a logging stack that throws (or a disposed
+    /// scope on a torn-down circuit) cannot escape into the render loop.
+    /// </param>
+    public void Flush(IServiceProvider? services)
     {
-        if (_flushed || _conflicts.Count == 0)
+        if (_conflicts.Count == _logged.Count)
         {
             return;
         }
 
-        _flushed = true;
-
-        // A diagnostic must never break a render, so a logger that throws is swallowed.
+        // A diagnostic must never break a render, so anything thrown in here is swallowed —
+        // including the service resolution, which is the one call that can realistically fail.
         try
         {
-            var logger = loggerFactory?.CreateLogger(ShrinkLabelDiagnostic.Category);
+            var fresh = _conflicts.Where(c => !_logged.Contains(c.Key)).ToList();
+            if (fresh.Count == 0)
+            {
+                return;
+            }
+
+            var logger = services?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(ShrinkLabelDiagnostic.Category);
+
+            // Mark as logged either way: with no logger there is nothing to emit, and retrying
+            // on every render would just re-walk the same set forever.
+            foreach (var (key, _) in fresh)
+            {
+                _logged.Add(key);
+            }
+
             if (logger is null)
             {
                 return;
             }
 
-            var detail = string.Join(", ", _conflicts.Select(c => $"'{c.Key}' (has {c.Value})"));
+            var detail = string.Join(", ", fresh.Select(c => $"'{c.Value.Label}' (has {c.Value.Conflict})"));
 
             logger.LogWarning(
                 "ShrinkLabel=false will not take effect on {Count} field(s): {Fields}. MudBlazor " +
                 "pins the label whenever a field has a value, a placeholder or a start adornment, " +
                 "so the label stays put. Remove the conflicting property to get a floating label, " +
                 "or drop ShrinkLabel=false.",
-                _conflicts.Count,
+                fresh.Count,
                 detail);
         }
         catch

--- a/FormCraft.ForMudBlazor/Diagnostics/ShrinkLabelDiagnosticCollector.cs
+++ b/FormCraft.ForMudBlazor/Diagnostics/ShrinkLabelDiagnosticCollector.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor;
+
+/// <summary>
+/// Gathers per-field ShrinkLabel conflicts during a form's render pass so the form can emit a
+/// single warning naming every affected field (#181), instead of one warning per field.
+/// </summary>
+/// <remarks>
+/// Cascaded by <see cref="FormCraftComponent{TModel}"/> under
+/// <see cref="FormCraftCascadingValues.ShrinkLabelDiagnostics"/>. A field rendered outside a
+/// FormCraftComponent sees no collector and logs directly instead, so standalone usage still
+/// gets the diagnostic. Not thread-safe by design: Blazor renders a component tree on a single
+/// synchronisation context.
+/// </remarks>
+public sealed class ShrinkLabelDiagnosticCollector
+{
+    private readonly Dictionary<string, string> _conflicts = [];
+    private bool _flushed;
+
+    /// <summary>
+    /// Records that <paramref name="field"/> asked for a floating label it will not get.
+    /// Repeated reports for the same field collapse into one — a collection of 50 rows must not
+    /// list its item field 50 times.
+    /// </summary>
+    /// <param name="field">The field's label, else its name.</param>
+    /// <param name="conflict">The property that overrides the setting, e.g. "a Placeholder".</param>
+    public void Report(string field, string conflict) => _conflicts[field] = conflict;
+
+    /// <summary>
+    /// Emits one warning naming every reported field, then stops reporting for this form.
+    /// </summary>
+    /// <remarks>
+    /// Flushes at most once: the conflict is a configuration fact, so re-reporting it on every
+    /// re-render would flood the console as the user types.
+    /// </remarks>
+    /// <param name="loggerFactory">Logger factory; when null the diagnostic degrades silently.</param>
+    public void Flush(ILoggerFactory? loggerFactory)
+    {
+        if (_flushed || _conflicts.Count == 0)
+        {
+            return;
+        }
+
+        _flushed = true;
+
+        // A diagnostic must never break a render, so a logger that throws is swallowed.
+        try
+        {
+            var logger = loggerFactory?.CreateLogger(ShrinkLabelDiagnostic.Category);
+            if (logger is null)
+            {
+                return;
+            }
+
+            var detail = string.Join(", ", _conflicts.Select(c => $"'{c.Key}' (has {c.Value})"));
+
+            logger.LogWarning(
+                "ShrinkLabel=false will not take effect on {Count} field(s): {Fields}. MudBlazor " +
+                "pins the label whenever a field has a value, a placeholder or a start adornment, " +
+                "so the label stays put. Remove the conflicting property to get a floating label, " +
+                "or drop ShrinkLabel=false.",
+                _conflicts.Count,
+                detail);
+        }
+        catch
+        {
+            // Ignored: a failing diagnostic must not take the form down with it.
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
@@ -46,6 +48,19 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// </summary>
     [CascadingParameter(Name = FormCraftCascadingValues.DefaultShrinkLabel)]
     public bool? FormDefaultShrinkLabel { get; set; }
+
+    /// <summary>
+    /// Service provider used to resolve an optional <see cref="ILoggerFactory"/> for the
+    /// ShrinkLabel diagnostic (#181). Degrades silently when no logger is registered.
+    /// </summary>
+    [Inject]
+    private IServiceProvider? DiagnosticServices { get; set; }
+
+    /// <summary>
+    /// Item fields already reported, so the diagnostic fires once per field rather than once
+    /// per row — a collection of 50 items must not produce 50 identical warnings.
+    /// </summary>
+    private readonly HashSet<string> _warnedItemFields = [];
 
     /// <summary>
     /// Gets or sets the parent form's EditContext, cascaded from the surrounding EditForm.
@@ -275,7 +290,53 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);
         builder.AddAttribute(startIndex++, "Variant", GetItemFieldVariant(field));
         builder.AddAttribute(startIndex++, "Margin", Margin.Dense);
-        builder.AddAttribute(startIndex, "ShrinkLabel", GetItemFieldShrinkLabel(field));
+
+        var shrinkLabel = GetItemFieldShrinkLabel(field);
+        builder.AddAttribute(startIndex, "ShrinkLabel", shrinkLabel);
+
+        WarnIfShrinkLabelUnhonoured(field, shrinkLabel);
+    }
+
+    /// <summary>
+    /// Reports a ShrinkLabel conflict for an item field (#181), using the same rule as the
+    /// component render path — <see cref="ShrinkLabelDiagnostic.Conflict"/> is the single
+    /// implementation, so the two paths cannot drift apart.
+    /// </summary>
+    private void WarnIfShrinkLabelUnhonoured(IFieldConfiguration<TItem, object> field, bool shrinkLabel)
+    {
+        if (shrinkLabel || !_warnedItemFields.Add(field.FieldName))
+        {
+            return;
+        }
+
+        field.AdditionalAttributes.TryGetValue("Adornment", out var adornmentValue);
+        var conflict = ShrinkLabelDiagnostic.Conflict(
+            field.Placeholder,
+            adornmentValue as Adornment?);
+
+        if (conflict is null)
+        {
+            return;
+        }
+
+        // A diagnostic must never break a render, so a logger that throws is swallowed.
+        try
+        {
+            var logger = DiagnosticServices?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(ShrinkLabelDiagnostic.Category);
+
+            logger?.LogWarning(
+                "Field '{Field}' sets ShrinkLabel=false but also has {Conflict}, which MudBlazor " +
+                "lets win — the label stays pinned and will not float. Remove that property to get " +
+                "a floating label, or drop ShrinkLabel=false.",
+                field.Label ?? field.FieldName,
+                conflict);
+        }
+        catch
+        {
+            // Ignored: a failing diagnostic must not take the form down with it.
+        }
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -57,6 +57,12 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private IServiceProvider? DiagnosticServices { get; set; }
 
     /// <summary>
+    /// The form's diagnostic collector, so item-field conflicts join the form's single warning.
+    /// </summary>
+    [CascadingParameter(Name = FormCraftCascadingValues.ShrinkLabelDiagnostics)]
+    public ShrinkLabelDiagnosticCollector? ShrinkLabelDiagnostics { get; set; }
+
+    /// <summary>
     /// Item fields already reported, so the diagnostic fires once per field rather than once
     /// per row — a collection of 50 items must not produce 50 identical warnings.
     /// </summary>
@@ -316,6 +322,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
 
         if (conflict is null)
         {
+            return;
+        }
+
+        // Prefer the form's collector so item fields join the single aggregated warning.
+        if (ShrinkLabelDiagnostics is not null)
+        {
+            ShrinkLabelDiagnostics.Report(field.Label ?? field.FieldName, conflict);
             return;
         }
 

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -315,10 +315,12 @@ public partial class CollectionFieldComponent<TModel, TItem>
             return;
         }
 
-        field.AdditionalAttributes.TryGetValue("Adornment", out var adornmentValue);
-        var conflict = ShrinkLabelDiagnostic.Conflict(
-            field.Placeholder,
-            adornmentValue as Adornment?);
+        // Adornment is deliberately passed as null: AddCommonFieldAttributes above does not emit
+        // an Adornment attribute, so this render path never draws one. Reading the field's
+        // configured adornment here would warn that the label "will not float" when in fact the
+        // adornment is dropped and ShrinkLabel=false IS honoured — pushing the developer to
+        // remove a setting that was working. Same rule, different inputs per render path.
+        var conflict = ShrinkLabelDiagnostic.Conflict(field.Placeholder, adornment: null);
 
         if (conflict is null)
         {
@@ -328,7 +330,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // Prefer the form's collector so item fields join the single aggregated warning.
         if (ShrinkLabelDiagnostics is not null)
         {
-            ShrinkLabelDiagnostics.Report(field.Label ?? field.FieldName, conflict);
+            ShrinkLabelDiagnostics.Report(field.FieldName, field.Label, conflict);
             return;
         }
 

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
@@ -11,6 +11,7 @@
 
 <CascadingValue TValue="Variant?" Name="@FormCraftCascadingValues.DefaultVariant" Value="@DefaultVariant">
 <CascadingValue TValue="bool?" Name="@FormCraftCascadingValues.DefaultShrinkLabel" Value="@DefaultShrinkLabel">
+<CascadingValue TValue="ShrinkLabelDiagnosticCollector" Name="@FormCraftCascadingValues.ShrinkLabelDiagnostics" Value="@_shrinkLabelDiagnostics" IsFixed="true">
 <EditForm EditContext="@_editContext" OnSubmit="@HandleSubmit">
     <DynamicFormValidator TModel="TModel" Configuration="@Configuration" @ref="_validator" />
     
@@ -113,6 +114,7 @@
         </MudButton>
     }
 </EditForm>
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -117,9 +117,11 @@ public partial class FormCraftComponent<TModel>
     {
         base.OnAfterRender(firstRender);
 
-        // Every field has now rendered and reported, so the collector holds the complete set.
-        // Flush is idempotent — it emits at most once per form.
-        _shrinkLabelDiagnostics.Flush(ServiceProvider.GetService<ILoggerFactory>());
+        // Every field has now rendered and reported, so the collector holds the current set.
+        // Flush reports each field once but stays live, so fields revealed later (a visibility
+        // condition, an expanded group, a new collection row) are still picked up. Resolving the
+        // logger is Flush's job — it happens inside that method's exception guard.
+        _shrinkLabelDiagnostics.Flush(ServiceProvider);
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor.cs
@@ -85,6 +85,12 @@ public partial class FormCraftComponent<TModel>
     [Inject]
     private IServiceProvider ServiceProvider { get; set; } = null!;
 
+    /// <summary>
+    /// Collects ShrinkLabel conflicts reported by this form's fields during the render pass, so
+    /// they surface as one warning naming every affected field rather than one warning each (#181).
+    /// </summary>
+    private readonly ShrinkLabelDiagnosticCollector _shrinkLabelDiagnostics = new();
+
     private EditContext? _editContext;
     private DynamicFormValidator<TModel>? _validator;
     private string? _csrfToken;
@@ -104,6 +110,16 @@ public partial class FormCraftComponent<TModel>
         }
         await InitializeSecurityAsync();
         await base.OnInitializedAsync();
+    }
+
+    /// <inheritdoc />
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+
+        // Every field has now rendered and reported, so the collector holds the complete set.
+        // Flush is idempotent — it emits at most once per form.
+        _shrinkLabelDiagnostics.Flush(ServiceProvider.GetService<ILoggerFactory>());
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/LovField/MudBlazorLovFieldComponent.razor.cs
@@ -23,6 +23,18 @@ public partial class MudBlazorLovFieldComponent<TModel, TValue, TItem>
     protected ILovConfiguration<TItem, TValue>? LovConfig => _lovConfig;
 
     /// <summary>
+    /// Suppresses the ShrinkLabel diagnostic (#181) for LOV fields.
+    /// </summary>
+    /// <remarks>
+    /// This component always renders a non-empty placeholder — the caller's, else
+    /// "Click to select..." — and MudBlazor pins the label whenever a placeholder is present.
+    /// A LOV label therefore can never float, whatever <c>ShrinkLabel</c> says, so the warning
+    /// would be unactionable: there is no configuration change that would satisfy it. Silence
+    /// here is deliberate, and asserted by ShrinkLabelDiagnosticsTests.
+    /// </remarks>
+    protected override bool SuppressShrinkLabelDiagnostic => true;
+
+    /// <summary>
     /// Gets whether multiple selection is enabled.
     /// </summary>
     protected bool IsMultiSelect => _lovConfig?.SelectionMode == LovSelectionMode.Multiple;

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -88,6 +88,12 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
 
     private bool _shrinkLabelDiagnosticEmitted;
 
+    /// <summary>
+    /// When true, this component never reports a ShrinkLabel conflict. Override in components
+    /// whose label is structurally always pinned, where the warning would be unactionable.
+    /// </summary>
+    protected virtual bool SuppressShrinkLabelDiagnostic => false;
+
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
@@ -108,7 +114,7 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     {
         // Once per component instance: the conflict is a configuration fact, so re-reporting it
         // on every parameter change would flood the console as the user types.
-        if (_shrinkLabelDiagnosticEmitted || EffectiveShrinkLabel)
+        if (_shrinkLabelDiagnosticEmitted || EffectiveShrinkLabel || SuppressShrinkLabelDiagnostic)
         {
             return;
         }
@@ -146,7 +152,7 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     /// null when the setting will be honoured.
     /// </summary>
     private string? ShrinkLabelConflict() =>
-        ShrinkLabelDiagnostic.Conflict(Placeholder);
+        ShrinkLabelDiagnostic.Conflict(Placeholder, GetAttribute<Adornment?>("Adornment"));
 }
 
 /// <summary>
@@ -168,6 +174,14 @@ internal static class ShrinkLabelDiagnostic
     /// label or the two overlap, so that override is correct behaviour rather than a surprise —
     /// warning about it would be noise on every filled form.
     /// </remarks>
-    internal static string? Conflict(string? placeholder) =>
-        !string.IsNullOrWhiteSpace(placeholder) ? "a Placeholder" : null;
+    internal static string? Conflict(string? placeholder, Adornment? adornment)
+    {
+        if (!string.IsNullOrWhiteSpace(placeholder))
+        {
+            return "a Placeholder";
+        }
+
+        // Only a START adornment sits where a floating label would go; End is harmless.
+        return adornment == Adornment.Start ? "a start Adornment" : null;
+    }
 }

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
@@ -71,4 +73,101 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     /// </remarks>
     protected bool EffectiveShrinkLabel =>
         GetAttribute<bool?>("ShrinkLabel") ?? FormDefaultShrinkLabel ?? true;
+
+    /// <summary>
+    /// Service provider used to resolve an optional <see cref="ILoggerFactory"/> for the
+    /// ShrinkLabel diagnostic. Diagnostics degrade silently when no logger is registered.
+    /// </summary>
+    /// <remarks>
+    /// Private on purpose: derived components inject their own <c>ServiceProvider</c>
+    /// (MudBlazorLovFieldComponent does), and a protected member of the same name would hide
+    /// theirs (CS0108). Blazor injects non-public properties, so privacy costs nothing here.
+    /// </remarks>
+    [Inject]
+    private IServiceProvider? DiagnosticServices { get; set; }
+
+    private bool _shrinkLabelDiagnosticEmitted;
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        EmitShrinkLabelDiagnosticIfNeeded();
+    }
+
+    /// <summary>
+    /// Warns when the field asked for a floating label that MudBlazor will not give it.
+    /// <para>
+    /// MudInput decides the shrunk state by OR-ing <c>ShrinkLabel</c> with "has a value",
+    /// "has a placeholder" and "has a start adornment", so <c>ShrinkLabel=false</c> is only
+    /// observable on an empty field with neither. Rendering is untouched — this only tells the
+    /// developer why their setting appears to do nothing.
+    /// </para>
+    /// </summary>
+    private void EmitShrinkLabelDiagnosticIfNeeded()
+    {
+        // Once per component instance: the conflict is a configuration fact, so re-reporting it
+        // on every parameter change would flood the console as the user types.
+        if (_shrinkLabelDiagnosticEmitted || EffectiveShrinkLabel)
+        {
+            return;
+        }
+
+        var conflict = ShrinkLabelConflict();
+        if (conflict is null)
+        {
+            return;
+        }
+
+        _shrinkLabelDiagnosticEmitted = true;
+
+        // A diagnostic must never break a render, so a logger that throws is swallowed.
+        try
+        {
+            var logger = DiagnosticServices?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(ShrinkLabelDiagnostic.Category);
+
+            logger?.LogWarning(
+                "Field '{Field}' sets ShrinkLabel=false but also has {Conflict}, which MudBlazor " +
+                "lets win — the label stays pinned and will not float. Remove that property to get " +
+                "a floating label, or drop ShrinkLabel=false.",
+                Label ?? Context.Field.FieldName,
+                conflict);
+        }
+        catch
+        {
+            // Ignored: a failing diagnostic must not take the form down with it.
+        }
+    }
+
+    /// <summary>
+    /// Returns the property that will override <c>ShrinkLabel=false</c> for this field, or
+    /// null when the setting will be honoured.
+    /// </summary>
+    private string? ShrinkLabelConflict() =>
+        ShrinkLabelDiagnostic.Conflict(Placeholder);
+}
+
+/// <summary>
+/// The single implementation of the ShrinkLabel conflict rule, shared by the component render
+/// path (<see cref="MudBlazorFieldComponentBase{TModel, TValue}"/>) and the imperative
+/// RenderTreeBuilder path used for collection item fields.
+/// </summary>
+internal static class ShrinkLabelDiagnostic
+{
+    /// <summary>Logger category for the ShrinkLabel diagnostic.</summary>
+    internal const string Category = "FormCraft.ForMudBlazor.ShrinkLabel";
+
+    /// <summary>
+    /// Names the property that will override <c>ShrinkLabel=false</c>, or returns null when
+    /// nothing does and the setting will be honoured.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT consider "the field has a value". A populated field must shrink its
+    /// label or the two overlap, so that override is correct behaviour rather than a surprise —
+    /// warning about it would be noise on every filled form.
+    /// </remarks>
+    internal static string? Conflict(string? placeholder) =>
+        !string.IsNullOrWhiteSpace(placeholder) ? "a Placeholder" : null;
 }

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -24,6 +24,12 @@ public static class FormCraftCascadingValues
     /// <c>.WithShrinkLabel(...)</c> (the "ShrinkLabel" additional attribute).
     /// </summary>
     public const string DefaultShrinkLabel = "FormCraftDefaultShrinkLabel";
+
+    /// <summary>
+    /// Name of the cascading <see cref="ShrinkLabelDiagnosticCollector"/> that gathers
+    /// ShrinkLabel conflicts so the form can report them in a single warning (#181).
+    /// </summary>
+    public const string ShrinkLabelDiagnostics = "FormCraftShrinkLabelDiagnostics";
 }
 
 /// <summary>
@@ -86,6 +92,13 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     [Inject]
     private IServiceProvider? DiagnosticServices { get; set; }
 
+    /// <summary>
+    /// The form's diagnostic collector, when this field is rendered inside a
+    /// <see cref="FormCraftComponent{TModel}"/>. Null for a standalone field.
+    /// </summary>
+    [CascadingParameter(Name = FormCraftCascadingValues.ShrinkLabelDiagnostics)]
+    public ShrinkLabelDiagnosticCollector? ShrinkLabelDiagnostics { get; set; }
+
     private bool _shrinkLabelDiagnosticEmitted;
 
     /// <summary>
@@ -127,6 +140,17 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
 
         _shrinkLabelDiagnosticEmitted = true;
 
+        var field = Label ?? Context.Field.FieldName;
+
+        // Inside a FormCraftComponent, report to the form's collector so all conflicting fields
+        // arrive in one warning. Rendered standalone there is no collector, so log directly
+        // rather than lose the diagnostic entirely.
+        if (ShrinkLabelDiagnostics is not null)
+        {
+            ShrinkLabelDiagnostics.Report(field, conflict);
+            return;
+        }
+
         // A diagnostic must never break a render, so a logger that throws is swallowed.
         try
         {
@@ -138,7 +162,7 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
                 "Field '{Field}' sets ShrinkLabel=false but also has {Conflict}, which MudBlazor " +
                 "lets win — the label stays pinned and will not float. Remove that property to get " +
                 "a floating label, or drop ShrinkLabel=false.",
-                Label ?? Context.Field.FieldName,
+                field,
                 conflict);
         }
         catch

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -140,14 +140,15 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
 
         _shrinkLabelDiagnosticEmitted = true;
 
-        var field = Label ?? Context.Field.FieldName;
+        var fieldName = Context.Field.FieldName;
+        var field = Label ?? fieldName;
 
         // Inside a FormCraftComponent, report to the form's collector so all conflicting fields
         // arrive in one warning. Rendered standalone there is no collector, so log directly
         // rather than lose the diagnostic entirely.
         if (ShrinkLabelDiagnostics is not null)
         {
-            ShrinkLabelDiagnostics.Report(field, conflict);
+            ShrinkLabelDiagnostics.Report(fieldName, Label, conflict);
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -587,6 +587,17 @@ var formConfig = FormBuilder<UserModel>
 
 > [!IMPORTANT]
 > **`ShrinkLabel="false"` only shows up on an empty field with no placeholder and no start adornment.** MudBlazor decides the shrunk state by OR-ing `ShrinkLabel` with "has a value", "has a placeholder" and "has a start adornment" — so on a field configured with `.WithPlaceholder(...)` or `.WithAdornment(...)`, the label stays pinned no matter what you pass here. This is MudBlazor's rule, not FormCraft's. If you want the label to float on a `Variant.Text` field, leave its placeholder unset and let the label do that job.
+>
+> **You don't have to remember this — FormCraft tells you.** When a field asks for `ShrinkLabel="false"` and carries a placeholder or start adornment, the form logs one warning naming every affected field:
+>
+> ```text
+> warn: FormCraft.ForMudBlazor.ShrinkLabel
+>       ShrinkLabel=false will not take effect on 2 field(s): 'Email' (has a Placeholder),
+>       'Search' (has a start Adornment). MudBlazor pins the label whenever a field has a
+>       value, a placeholder or a start adornment, so the label stays put.
+> ```
+>
+> Rendering is unaffected — this is a diagnostic only. It stays quiet when the setting *does* work, when a field is merely populated (a filled field must shrink its label), and on LOV fields, whose built-in placeholder means their label can never float anyway. No logger registered? The diagnostic degrades silently.
 
 `Variant` is honored by text, numeric, date/time pickers, select, multi-select, autocomplete, lookup, LOV, color picker and collection-item fields. `ShrinkLabel` reaches all of the same components, subject to the rule above — note that LOV fields always supply their own `"Click to select..."` placeholder, so their label is always pinned.
 


### PR DESCRIPTION
Implements #181.

Closes #181.

Follow-up to #177/#178. MudBlazor ORs `ShrinkLabel` with has-value / has-placeholder / has-start-adornment before emitting `mud-shrink`, so `.WithShrinkLabel(false)` is silently inert on any field carrying a placeholder or start adornment — the API accepts a value it cannot honour, with no warning and no exception.

This makes the conflict visible at render time via a logged warning, **without changing what any form renders**.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are ticked as each task lands. Opened as a draft — will be marked ready after the final task and a code-review pass.

### Plan
- [x] Task 1: Detect the conflict and warn on the component path
- [x] Task 2: Cover the start-adornment case and suppress the LOV false positive
- [x] Task 3: Collection item fields
- [x] Task 4: Aggregate form-wide noise and document
