### PR TITLE
fix(mudblazor): render adornments on collection item fields (#184)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -395,7 +395,9 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         // field. The two go through different renderers (component vs CollectionFieldComponent's
         // RenderTreeBuilder), and presentation attributes have repeatedly drifted between them:
         // Variant in #146, ShrinkLabel in #177, the adornments in #184 — each found reactively,
-        // years apart. Comparing the whole set here means the NEXT one fails a test instead.
+        // years apart. This pins the set the two paths DO agree on, so a regression in any of them
+        // fails here. It is not a claim that the paths agree on everything: see Presentation()
+        // for the attributes still known to diverge.
         static void Configure<TOwner>(FieldBuilder<TOwner, string> field)
             where TOwner : new()
             => field
@@ -436,8 +438,19 @@ public class RenderPipelineParityTests : MudBlazorTestBase
     }
 
     /// <summary>
-    /// The presentation attributes both render paths are expected to honour identically. Add to
-    /// this list whenever a field component gains one.
+    /// The presentation attributes both render paths are expected to honour identically, and which
+    /// the test above actually configures. Add to this list whenever a field component gains one.
+    /// <para>
+    /// Deliberately NOT compared, because the two paths are known to disagree today — each is
+    /// tracked separately, and listing one here without configuring it would assert nothing while
+    /// looking like coverage:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><c>Required</c> — the collection path emits it, no component-path renderer does.</item>
+    /// <item><c>InputType</c>, <c>Lines</c>, <c>MaxLength</c>, <c>Autocomplete</c> — component path
+    /// only; a <c>.AsPassword()</c> item field still renders as plain text inside a collection.</item>
+    /// <item><c>OnAdornmentClick</c> — component path only (an explicit non-goal of #184).</item>
+    /// </list>
     /// </summary>
     private static object?[] Presentation(MudTextField<string> field) =>
     [
@@ -450,9 +463,6 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         field.Adornment,
         field.AdornmentIcon,
         field.AdornmentColor,
-        field.ReadOnly,
-        field.Disabled,
-        field.Required,
     ];
 
     private class OrderModel

--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -389,6 +389,83 @@ public class RenderPipelineParityTests : MudBlazorTestBase
     }
 
     [Fact]
+    public void CollectionItemField_Should_Honour_The_Same_Presentation_Attributes_As_A_Standalone_Field()
+    {
+        // Arrange - the SAME builder calls applied to a standalone field and to a collection item
+        // field. The two go through different renderers (component vs CollectionFieldComponent's
+        // RenderTreeBuilder), and presentation attributes have repeatedly drifted between them:
+        // Variant in #146, ShrinkLabel in #177, the adornments in #184 — each found reactively,
+        // years apart. Comparing the whole set here means the NEXT one fails a test instead.
+        static void Configure<TOwner>(FieldBuilder<TOwner, string> field)
+            where TOwner : new()
+            => field
+                .WithLabel("Product")
+                .WithPlaceholder("e.g. Widget")
+                .WithHelpText("The catalogue name")
+                .WithAdornment(Icons.Material.Filled.Search, Adornment.Start, Color.Secondary)
+                .WithVariant(Variant.Filled);
+
+        var standaloneConfig = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Status, Configure)
+            .Build();
+
+        var collectionConfig = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item.AddField(x => x.ProductName, Configure)))
+            .Build();
+
+        // Act
+        var standalone = RenderForm(standaloneConfig)
+            .FindComponent<MudTextField<string>>().Instance;
+
+        var itemField = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+                .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+                .Add(p => p.Configuration, collectionConfig))
+            .FindComponent<MudTextField<string>>().Instance;
+
+        // Assert - compared as one set, so a newly-honoured attribute on the component path that
+        // the collection path ignores shows up here rather than in a bug report
+        Presentation(itemField).ShouldBe(Presentation(standalone));
+
+        // Guard the guard: a comparison of two all-default fields would pass while proving nothing.
+        standalone.Adornment.ShouldBe(Adornment.Start);
+        standalone.Variant.ShouldBe(Variant.Filled);
+    }
+
+    /// <summary>
+    /// The presentation attributes both render paths are expected to honour identically. Add to
+    /// this list whenever a field component gains one.
+    /// </summary>
+    private static object?[] Presentation(MudTextField<string> field) =>
+    [
+        field.Label,
+        field.Placeholder,
+        field.HelperText,
+        field.Variant,
+        field.Margin,
+        field.ShrinkLabel,
+        field.Adornment,
+        field.AdornmentIcon,
+        field.AdornmentColor,
+        field.ReadOnly,
+        field.Disabled,
+        field.Required,
+    ];
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+
+    [Fact]
     public void CustomTemplate_Should_Take_Precedence_Over_Options()
     {
         // Arrange - custom templates beat every built-in renderer, including selects

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -162,6 +162,64 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         picker.AdornmentIcon.ShouldNotBeNullOrEmpty();
     }
 
+    [Fact]
+    public void Reordering_A_Mixed_Item_Form_Should_Move_Values_With_Their_Rows()
+    {
+        // Arrange - the adornment forward makes a text row emit more render-tree frames than a date
+        // row, so a mixed item form now has rows of differing frame counts in a keyless loop. If the
+        // sequence numbers were computed rather than source-position constants, Blazor would pair
+        // frames positionally across a reorder and a value could stay on the row it was on.
+        var model = new MixedModel
+        {
+            Rows =
+            {
+                new MixedRow { Name = "first", When = new DateTime(2020, 1, 1) },
+                new MixedRow { Name = "second", When = new DateTime(2030, 12, 31) },
+            },
+        };
+
+        var config = FormBuilder<MixedModel>
+            .Create()
+            .AddCollectionField(x => x.Rows, collection => collection
+                .WithLabel("Rows")
+                .AllowReorder()
+                .WithItemForm(item => item
+                    .AddField(x => x.Name, field => field
+                        .WithLabel("Name")
+                        .WithAdornment(Icons.Material.Filled.Search, Adornment.Start))
+                    .AddField(x => x.When, field => field.WithLabel("When"))))
+            .Build();
+
+        var component = Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<FormCraftComponent<MixedModel>>(1);
+            builder.AddComponentParameter(2, "Model", model);
+            builder.AddComponentParameter(3, "Configuration", config);
+            builder.CloseComponent();
+        });
+
+        // Act - move the second row up
+        component.FindAll("button[aria-label='Move up']")[1].Click();
+
+        // Assert - the model reordered, and each rendered row shows its own row's values
+        model.Rows.Select(r => r.Name).ShouldBe(new[] { "second", "first" });
+
+        // MudDatePicker embeds a MudTextField<string> of its own, so select only our name fields
+        var texts = component.FindComponents<MudTextField<string>>()
+            .Select(t => t.Instance)
+            .Where(t => t.Label == "Name")
+            .ToList();
+
+        texts.Select(t => t.Value).ShouldBe(new[] { "second", "first" });
+        texts.Select(t => t.Adornment).ShouldAllBe(a => a == Adornment.Start);
+
+        component.FindComponents<MudDatePicker>()
+            .Select(p => p.Instance.Date)
+            .ShouldBe(new DateTime?[] { new DateTime(2030, 12, 31), new DateTime(2020, 1, 1) });
+    }
+
     private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
         IFormConfiguration<OrderModel> config)
     {
@@ -208,6 +266,18 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         public int Quantity { get; set; }
 
         public bool IsGift { get; set; }
+    }
+
+    private class MixedModel
+    {
+        public List<MixedRow> Rows { get; set; } = new();
+    }
+
+    private class MixedRow
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public DateTime When { get; set; }
     }
 
     private class AppointmentModel

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -62,6 +62,82 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     }
 
     [Fact]
+    public void NumericItemField_Should_Render_An_End_Adornment()
+    {
+        // Arrange - WithAdornment is declared on FieldBuilder<TModel, string> only, so a numeric
+        // field configures the same three attributes through raw WithAttribute. The renderer must
+        // honour them either way: it reads AdditionalAttributes, not the builder method.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field
+                        .WithLabel("Quantity")
+                        .WithAttribute("Adornment", Adornment.End)
+                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Numbers)
+                        .WithAttribute("AdornmentColor", Color.Primary))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var numeric = component.FindComponent<MudNumericField<int>>().Instance;
+        numeric.Adornment.ShouldBe(Adornment.End);
+        numeric.AdornmentIcon.ShouldBe(Icons.Material.Filled.Numbers);
+        numeric.AdornmentColor.ShouldBe(Color.Primary);
+    }
+
+    [Fact]
+    public void NumericItemField_Without_An_Adornment_Should_Render_None()
+    {
+        // Arrange & Act - unchanged from before #184
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field.WithLabel("Quantity"))))
+            .Build();
+
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Adornment.ShouldBe(Adornment.None);
+    }
+
+    [Fact]
+    public void BooleanItemField_With_An_Adornment_Should_Render_Without_One()
+    {
+        // Arrange - MudCheckBox has no adornment concept at all, so RenderBooleanField sets its own
+        // attributes and takes no part in the forward. Configuring one must be inert, not a throw.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.IsGift, field => field
+                        .WithLabel("Gift")
+                        .WithAttribute("Adornment", Adornment.Start)
+                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
+        component.Markup.ShouldNotContain(Icons.Material.Filled.Search);
+    }
+
+    [Fact]
     public void DateItemField_Should_Keep_Its_Calendar_Icon()
     {
         // Arrange - MudDatePicker's own default is Adornment.End with a calendar icon, unlike the
@@ -120,6 +196,18 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     private class OrderItem
     {
         public string ProductName { get; set; } = string.Empty;
+    }
+
+    private class BasketModel
+    {
+        public List<BasketLine> Lines { get; set; } = new();
+    }
+
+    private class BasketLine
+    {
+        public int Quantity { get; set; }
+
+        public bool IsGift { get; set; }
     }
 
     private class AppointmentModel

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -1,0 +1,134 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that collection item fields honor <c>.WithAdornment(...)</c> (#184). These render through
+/// CollectionFieldComponent's imperative RenderTreeBuilder path, which resolves presentation
+/// attributes in AddCommonFieldAttributes rather than through MudBlazorFieldComponentBase — so it
+/// needs its own coverage. Before #184 the three adornment attributes were silently dropped here
+/// while the component path forwarded them, so the same builder call rendered differently
+/// depending on whether the field sat inside <c>.WithItemForm(...)</c>.
+/// </summary>
+public class CollectionAdornmentTests : MudBlazorTestBase
+{
+    [Fact]
+    public void ItemField_Should_Render_A_Start_Adornment()
+    {
+        // Arrange & Act
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .WithAdornment(Icons.Material.Filled.Search, Adornment.Start)));
+
+        // Assert
+        var textField = component.FindComponent<MudTextField<string>>().Instance;
+        textField.Adornment.ShouldBe(Adornment.Start);
+        textField.AdornmentIcon.ShouldBe(Icons.Material.Filled.Search);
+    }
+
+    [Fact]
+    public void ItemField_Should_Render_The_Configured_Adornment_Color()
+    {
+        // Arrange & Act - WithAdornment always writes all three attributes, colour included
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .WithAdornment(Icons.Material.Filled.Search, Adornment.Start, Color.Secondary)));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.AdornmentColor
+            .ShouldBe(Color.Secondary);
+    }
+
+    [Fact]
+    public void ItemField_Without_An_Adornment_Should_Render_None()
+    {
+        // Arrange & Act - unchanged from before #184: no adornment configured, none rendered
+        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+
+        // Assert
+        var textField = component.FindComponent<MudTextField<string>>().Instance;
+        textField.Adornment.ShouldBe(Adornment.None);
+        textField.AdornmentIcon.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ItemField_With_Only_An_Adornment_Position_Should_Default_Its_Color()
+    {
+        // Arrange & Act - a field that set "Adornment" through raw WithAttribute has no colour to
+        // read, so the resolver must supply one rather than assume all three are present.
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .WithAttribute("Adornment", Adornment.End)));
+
+        // Assert
+        var textField = component.FindComponent<MudTextField<string>>().Instance;
+        textField.Adornment.ShouldBe(Adornment.End);
+        textField.AdornmentColor.ShouldBe(Color.Default);
+    }
+
+    [Fact]
+    public void DateItemField_Should_Keep_Its_Calendar_Icon()
+    {
+        // Arrange - MudDatePicker's own default is Adornment.End with a calendar icon, unlike the
+        // text and numeric fields whose default is None. Forwarding an unset adornment onto it
+        // would silently erase that icon, so the date path deliberately does not take the forward.
+        var config = FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field => field.WithLabel("When"))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
+            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var picker = component.FindComponent<MudDatePicker>().Instance;
+        picker.Adornment.ShouldBe(Adornment.End);
+        picker.AdornmentIcon.ShouldNotBeNullOrEmpty();
+    }
+
+    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
+        IFormConfiguration<OrderModel> config)
+    {
+        var model = new OrderModel { Items = { new OrderItem { ProductName = "Widget" } } };
+
+        return Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+    }
+
+    private static IFormConfiguration<OrderModel> BuildConfiguration(
+        Action<FieldBuilder<OrderItem, string>> configureItemField)
+    {
+        return FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field =>
+                    {
+                        field.WithLabel("Product");
+                        configureItemField(field);
+                    })))
+            .Build();
+    }
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+
+    private class AppointmentModel
+    {
+        public List<AppointmentSlot> Slots { get; set; } = new();
+    }
+
+    private class AppointmentSlot
+    {
+        public DateTime When { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -262,11 +262,12 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
     }
 
     [Fact]
-    public void Should_Not_Warn_About_An_Adornment_On_A_Collection_Item_Field()
+    public void Should_Warn_About_A_Start_Adornment_On_A_Collection_Item_Field()
     {
-        // Arrange - the collection render path never emits an Adornment attribute, so the
-        // adornment is dropped and ShrinkLabel=false IS honoured there. Warning would push the
-        // developer to remove a setting that was working.
+        // Arrange - #183 suppressed this warning because the collection path dropped the adornment
+        // entirely, so ShrinkLabel=false WAS honoured and warning would have pushed the developer
+        // to remove a setting that worked. Since #184 the adornment really is rendered there, so
+        // the same conflict as the component path applies and the diagnostic must say so.
         var config = FormBuilder<OrderModel>
             .Create()
             .AddCollectionField(x => x.Items, collection => collection
@@ -282,6 +283,67 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         Render<FormCraftComponent<OrderModel>>(parameters => parameters
             .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
             .Add(p => p.Configuration, config));
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Product");
+        warnings[0].ShouldContain("Adornment");
+    }
+
+    [Fact]
+    public void Should_Not_Warn_About_An_End_Adornment_On_A_Collection_Item_Field()
+    {
+        // Arrange - only a START adornment competes with the label, on either render path
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field => field
+                        .WithLabel("Product")
+                        .WithAdornment(Icons.Material.Filled.Search, Adornment.End)
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_About_An_Adornment_On_A_Collection_Date_Item_Field()
+    {
+        // Arrange - the date path deliberately keeps MudDatePicker's own calendar adornment rather
+        // than taking #184's forward, so a configured start adornment is still dropped there and
+        // ShrinkLabel=false IS honoured. This is #183's rule, now scoped to the one path that still
+        // needs it — the diagnostic must see what each path actually renders, not what was asked.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.OrderedOn, field => field
+                        .WithLabel("Ordered on")
+                        .WithAttribute("Adornment", Adornment.Start)
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act - next to a MudPopoverProvider, or MudDatePicker logs a warning of its own that has
+        // nothing to do with this diagnostic
+        Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<FormCraftComponent<OrderModel>>(1);
+            builder.AddComponentParameter(2, "Model", new OrderModel { Items = { new OrderItem() } });
+            builder.AddComponentParameter(3, "Configuration", config);
+            builder.CloseComponent();
+        });
 
         // Assert
         _logs.Warnings.ShouldBeEmpty();
@@ -318,6 +380,8 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
     private class OrderItem
     {
         public string ProductName { get; set; } = string.Empty;
+
+        public DateTime OrderedOn { get; set; }
     }
 
     private IRenderedComponent<FormCraftComponent<TestModel>> RenderFormWithPopover(

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -236,12 +236,12 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private void RenderTextField(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, string? value, int itemIndex)
     {
         builder.OpenComponent<MudTextField<string>>(0);
-        AddCommonFieldAttributes(builder, field, 1);
-        builder.AddAttribute(2, "Value", value);
-        builder.AddAttribute(3, "ValueChanged",
+        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: true);
+        builder.AddAttribute(index++, "Value", value);
+        builder.AddAttribute(index++, "ValueChanged",
             EventCallback.Factory.Create<string>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
-        builder.AddAttribute(4, "Immediate", true);
+        builder.AddAttribute(index, "Immediate", true);
         builder.CloseComponent();
     }
 
@@ -249,16 +249,16 @@ public partial class CollectionFieldComponent<TModel, TItem>
         where T : struct
     {
         builder.OpenComponent(0, typeof(MudNumericField<>).MakeGenericType(typeof(T)));
-        AddCommonFieldAttributes(builder, field, 1);
-        builder.AddAttribute(2, "Value", value);
-        builder.AddAttribute(3, "ValueChanged",
+        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: false);
+        builder.AddAttribute(index++, "Value", value);
+        builder.AddAttribute(index++, "ValueChanged",
             EventCallback.Factory.Create<T>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
-        builder.AddAttribute(4, "Immediate", true);
+        builder.AddAttribute(index++, "Immediate", true);
         // MudBlazor appends '*' to Pattern before emitting the HTML attribute, so a
         // fully-anchored regex here becomes invalid (e.g. "...?*"). The component's
         // default pattern already handles decimal input; only Culture is needed.
-        builder.AddAttribute(5, "Culture", System.Globalization.CultureInfo.InvariantCulture);
+        builder.AddAttribute(index, "Culture", System.Globalization.CultureInfo.InvariantCulture);
         builder.CloseComponent();
     }
 
@@ -278,15 +278,41 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private void RenderDateTimeField(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, DateTime? value, int itemIndex)
     {
         builder.OpenComponent<MudDatePicker>(0);
-        AddCommonFieldAttributes(builder, field, 1);
-        builder.AddAttribute(2, "Date", value);
-        builder.AddAttribute(3, "DateChanged",
+        // rendersAdornment: false — MudDatePicker defaults to Adornment.End with its calendar
+        // icon, so forwarding a field's (usually unset) adornment here would silently strip that
+        // icon on every date item field. Out of scope for #184; see the issue's non-goals.
+        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: false);
+        builder.AddAttribute(index++, "Date", value);
+        builder.AddAttribute(index, "DateChanged",
             EventCallback.Factory.Create<DateTime?>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
         builder.CloseComponent();
     }
 
-    private void AddCommonFieldAttributes(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, int startIndex)
+    /// <summary>
+    /// Emits the presentation attributes every item field shares, and returns the next free
+    /// RenderTreeBuilder sequence number so the caller can continue from it.
+    /// </summary>
+    /// <param name="builder">The render tree builder for the open item-field component.</param>
+    /// <param name="field">The item field's configuration.</param>
+    /// <param name="startIndex">The first sequence number this method may use.</param>
+    /// <param name="rendersAdornment">
+    /// Whether the target component takes MudBlazor's three adornment parameters and defaults them
+    /// to "no adornment" (#184). True for MudTextField and MudNumericField. False for MudDatePicker,
+    /// whose own default is <see cref="Adornment.End"/> with a calendar icon that forwarding would
+    /// erase.
+    /// </param>
+    /// <returns>The next free sequence number.</returns>
+    /// <remarks>
+    /// The caller and this method share one sequence-number space, so returning the next index —
+    /// rather than having callers resume from a hardcoded offset — is what keeps them from
+    /// colliding as the common set grows.
+    /// </remarks>
+    private int AddCommonFieldAttributes(
+        RenderTreeBuilder builder,
+        IFieldConfiguration<TItem, object> field,
+        int startIndex,
+        bool rendersAdornment)
     {
         builder.AddAttribute(startIndex++, "Label", field.Label);
         builder.AddAttribute(startIndex++, "Placeholder", field.Placeholder);
@@ -298,9 +324,21 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Margin", Margin.Dense);
 
         var shrinkLabel = GetItemFieldShrinkLabel(field);
-        builder.AddAttribute(startIndex, "ShrinkLabel", shrinkLabel);
+        builder.AddAttribute(startIndex++, "ShrinkLabel", shrinkLabel);
+
+        if (rendersAdornment)
+        {
+            // Emitted unconditionally (not only when configured) so the frame layout stays the
+            // same on every render of a given field. The defaults below are the component's own,
+            // so an item field with no adornment renders exactly as it did before #184.
+            builder.AddAttribute(startIndex++, "Adornment", GetItemFieldAdornment(field));
+            builder.AddAttribute(startIndex++, "AdornmentIcon", GetItemFieldAttribute<string?>(field, "AdornmentIcon", null));
+            builder.AddAttribute(startIndex++, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
+        }
 
         WarnIfShrinkLabelUnhonoured(field, shrinkLabel);
+
+        return startIndex;
     }
 
     /// <summary>
@@ -367,6 +405,27 @@ public partial class CollectionFieldComponent<TModel, TItem>
 
         return FormDefaultVariant ?? Variant.Outlined;
     }
+
+    /// <summary>
+    /// Resolves the adornment position for an item field (#184): the field-level "Adornment"
+    /// attribute when present, otherwise none. There is no form-level default for adornments.
+    /// </summary>
+    private static Adornment GetItemFieldAdornment(IFieldConfiguration<TItem, object> field)
+        => GetItemFieldAttribute(field, "Adornment", Adornment.None);
+
+    /// <summary>
+    /// Reads a strongly-typed item-field attribute, returning <paramref name="fallback"/> when it
+    /// is absent or holds a value of another type.
+    /// </summary>
+    /// <remarks>
+    /// <c>WithAdornment(...)</c> always writes all three adornment attributes together, but a field
+    /// that set only "Adornment" through raw <c>WithAttribute(...)</c> has no icon or colour to
+    /// read — so each is resolved independently rather than assuming the others are present.
+    /// </remarks>
+    private static T GetItemFieldAttribute<T>(IFieldConfiguration<TItem, object> field, string name, T fallback)
+        => field.AdditionalAttributes.TryGetValue(name, out var value) && value is T typed
+            ? typed
+            : fallback;
 
     /// <summary>
     /// Resolves ShrinkLabel for an item field: the field-level "ShrinkLabel" attribute when

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -336,7 +336,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
             builder.AddAttribute(startIndex++, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
         }
 
-        WarnIfShrinkLabelUnhonoured(field, shrinkLabel);
+        // The diagnostic has to judge what this path actually RENDERS, not what was configured:
+        // a dropped adornment cannot pin the label, so reporting one would tell the developer to
+        // remove a setting that was working (#183).
+        WarnIfShrinkLabelUnhonoured(
+            field,
+            shrinkLabel,
+            rendersAdornment ? GetItemFieldAdornment(field) : null);
 
         return startIndex;
     }
@@ -346,19 +352,25 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// component render path — <see cref="ShrinkLabelDiagnostic.Conflict"/> is the single
     /// implementation, so the two paths cannot drift apart.
     /// </summary>
-    private void WarnIfShrinkLabelUnhonoured(IFieldConfiguration<TItem, object> field, bool shrinkLabel)
+    /// <param name="field">The item field's configuration.</param>
+    /// <param name="shrinkLabel">The ShrinkLabel value this field renders with.</param>
+    /// <param name="renderedAdornment">
+    /// The adornment this render path actually draws, or <c>null</c> when it draws none — which is
+    /// not the same as the field's configured adornment. Item fields whose component takes the
+    /// forward (#184) pass the real value; the date path, which keeps MudDatePicker's own calendar
+    /// adornment instead, passes null so that a configured-but-dropped adornment is not reported.
+    /// </param>
+    private void WarnIfShrinkLabelUnhonoured(
+        IFieldConfiguration<TItem, object> field,
+        bool shrinkLabel,
+        Adornment? renderedAdornment)
     {
         if (shrinkLabel || !_warnedItemFields.Add(field.FieldName))
         {
             return;
         }
 
-        // Adornment is deliberately passed as null: AddCommonFieldAttributes above does not emit
-        // an Adornment attribute, so this render path never draws one. Reading the field's
-        // configured adornment here would warn that the label "will not float" when in fact the
-        // adornment is dropped and ShrinkLabel=false IS honoured — pushing the developer to
-        // remove a setting that was working. Same rule, different inputs per render path.
-        var conflict = ShrinkLabelDiagnostic.Conflict(field.Placeholder, adornment: null);
+        var conflict = ShrinkLabelDiagnostic.Conflict(field.Placeholder, renderedAdornment);
 
         if (conflict is null)
         {

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -236,12 +236,12 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private void RenderTextField(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, string? value, int itemIndex)
     {
         builder.OpenComponent<MudTextField<string>>(0);
-        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: true);
-        builder.AddAttribute(index++, "Value", value);
-        builder.AddAttribute(index++, "ValueChanged",
+        AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: true);
+        builder.AddAttribute(CallerAttributeStart, "Value", value);
+        builder.AddAttribute(CallerAttributeStart + 1, "ValueChanged",
             EventCallback.Factory.Create<string>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
-        builder.AddAttribute(index, "Immediate", true);
+        builder.AddAttribute(CallerAttributeStart + 2, "Immediate", true);
         builder.CloseComponent();
     }
 
@@ -249,16 +249,16 @@ public partial class CollectionFieldComponent<TModel, TItem>
         where T : struct
     {
         builder.OpenComponent(0, typeof(MudNumericField<>).MakeGenericType(typeof(T)));
-        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: true);
-        builder.AddAttribute(index++, "Value", value);
-        builder.AddAttribute(index++, "ValueChanged",
+        AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: true);
+        builder.AddAttribute(CallerAttributeStart, "Value", value);
+        builder.AddAttribute(CallerAttributeStart + 1, "ValueChanged",
             EventCallback.Factory.Create<T>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
-        builder.AddAttribute(index++, "Immediate", true);
+        builder.AddAttribute(CallerAttributeStart + 2, "Immediate", true);
         // MudBlazor appends '*' to Pattern before emitting the HTML attribute, so a
         // fully-anchored regex here becomes invalid (e.g. "...?*"). The component's
         // default pattern already handles decimal input; only Culture is needed.
-        builder.AddAttribute(index, "Culture", System.Globalization.CultureInfo.InvariantCulture);
+        builder.AddAttribute(CallerAttributeStart + 3, "Culture", System.Globalization.CultureInfo.InvariantCulture);
         builder.CloseComponent();
     }
 
@@ -281,17 +281,30 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // rendersAdornment: false — MudDatePicker defaults to Adornment.End with its calendar
         // icon, so forwarding a field's (usually unset) adornment here would silently strip that
         // icon on every date item field. Out of scope for #184; see the issue's non-goals.
-        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: false);
-        builder.AddAttribute(index++, "Date", value);
-        builder.AddAttribute(index, "DateChanged",
+        AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: false);
+        builder.AddAttribute(CallerAttributeStart, "Date", value);
+        builder.AddAttribute(CallerAttributeStart + 1, "DateChanged",
             EventCallback.Factory.Create<DateTime?>(this,
                 newValue => UpdateItemFieldValue(itemIndex, field.FieldName, newValue)));
         builder.CloseComponent();
     }
 
     /// <summary>
-    /// Emits the presentation attributes every item field shares, and returns the next free
-    /// RenderTreeBuilder sequence number so the caller can continue from it.
+    /// First sequence number <see cref="AddCommonFieldAttributes"/> may use. It never emits more
+    /// than <see cref="CallerAttributeStart"/> minus this many attributes.
+    /// </summary>
+    private const int CommonAttributeStart = 1;
+
+    /// <summary>
+    /// First sequence number an item-field renderer may use for its own attributes. Deliberately
+    /// well clear of the common block: Blazor requires sequence numbers to be constants tied to a
+    /// source position, never computed, so callers cannot resume from "wherever the shared helper
+    /// stopped" — the gap is what lets the common set grow without every caller moving.
+    /// </summary>
+    private const int CallerAttributeStart = 20;
+
+    /// <summary>
+    /// Emits the presentation attributes every item field shares.
     /// </summary>
     /// <param name="builder">The render tree builder for the open item-field component.</param>
     /// <param name="field">The item field's configuration.</param>
@@ -302,13 +315,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// whose own default is <see cref="Adornment.End"/> with a calendar icon that forwarding would
     /// erase.
     /// </param>
-    /// <returns>The next free sequence number.</returns>
-    /// <remarks>
-    /// The caller and this method share one sequence-number space, so returning the next index —
-    /// rather than having callers resume from a hardcoded offset — is what keeps them from
-    /// colliding as the common set grows.
-    /// </remarks>
-    private int AddCommonFieldAttributes(
+    private void AddCommonFieldAttributes(
         RenderTreeBuilder builder,
         IFieldConfiguration<TItem, object> field,
         int startIndex,
@@ -330,22 +337,22 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // tell apart from "none configured".
         var adornment = rendersAdornment ? GetItemFieldAdornment(field) : (Adornment?)null;
 
+        // The branch is per-CALL-SITE, not per-configuration: `adornment` is null exactly when the
+        // caller passed rendersAdornment: false, so a given renderer always emits the same frames
+        // in the same order. Within the branch all three are emitted whether or not the field
+        // configured one, using the component's own defaults — so an item field with no adornment
+        // renders exactly as it did before #184.
         if (adornment is { } rendered)
         {
-            // Emitted unconditionally (not only when configured) so the frame layout stays the
-            // same on every render of a given field. The defaults below are the component's own,
-            // so an item field with no adornment renders exactly as it did before #184.
             builder.AddAttribute(startIndex++, "Adornment", rendered);
             builder.AddAttribute(startIndex++, "AdornmentIcon", GetItemFieldAttribute<string?>(field, "AdornmentIcon", null));
-            builder.AddAttribute(startIndex++, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
+            builder.AddAttribute(startIndex, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
         }
 
         // The diagnostic has to judge what this path actually RENDERS, not what was configured:
         // a dropped adornment cannot pin the label, so reporting one would tell the developer to
         // remove a setting that was working (#183).
         WarnIfShrinkLabelUnhonoured(field, shrinkLabel, adornment);
-
-        return startIndex;
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -249,7 +249,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         where T : struct
     {
         builder.OpenComponent(0, typeof(MudNumericField<>).MakeGenericType(typeof(T)));
-        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: false);
+        var index = AddCommonFieldAttributes(builder, field, 1, rendersAdornment: true);
         builder.AddAttribute(index++, "Value", value);
         builder.AddAttribute(index++, "ValueChanged",
             EventCallback.Factory.Create<T>(this,

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -326,12 +326,16 @@ public partial class CollectionFieldComponent<TModel, TItem>
         var shrinkLabel = GetItemFieldShrinkLabel(field);
         builder.AddAttribute(startIndex++, "ShrinkLabel", shrinkLabel);
 
-        if (rendersAdornment)
+        // Null on a path that draws no adornment of ours — which the diagnostic below needs to
+        // tell apart from "none configured".
+        var adornment = rendersAdornment ? GetItemFieldAdornment(field) : (Adornment?)null;
+
+        if (adornment is { } rendered)
         {
             // Emitted unconditionally (not only when configured) so the frame layout stays the
             // same on every render of a given field. The defaults below are the component's own,
             // so an item field with no adornment renders exactly as it did before #184.
-            builder.AddAttribute(startIndex++, "Adornment", GetItemFieldAdornment(field));
+            builder.AddAttribute(startIndex++, "Adornment", rendered);
             builder.AddAttribute(startIndex++, "AdornmentIcon", GetItemFieldAttribute<string?>(field, "AdornmentIcon", null));
             builder.AddAttribute(startIndex++, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
         }
@@ -339,10 +343,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // The diagnostic has to judge what this path actually RENDERS, not what was configured:
         // a dropped adornment cannot pin the label, so reporting one would tell the developer to
         // remove a setting that was working (#183).
-        WarnIfShrinkLabelUnhonoured(
-            field,
-            shrinkLabel,
-            rendersAdornment ? GetItemFieldAdornment(field) : null);
+        WarnIfShrinkLabelUnhonoured(field, shrinkLabel, adornment);
 
         return startIndex;
     }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
-- **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` like every other field (#184)
+- **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` (#184)
 
   ```csharp
   .AddCollectionField(x => x.Items, c => c.WithItemForm(item => item
@@ -67,7 +67,9 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
           .WithAdornment(Icons.Material.Filled.Search, Adornment.Start))))   // ← now renders
   ```
 
-  **Visual change to be aware of:** forms that already call `.WithAdornment(...)` inside a collection start showing the icon they asked for. Date item fields are unchanged — they keep MudBlazor's own calendar adornment. A parity test now compares the presentation attributes of both render paths, so the next one to drift fails a test rather than surfacing years later.
+  **Two behaviour changes to be aware of.** Forms that already call `.WithAdornment(...)` inside a collection start showing the icon they asked for. And because the adornment is now really drawn there, the `ShrinkLabel` diagnostic added in v3.2 stops suppressing itself on that path: a collection item field combining a **start** adornment with `ShrinkLabel="false"` now logs the same warning an ordinary field would. That warning is correct — the label was never going to float — but it is new output on the diagnostics channel.
+
+  **Scope.** Date item fields are unchanged: they keep MudBlazor's own calendar adornment, which a blanket forward would erase. Standalone (non-collection) numeric fields still do not render adornments at all, so a numeric field configured through raw `.WithAttribute("Adornment", …)` renders differently inside and outside a collection — tracked separately. A parity test now pins the presentation attributes the two render paths **do** agree on; it names the ones still known to diverge rather than implying there are none.
 
 - **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
   - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` like every other field (#184)
+
+  ```csharp
+  .AddCollectionField(x => x.Items, c => c.WithItemForm(item => item
+      .AddField(x => x.ProductName, f => f
+          .WithLabel("Product")
+          .WithAdornment(Icons.Material.Filled.Search, Adornment.Start))))   // ← now renders
+  ```
+
+  **Visual change to be aware of:** forms that already call `.WithAdornment(...)` inside a collection start showing the icon they asked for. Date item fields are unchanged — they keep MudBlazor's own calendar adornment. A parity test now compares the presentation attributes of both render paths, so the next one to drift fails a test rather than surfacing years later.
+
 - **Configurable MudBlazor ShrinkLabel** — `.WithShrinkLabel(false)` per field and a `DefaultShrinkLabel` parameter on `FormCraftComponent`, completing the `Variant` work from v3.1.0: `Variant.Text` can now let its label float instead of pinning it above a borderless input. Field-level wins over form-level; the default stays `true`, so **no existing form changes appearance** (#177)
   - Caveat, inherited from MudBlazor: `ShrinkLabel="false"` is only visible on an **empty field with no placeholder and no start adornment**. MudBlazor ORs `ShrinkLabel` with those conditions, so a field with a placeholder keeps its label pinned whatever you pass. To get a floating label on a `Variant.Text` field, leave its placeholder unset.
 - **`LovBuilder.WithDisplay` / `WithKey` accept a plain lambda again — no cast, no breaking change.** `.WithDisplay(c => c.Name)`, the form shown throughout our own documentation, did not compile: each method had an `Expression<Func<…>>` overload alongside a `Func<…>` one, and an expression-bodied lambda converts to both (`CS0121`). The `Func` overloads now carry `[OverloadResolutionPriority(1)]`, so a lambda binds to them unambiguously (#180)


### PR DESCRIPTION
Implements #184.

Closes #184.

`.WithAdornment(...)` is accepted and silently discarded on any field inside a collection item form —
the imperative `CollectionFieldComponent` render path never emits the three adornment attributes the
declarative component path forwards. This PR closes that gap and adds a parity test so the next
presentation attribute that drifts between the two paths fails a test instead of surfacing years
later as a false positive in an unrelated feature (which is how this one was found, via #181/#183).

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

### Plan
- [x] Task 1: Forward the adornment attributes on the collection path
- [x] Task 2: Cover numeric and boolean item fields
- [x] Task 3: Lift the ShrinkLabel diagnostic suppression
- [x] Task 4: Parity test and release note

## Notes on the implementation

- **The forward is opt-in per component, not blanket.** The plan said to default `Adornment` to
  `Adornment.None` in `AddCommonFieldAttributes`. Measured first: `MudDatePicker` defaults to
  `Adornment.End` **with a calendar icon**, so a blanket forward would silently erase it on every
  date item field. `AddCommonFieldAttributes` now takes a `rendersAdornment` flag — true for
  `MudTextField`/`MudNumericField` (whose own default really is `None`), false for `MudDatePicker`.
  A regression test pins the calendar icon.
- **The diagnostic sees what each path *renders*, not what was configured.** `WarnIfShrinkLabelUnhonoured`
  now takes the rendered adornment, so #183's rule survives exactly where it is still true — the date
  path — and stops suppressing where it is not.
- **Callers resume from the index the helper returns** instead of a hardcoded offset. That also fixes
  a pre-existing collision: the helper already consumed sequence numbers 1–9 while its callers
  restarted at 2.

## Code review

A review pass over `dev...HEAD` raised 12 findings. Four were confirmed by probe and fixed here
(commit `fix: address code-review findings`); the rest are pre-existing or out of scope and are
listed below. One claim did **not** reproduce and is recorded as such.

**Fixed in this PR**

- Numeric forward created a *new* divergence (standalone numeric renders `Adornment.None`, collection now `End`). README no longer claims parity "like every other field".
- `Required` was in the parity test's compared set but never configured — a vacuous assertion over an attribute the two paths genuinely disagree on (`False` vs `True`). Removed, with the known divergences documented instead.
- README documented the visual change but not the **new console warning** this PR un-suppresses from #183.
- A comment claimed the adornment attributes were "emitted unconditionally" from inside an `if` guard.

**Advice adopted, but the alleged failure does not reproduce**

The review argued that computing `RenderTreeBuilder` sequence numbers (`return startIndex` → caller
resumes) would mis-diff rows on reorder. Sequence numbers are now source-position literals
(`CommonAttributeStart` / `CallerAttributeStart`), which is Blazor's actual contract — but the concrete
symptom was tested rather than assumed: `Reordering_A_Mixed_Item_Form_Should_Move_Values_With_Their_Rows`
reorders a mixed string+DateTime item form and values track their rows correctly.

## Follow-ups

- 🔴 **`.AsPassword()` inside a collection renders `InputType=Text`** — measured: standalone `Password`, collection `Text`. A password is shown in clear text inside a collection row. Pre-existing, not introduced here, and the most serious thing the review turned up.
- **`Required` diverges between the two paths** — the collection path emits it, no component-path renderer does. This contradicts the repo's own documented convention (`Required()` adds validation but not the HTML5 attribute), and inside a collection MudBlazor's native required validation fires alongside FluentValidation.
- **Standalone numeric fields render no adornments at all**, so a numeric field configured via raw `.WithAttribute("Adornment", …)` now renders differently inside vs outside a collection.
- **Adornments on date item fields** — supporting them means letting a configured adornment override `MudDatePicker`'s default without erasing it when unset.
- **`WithAdornment`'s `onClick` parameter is dead** — accepted, XML-documented as "Optional click handler", never written to any attribute on either path.
- **`WithAdornment` is declared on `FieldBuilder<TModel, string>` only**, so numeric fields need raw `.WithAttribute(...)`. A typed overload would close that gap.
- **`OnAdornmentClick` is component-path-only**, as the issue's non-goals state.
- **`RenderBooleanField` bypasses `AddCommonFieldAttributes` entirely** — `MudCheckBox` does have a `Required` parameter and never receives it; a fourth un-consolidated render branch.
- **Attribute-resolution duplication** — `GetItemFieldAttribute<T>` mirrors `FieldComponentBase.GetAttribute<T>`, and `GetItemFieldVariant` / `GetItemFieldShrinkLabel` still open-code the same lookup.
- **Collection test-model duplication** — `OrderModel`/`OrderItem` now exist in four test files; a shared `CollectionTestModels` + one `RenderOrderForm` helper would cover them.
- `.gitignore:13` reads `/test-results/.claude/worktrees/` — two entries collapsed onto one line, so **neither** `/test-results/` nor `.claude/worktrees/` is actually ignored.
- This repo has no `.claude/skills/repo-profile.md`. One was generated locally for this run (it is what the issue/PR lifecycle skills read) but deliberately left **uncommitted** to keep this PR scoped.


