### PR TITLE
fix(mudblazor): stop emitting the HTML5 Required attribute on collection item fields (#190)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -405,7 +405,8 @@ public class RenderPipelineParityTests : MudBlazorTestBase
                 .WithPlaceholder("e.g. Widget")
                 .WithHelpText("The catalogue name")
                 .WithAdornment(Icons.Material.Filled.Search, Adornment.Start, Color.Secondary)
-                .WithVariant(Variant.Filled);
+                .WithVariant(Variant.Filled)
+                .Required("Product name is required");
 
         var standaloneConfig = FormBuilder<TestModel>
             .Create()
@@ -435,18 +436,31 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         // Guard the guard: a comparison of two all-default fields would pass while proving nothing.
         standalone.Adornment.ShouldBe(Adornment.Start);
         standalone.Variant.ShouldBe(Variant.Filled);
+
+        // Required is the one compared attribute whose agreed value IS the default (#190): both
+        // paths must render false for a .Required(...) field, because validation here is
+        // server-side. So unlike the others it cannot be guarded by asserting a non-default —
+        // its bite comes from the collection path, which used to render true off field.IsRequired
+        // and would diverge from this standalone false the moment that emission came back.
+        standalone.Required.ShouldBeFalse();
     }
 
     /// <summary>
     /// The presentation attributes both render paths are expected to honour identically, and which
     /// the test above actually configures. Add to this list whenever a field component gains one.
     /// <para>
+    /// <c>Required</c> joined the set in #190: both paths must render it <c>false</c> even for a
+    /// <c>.Required(...)</c> field, because validation is server-side and forms render
+    /// <c>novalidate</c>. It was previously listed as a known divergence while the test never
+    /// configured it — so the comparison passed vacuously over a real disagreement, which is the
+    /// trap the list below warns about.
+    /// </para>
+    /// <para>
     /// Deliberately NOT compared, because the two paths are known to disagree today — each is
     /// tracked separately, and listing one here without configuring it would assert nothing while
     /// looking like coverage:
     /// </para>
     /// <list type="bullet">
-    /// <item><c>Required</c> — the collection path emits it, no component-path renderer does.</item>
     /// <item><c>InputType</c>, <c>Lines</c>, <c>MaxLength</c>, <c>Autocomplete</c> — component path
     /// only; a <c>.AsPassword()</c> item field still renders as plain text inside a collection.</item>
     /// <item><c>OnAdornmentClick</c> — component path only (an explicit non-goal of #184).</item>
@@ -457,6 +471,7 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         field.Label,
         field.Placeholder,
         field.HelperText,
+        field.Required,
         field.Variant,
         field.Margin,
         field.ShrinkLabel,

--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -461,6 +461,10 @@ public class RenderPipelineParityTests : MudBlazorTestBase
     /// looking like coverage:
     /// </para>
     /// <list type="bullet">
+    /// <item>The raw <c>"Required"</c> attribute — collection path only. <c>.Required(...)</c> is
+    /// compared above and agrees, but <c>.WithAttribute("Required", true)</c> is read solely by
+    /// <c>CollectionFieldComponent</c>; no component-path renderer looks for that key, so the
+    /// opt-in is honoured inside an item form and ignored outside one.</item>
     /// <item><c>InputType</c>, <c>Lines</c>, <c>MaxLength</c>, <c>Autocomplete</c> — component path
     /// only; a <c>.AsPassword()</c> item field still renders as plain text inside a collection.</item>
     /// <item><c>OnAdornmentClick</c> — component path only (an explicit non-goal of #184).</item>

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -2,8 +2,10 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 
 /// <summary>
 /// Tests that collection item fields do NOT carry the HTML5 <c>Required</c> attribute (#190).
-/// The project's validation convention is server-side only — forms render <c>novalidate</c>, messages
-/// come from the validator, and no component-path renderer emits <c>Required</c>. The collection
+/// The project's validation convention is server-side only — messages come from the validator, no
+/// component-path renderer emits <c>Required</c>, and the form is marked <c>novalidate</c> (on a
+/// best-effort basis: it is applied by script to the first form in the document after the first
+/// render, so it is not a guarantee the rendered attribute can rely on). The collection
 /// path drove it from <c>field.IsRequired</c>, so the same <c>.Required("…")</c> call put
 /// <c>required</c> and <c>aria-required="true"</c> on the input inside <c>.WithItemForm(...)</c> and
 /// neither outside it.
@@ -40,8 +42,13 @@ public class CollectionRequiredTests : MudBlazorTestBase
         var component = RenderOrderForm(BuildConfiguration(field => field
             .WithAttribute("Required", true)));
 
-        // Assert
-        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+        // Assert - the property, and that it actually reaches the DOM. Asserting only the property
+        // would stay green if a future change stopped it reaching the input, and this test is the
+        // opt-in's only guard.
+        var textField = component.FindComponent<MudTextField<string>>();
+        textField.Instance.Required.ShouldBeTrue();
+        textField.Find("input").HasAttribute("required").ShouldBeTrue();
+        component.FindAll(".mud-input-required").Count.ShouldBe(1);
     }
 
     [Fact]
@@ -57,8 +64,8 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void Required_NumericItemField_Should_Not_Render_The_Html5_Required_Attribute()
     {
-        // Arrange - AddCommonFieldAttributes is shared by the text and numeric paths, so the numeric
-        // one must lose the forward too rather than being fixed only where it was measured.
+        // Arrange - AddCommonFieldAttributes feeds three renderers (text, numeric and date), so the
+        // numeric one must lose the forward too rather than being fixed only where it was measured.
         var config = FormBuilder<BasketModel>
             .Create()
             .AddCollectionField(x => x.Lines, collection => collection
@@ -87,10 +94,101 @@ public class CollectionRequiredTests : MudBlazorTestBase
         var component = RenderOrderForm(BuildConfiguration(field => field
             .Required("Product name is required")));
 
-        // Assert
-        var input = component.FindAll("input")[0];
+        // Assert - anchored to the field under test, not to whichever input happens to be first
+        var input = component.FindComponent<MudTextField<string>>().Find("input");
         input.HasAttribute("required").ShouldBeFalse();
-        input.GetAttribute("aria-required").ShouldBe("false");
+        input.GetAttribute("aria-required").ShouldNotBe("true");
+    }
+
+    [Fact]
+    public void Required_ItemField_Should_Not_Render_MudBlazors_Required_Asterisk()
+    {
+        // Arrange & Act - the asterisk is a CSS ::after on .mud-input-required, which MudBlazor adds
+        // only when Required is true. A markup search for "*" cannot see it, so the CLASS is the
+        // measurable proxy. This is the user-visible half of the change: a required item field now
+        // looks exactly like a required ordinary field, which never carried one.
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .Required("Product name is required")));
+
+        // Assert
+        component.FindAll(".mud-input-required").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void DateItemField_Should_Not_Render_The_Html5_Required_Attribute()
+    {
+        // Arrange - MudDatePicker is the THIRD renderer fed by AddCommonFieldAttributes, and it
+        // derives from MudFormComponent too, so it took the same forward. Its sibling suite covers
+        // the date path for adornments (#184); this keeps that parity for Required.
+        var config = FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field => field
+                        .WithLabel("When")
+                        .Required("When is required"))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
+            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeFalse();
+        component.FindAll(".mud-input-required").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void DateItemField_Should_Honour_An_Explicit_Required_Attribute()
+    {
+        // Arrange - the opt-in has to reach the date path too, or the escape hatch is text/numeric
+        // only while the README promises it for item fields generally.
+        var config = FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field => field
+                        .WithLabel("When")
+                        .WithAttribute("Required", true))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
+            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BooleanItemField_With_An_Explicit_Required_Attribute_Should_Be_Inert()
+    {
+        // Arrange - RenderBooleanField sets its own attributes and never calls
+        // AddCommonFieldAttributes, so the opt-in is silently inert here. Pinned rather than fixed,
+        // exactly as CollectionAdornmentTests pins the same inertness for adornments (#184): the
+        // point is that configuring it is harmless, not that it works.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.IsGift, field => field
+                        .WithLabel("Gift")
+                        .WithAttribute("Required", true))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert - renders, does not throw, and takes no notice of the attribute
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
+        component.FindAll(".mud-input-required").ShouldBeEmpty();
     }
 
     [Fact]
@@ -137,9 +235,13 @@ public class CollectionRequiredTests : MudBlazorTestBase
         // Act
         await component.InvokeAsync(() => component.Instance.ValidateAsync());
 
-        // Assert - FieldValidationMessage renders one MudText per error for the field
+        // Assert - scoped to the FieldValidationMessage bound to Items[0].ProductName, not to every
+        // error-coloured MudText in the form: a second item field, or any unrelated error text,
+        // would otherwise move this count for a reason that has nothing to do with duplication.
         component.WaitForAssertion(() =>
-            component.FindComponents<MudText>()
+            component.FindComponents<FieldValidationMessage>()
+                .Single(m => m.Instance.FieldName == "Items[0].ProductName")
+                .FindComponents<MudText>()
                 .Count(t => t.Instance.Color == Color.Error)
                 .ShouldBe(1));
 
@@ -193,5 +295,17 @@ public class CollectionRequiredTests : MudBlazorTestBase
     private class BasketLine
     {
         public int Quantity { get; set; }
+
+        public bool IsGift { get; set; }
+    }
+
+    private class AppointmentModel
+    {
+        public List<AppointmentSlot> Slots { get; set; } = new();
+    }
+
+    private class AppointmentSlot
+    {
+        public DateTime When { get; set; }
     }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -4,9 +4,16 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// Tests that collection item fields do NOT carry the HTML5 <c>Required</c> attribute (#190).
 /// The project's validation convention is server-side only — forms render <c>novalidate</c>, messages
 /// come from the validator, and no component-path renderer emits <c>Required</c>. The collection
-/// path drove it from <c>field.IsRequired</c>, so the same <c>.Required("…")</c> call rendered
-/// differently inside <c>.WithItemForm(...)</c>, and MudBlazor's own required validation ran
-/// alongside the configured one — two differently-worded messages for one problem.
+/// path drove it from <c>field.IsRequired</c>, so the same <c>.Required("…")</c> call put
+/// <c>required</c> and <c>aria-required="true"</c> on the input inside <c>.WithItemForm(...)</c> and
+/// neither outside it.
+/// <para>
+/// Measured while fixing #190: the attribute armed no second validator — item fields sit in no
+/// <c>MudForm</c> and carry no <c>For</c>, so MudBlazor's own required check never fired and the
+/// field surfaced one message either way. The defect is the contradicted convention and the
+/// accessibility semantics, not duplicate messages; the one-message test below pins the count so
+/// that stays true if item fields are ever wired into MudBlazor's validation.
+/// </para>
 /// <para>
 /// The attribute is now resolved from an explicit <c>"Required"</c> attribute instead, so a field
 /// that opts back in with <c>.WithAttribute("Required", true)</c> still gets it.
@@ -115,9 +122,11 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public async Task Blank_Required_ItemField_Should_Surface_Exactly_One_Message()
     {
-        // Arrange - MudBlazor's Required drives a second, differently-worded required check of its
-        // own. Emitting the attribute was the way that check could ever be armed for an item field,
-        // so this pins the count at one rather than merely asserting the right text is present.
+        // Arrange - MudBlazor's Required can drive a second, differently-worded required check of
+        // its own. It does not fire for item fields today (no MudForm, no For), and emitting the
+        // attribute was the only way it could ever be armed - so this pins the COUNT at one rather
+        // than merely asserting the right text is present, and would catch the duplicate if that
+        // wiring ever changed.
         var model = new OrderModel { Items = { new OrderItem() } };
 
         var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -71,6 +71,75 @@ public class CollectionRequiredTests : MudBlazorTestBase
         component.FindComponent<MudNumericField<int>>().Instance.Required.ShouldBeFalse();
     }
 
+    [Fact]
+    public void Required_ItemField_Should_Not_Put_The_Required_Attribute_On_The_Input_Element()
+    {
+        // Arrange & Act - the component property is the cause; this is the effect the convention
+        // actually names ("Required() adds validation but NOT the HTML5 required attribute").
+        // Measured before the fix: the input carried required="" and aria-required="true".
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .Required("Product name is required")));
+
+        // Assert
+        var input = component.FindAll("input")[0];
+        input.HasAttribute("required").ShouldBeFalse();
+        input.GetAttribute("aria-required").ShouldBe("false");
+    }
+
+    [Fact]
+    public async Task Blank_Required_ItemField_Should_Still_Fail_Validation_With_The_Configured_Message()
+    {
+        // Arrange - dropping the attribute must not drop the validation it never drove.
+        var model = new OrderModel { Items = { new OrderItem() } };
+        EditContext? editContext = null;
+
+        var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, BuildConfiguration(field => field
+                .Required("Product name is required")))
+            .Add(p => p.OnEditContextCreated, ctx => editContext = ctx));
+
+        // Act
+        var isValid = true;
+        await component.InvokeAsync(async () => isValid = await component.Instance.ValidateAsync());
+
+        // Assert - the developer's own wording, on the nested identifier, and in the markup
+        isValid.ShouldBeFalse();
+        editContext.ShouldNotBeNull();
+        editContext!.GetValidationMessages(new FieldIdentifier(model, "Items[0].ProductName"))
+            .ShouldContain("Product name is required");
+        component.WaitForAssertion(() =>
+            component.Markup.ShouldContain("Product name is required"));
+    }
+
+    [Fact]
+    public async Task Blank_Required_ItemField_Should_Surface_Exactly_One_Message()
+    {
+        // Arrange - MudBlazor's Required drives a second, differently-worded required check of its
+        // own. Emitting the attribute was the way that check could ever be armed for an item field,
+        // so this pins the count at one rather than merely asserting the right text is present.
+        var model = new OrderModel { Items = { new OrderItem() } };
+
+        var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, BuildConfiguration(field => field
+                .Required("Product name is required"))));
+
+        // Act
+        await component.InvokeAsync(() => component.Instance.ValidateAsync());
+
+        // Assert - FieldValidationMessage renders one MudText per error for the field
+        component.WaitForAssertion(() =>
+            component.FindComponents<MudText>()
+                .Count(t => t.Instance.Color == Color.Error)
+                .ShouldBe(1));
+
+        // ...and MudBlazor's own error slot stays empty, so nothing is queued behind it
+        var textField = component.FindComponent<MudTextField<string>>().Instance;
+        textField.Error.ShouldBeFalse();
+        textField.ErrorText.ShouldBeNullOrEmpty();
+    }
+
     private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
         IFormConfiguration<OrderModel> config)
     {

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -1,0 +1,119 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that collection item fields do NOT carry the HTML5 <c>Required</c> attribute (#190).
+/// The project's validation convention is server-side only — forms render <c>novalidate</c>, messages
+/// come from the validator, and no component-path renderer emits <c>Required</c>. The collection
+/// path drove it from <c>field.IsRequired</c>, so the same <c>.Required("…")</c> call rendered
+/// differently inside <c>.WithItemForm(...)</c>, and MudBlazor's own required validation ran
+/// alongside the configured one — two differently-worded messages for one problem.
+/// <para>
+/// The attribute is now resolved from an explicit <c>"Required"</c> attribute instead, so a field
+/// that opts back in with <c>.WithAttribute("Required", true)</c> still gets it.
+/// </para>
+/// </summary>
+public class CollectionRequiredTests : MudBlazorTestBase
+{
+    [Fact]
+    public void Required_ItemField_Should_Not_Render_The_Html5_Required_Attribute()
+    {
+        // Arrange & Act - the same .Required(...) call a standalone field would use
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .Required("Product name is required")));
+
+        // Assert - validation still runs (see the EditContext tests); the attribute does not
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ItemField_Should_Honour_An_Explicit_Required_Attribute()
+    {
+        // Arrange & Act - the escape hatch: dropping the IsRequired forward must not also drop the
+        // ability to ask for MudBlazor's asterisk deliberately.
+        var component = RenderOrderForm(BuildConfiguration(field => field
+            .WithAttribute("Required", true)));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ItemField_Without_Any_Required_Configuration_Should_Not_Render_It()
+    {
+        // Arrange & Act - unchanged from before #190
+        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Required_NumericItemField_Should_Not_Render_The_Html5_Required_Attribute()
+    {
+        // Arrange - AddCommonFieldAttributes is shared by the text and numeric paths, so the numeric
+        // one must lose the forward too rather than being fixed only where it was measured.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field
+                        .WithLabel("Quantity")
+                        .Required("Quantity is required"))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Required.ShouldBeFalse();
+    }
+
+    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
+        IFormConfiguration<OrderModel> config)
+    {
+        var model = new OrderModel { Items = { new OrderItem() } };
+
+        return Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+    }
+
+    private static IFormConfiguration<OrderModel> BuildConfiguration(
+        Action<FieldBuilder<OrderItem, string>> configureItemField)
+    {
+        return FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field =>
+                    {
+                        field.WithLabel("Product");
+                        configureItemField(field);
+                    })))
+            .Build();
+    }
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+
+    private class BasketModel
+    {
+        public List<BasketLine> Lines { get; set; } = new();
+    }
+
+    private class BasketLine
+    {
+        public int Quantity { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -324,7 +324,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Label", field.Label);
         builder.AddAttribute(startIndex++, "Placeholder", field.Placeholder);
         builder.AddAttribute(startIndex++, "HelperText", field.HelpText);
-        builder.AddAttribute(startIndex++, "Required", field.IsRequired);
+        // Resolved from an explicit attribute, NOT from field.IsRequired (#190). The project's
+        // validation convention is server-side only — forms render novalidate and no component-path
+        // renderer emits Required — so driving it from IsRequired made a .Required("…") item field
+        // run MudBlazor's own required check alongside the configured validator, surfacing two
+        // differently-worded messages for one problem. Reading the attribute keeps the deliberate
+        // opt-in, .WithAttribute("Required", true), working.
+        builder.AddAttribute(startIndex++, "Required", GetItemFieldAttribute(field, "Required", false));
         builder.AddAttribute(startIndex++, "ReadOnly", field.IsReadOnly);
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);
         builder.AddAttribute(startIndex++, "Variant", GetItemFieldVariant(field));

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -325,12 +325,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Placeholder", field.Placeholder);
         builder.AddAttribute(startIndex++, "HelperText", field.HelpText);
         // Resolved from an explicit attribute, NOT from field.IsRequired (#190). Validation here is
-        // server-side — forms render novalidate, messages come from the configured validator, and no
-        // component-path renderer emits Required — so driving this from IsRequired put required and
-        // aria-required="true" on the rendered input of a .Required("…") item field while the same
-        // call on an ordinary field emitted neither. Measured: it armed no second validator (item
-        // fields have no MudForm and no For), so this is a convention and a11y-semantics fix, not a
-        // duplicate-message one. Reading the attribute keeps .WithAttribute("Required", true) working.
+        // server-side — messages come from the configured validator and no component-path renderer
+        // emits Required — so driving this from IsRequired put required and aria-required="true" on
+        // the rendered input of a .Required("…") item field, and MudBlazor's required asterisk with
+        // them, while the same call on an ordinary field produced none of it. Measured: it armed no
+        // second validator (item fields have no MudForm and no For), so what this restores is
+        // consistency and what it costs is the asterisk — see the release note.
+        // Reading the attribute keeps .WithAttribute("Required", true) working as the opt-in.
         builder.AddAttribute(startIndex++, "Required", GetItemFieldAttribute(field, "Required", false));
         builder.AddAttribute(startIndex++, "ReadOnly", field.IsReadOnly);
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -324,12 +324,13 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex++, "Label", field.Label);
         builder.AddAttribute(startIndex++, "Placeholder", field.Placeholder);
         builder.AddAttribute(startIndex++, "HelperText", field.HelpText);
-        // Resolved from an explicit attribute, NOT from field.IsRequired (#190). The project's
-        // validation convention is server-side only — forms render novalidate and no component-path
-        // renderer emits Required — so driving it from IsRequired made a .Required("…") item field
-        // run MudBlazor's own required check alongside the configured validator, surfacing two
-        // differently-worded messages for one problem. Reading the attribute keeps the deliberate
-        // opt-in, .WithAttribute("Required", true), working.
+        // Resolved from an explicit attribute, NOT from field.IsRequired (#190). Validation here is
+        // server-side — forms render novalidate, messages come from the configured validator, and no
+        // component-path renderer emits Required — so driving this from IsRequired put required and
+        // aria-required="true" on the rendered input of a .Required("…") item field while the same
+        // call on an ordinary field emitted neither. Measured: it armed no second validator (item
+        // fields have no MudForm and no For), so this is a convention and a11y-semantics fix, not a
+        // duplicate-message one. Reading the attribute keeps .WithAttribute("Required", true) working.
         builder.AddAttribute(startIndex++, "Required", GetItemFieldAttribute(field, "Required", false));
         builder.AddAttribute(startIndex++, "ReadOnly", field.IsReadOnly);
         builder.AddAttribute(startIndex++, "Disabled", field.IsDisabled);

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **Collection item fields no longer carry the HTML5 `Required` attribute.** `.Required("…")` inside `.WithItemForm(...)` set `Required="true"` on the underlying MudBlazor component, so the rendered `<input>` came out with `required` and `aria-required="true"` — while the identical call on an ordinary field did not. That contradicted the library's validation stance: validation is server-side, forms render `novalidate`, and messages come from the validator you configured. Item fields now match ordinary fields (#190)
+
+  ```csharp
+  .AddCollectionField(x => x.Items, c => c.WithItemForm(item => item
+      .AddField(x => x.ProductName, f => f
+          .WithLabel("Product")
+          .Required("Product name is required"))))   // ← validates; no HTML5 required attribute
+  ```
+
+  **Validation is unchanged.** `.Required(...)` still registers its validator, a blank item field still fails validation, and the message is still the one you passed. What changes is only the attribute on the element — and with it `aria-required`, which now reports `false` on these fields as it already did on ordinary ones.
+
+  **Opting back in.** `.WithAttribute("Required", true)` on an item field still renders `Required="true"`, so a form that deliberately wants MudBlazor's native required semantics keeps them. The attribute is now read from that explicit opt-in rather than inferred from `.Required(...)`.
+
 - **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` (#184)
 
   ```csharp

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
           .Required("Product name is required"))))   // ← validates; no HTML5 required attribute
   ```
 
-  **Validation is unchanged.** `.Required(...)` still registers its validator, a blank item field still fails validation, and the message is still the one you passed. What changes is only the attribute on the element — and with it `aria-required`, which now reports `false` on these fields as it already did on ordinary ones.
+  **Validation is unchanged.** `.Required(...)` still registers its validator, a blank item field still fails validation, and the message is still the one you passed.
 
-  **Opting back in.** `.WithAttribute("Required", true)` on an item field still renders `Required="true"`, so a form that deliberately wants MudBlazor's native required semantics keeps them. The attribute is now read from that explicit opt-in rather than inferred from `.Required(...)`.
+  **⚠️ This is a visible change, not just an attribute change.** MudBlazor draws the required asterisk from a CSS rule on the `mud-input-required` class, which it only adds when `Required="true"`. So text, numeric **and date** item fields configured with `.Required(...)` lose their `*` — they now look exactly like ordinary `.Required(...)` fields, which never had one. `aria-required` likewise reports `false` on these fields as it already did on ordinary ones; identifying required fields to assistive technology is a gap the library has on **both** render paths, tracked separately rather than fixed on one side here.
+
+  **Opting back in.** `.WithAttribute("Required", true)` on a text, numeric or date item field renders `Required="true"` again, restoring both the asterisk and MudBlazor's native required semantics. The attribute is now read from that explicit opt-in rather than inferred from `.Required(...)`. Two limits worth knowing: the opt-in is **collection-only** (an ordinary field ignores a raw `"Required"` attribute — use `.Required(...)` there), and it is **inert on boolean item fields**, which render through a path that takes none of these shared attributes.
 
 - **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` (#184)
 


### PR DESCRIPTION
Implements #190.

Closes #190.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

### Plan
- [x] Task 1: Stop driving `Required` from `IsRequired` on the collection path
- [x] Task 2: Prove validation still works, and only once
- [x] Task 3: Fold `Required` into the parity test and release-note it

### Verification notes

**The fix and its justification hold, but one claim in the issue did not survive measurement — flagging it so the release note isn't read as promising more than it delivers.**

The issue's *Consequence* paragraph says a blank required item field "can produce two error messages with different wording". I could not reproduce that. Probing a blank `.Required("…")` item field both with and without the attribute — via `ValidateAsync()`, and again after typing-then-clearing-then-blurring to mark the field touched — MudBlazor's own required check never fired in either state: `Error=False`, `ErrorText=''`, and exactly **one** message in the markup both before and after. Item fields aren't wired to a `MudForm` and carry no `For`, so `Required` arms no second validator here.

What the attribute *did* change is exactly what the issue's **title** says, and it is real, measured at the DOM:

| | `<input>` attributes |
|---|---|
| before | `required=""` · `aria-required="true"` |
| after | *(no `required`)* · `aria-required="false"` |

So this lands as a **convention + consistency** fix, not a duplicate-message fix. That is still the documented rule (`Required()` adds validation but not the HTML5 attribute), and the parity divergence was genuine.

**⚠️ Correction — the asterisk IS removed.** An earlier revision of this PR claimed nothing visual changed, on the strength of finding zero `*` characters in the markup. That was wrong, and it is the same mistake this PR's own commit history corrects elsewhere: searching a *rendering* instead of measuring the *effect*. MudBlazor draws the asterisk from a CSS rule — `.mud-input-required > … > .mud-input-label::after { content: "*" }` — so it never appears in markup as a character. Measuring the **class** instead: `.mud-input-required` is present with `Required=true` and absent without. Text, numeric **and date** item fields configured with `.Required(...)` therefore lose their asterisk. The release note now says so plainly, and `Required_ItemField_Should_Not_Render_MudBlazors_Required_Asterisk` pins it. Credit to the review for catching it.

`Blank_Required_ItemField_Should_Surface_Exactly_One_Message` is kept deliberately: it pins the count at one, so if item fields are ever wired into MudBlazor's validation the second message shows up as a test failure rather than a bug report.

The parity guard was verified to **bite**, not merely to pass: temporarily restoring the `field.IsRequired` emission turns **8 tests** red — the parity test plus 7 dedicated ones — then it was restored. `BooleanItemField_With_An_Explicit_Required_Attribute_Should_Be_Inert` deliberately does **not** bite; it pins inertness, exactly as its sibling in `CollectionAdornmentTests` does for adornments.

### Code review

Reviewed over the whole branch (`origin/dev...HEAD`) at high effort; 12 findings, triaged and **8 fixed in `fix: address code-review findings`**:

- the asterisk regression above (the most consequential — it made the release note actively misleading);
- the **date** render path was affected and untested — `AddCommonFieldAttributes` feeds *three* renderers, not the two my test comment claimed. Added two date tests; both bite;
- `.WithAttribute("Required", true)` is **inert on boolean item fields** (`RenderBooleanField` takes none of the shared attributes) — pinned and documented;
- the opt-in is **collection-only**: no component-path renderer reads a raw `"Required"` key, so the PR closed one divergence and opened another. Now listed in the parity test's divergence block and in the release note;
- `Blank_Required_ItemField_Should_Surface_Exactly_One_Message` counted error-coloured `MudText` across the **whole form** — rescoped to the `FieldValidationMessage` bound to `Items[0].ProductName`;
- DOM assertions picked their element positionally (`FindAll("input")[0]`) — anchored to the component under test, and `aria-required` loosened from `ShouldBe("false")` to `ShouldNotBe("true")` so a future MudBlazor that omits the attribute fails for the right reason;
- the opt-in test asserted only the component property — now asserts it reaches the DOM;
- `novalidate` is applied by script to the **first form in the document** after first render, so it is best-effort, not a guarantee. Statements that asserted it flatly are now qualified.

## Follow-ups

Real, out of scope here, deliberately not smuggled in:

1. **Required fields are not identified to assistive technology on either render path.** After this change a `.Required(...)` field reports `aria-required="false"` while its validator does reject a blank value, and with the asterisk gone there is no remaining required indicator in any modality. This is library-wide, not collection-specific — fixing it on one path only would re-open the divergence this PR closes. WCAG 3.3.2.
2. **Converge the two render paths.** `CollectionFieldComponent` injects `IFieldRendererService` and never calls it, hand-rolling field rendering with a `RenderTreeBuilder` instead. `Variant` (#146), `ShrinkLabel` (#177), adornments (#184) and now `Required` (#190) are one defect found four times, each fixed by adding another attribute to `AddCommonFieldAttributes`; the divergence list still names five more queued behind them.
3. **A typed builder method for the required opt-in.** `.WithAttribute("Required", true)` is a magic string in a bag that already mixes PascalCase MudBlazor keys with lowercase HTML-ish ones, so `.WithAttribute("required", true)` fails silently. Every sibling has one (`WithVariant`, `WithShrinkLabel`, `WithAdornment`).
4. **A shared collection-item test fixture.** `CollectionRequiredTests` and `CollectionAdornmentTests` duplicate their helpers and model classes; the next attribute test would be a third copy.
5. **`novalidate` robustness** — `document.querySelector('form')` targets the first form on the page, not this component's, and never runs during prerender.

