### PR TITLE
chore: restore the newline that merged two .gitignore entries into one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ riderModule.iml
 
 # Build artifacts
 /artifacts/
-/test-results/.claude/worktrees/
+/test-results/
+
+# Agent worktrees
+.claude/worktrees/


### PR DESCRIPTION
`.gitignore:13` read:

```
/test-results/.claude/worktrees/
```

That is **one** path, and it matches nothing. A missing newline had joined two entries, so neither `/test-results/` nor `.claude/worktrees/` was ignored — agent worktrees showed as untracked in every `git status` of this repo, one `git add -A` away from being committed into it.

Found while preparing a worktree for #216.

## Verification

```
$ git check-ignore -v .claude/worktrees/ test-results/
.gitignore:16:.claude/worktrees/   .claude/worktrees/
.gitignore:13:/test-results/       test-results/
```

Before the fix both paths returned nothing. `git status` in a clone with agent worktrees present is now clean.

No code touched.