### PR TITLE
fix(mudblazor): render a handler-less adornment as a plain icon, not a button (#216)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -659,13 +659,14 @@ public class RenderPipelineParityTests : MudBlazorTestBase
     /// which asserts each path actually invokes the configured handler.
     /// </para>
     /// <para>
-    /// That parity holds when a handler IS configured. Without one the paths still differ in
-    /// MARKUP, though not in behaviour: <c>MudBlazorTextFieldComponent.razor</c> binds
-    /// <c>OnAdornmentClick</c> unconditionally, so an ordinary field's adornment is always a
-    /// focusable <c>&lt;button&gt;</c> — inert, but in the tab order — while the collection path
-    /// emits an empty callback and MudBlazor draws a plain icon. Predates #192 on the component
-    /// side and is left alone rather than change an unrelated render path; both are click-inert,
-    /// which is what the two "…Without_A_Handler_Should_Stay_Inert" tests pin down.
+    /// The handler-less case used to diverge in MARKUP, though not in behaviour: the component path
+    /// bound <c>OnAdornmentClick</c> unconditionally, so an ordinary field's decorative adornment
+    /// was always a focusable <c>&lt;button&gt;</c> — inert, but in the tab order — while the
+    /// collection path emitted an empty callback and MudBlazor drew a plain icon. Closed in #216 by
+    /// making the component path's binding conditional too. Both paths now render a plain icon, each
+    /// pinned by its own test (<c>TextField_Adornment_Without_A_Handler_Should_Render_A_Plain_Icon</c>
+    /// and <c>ItemField_Adornment_Without_A_Handler_Should_Stay_Inert</c>), so a regression on either
+    /// side fails on its own rather than only as a parity mismatch.
     /// </para>
     /// </summary>
     private static object?[] Presentation(MudTextField<string> field) =>

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
@@ -316,9 +316,12 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
     }
 
     [Fact]
-    public void TextField_Adornment_Without_A_Handler_Should_Stay_Inert()
+    public void TextField_Adornment_Without_A_Handler_Should_Render_A_Plain_Icon()
     {
-        // Arrange - an adornment configured with no handler renders and clicks harmlessly
+        // Arrange - an adornment configured with no handler is decorative, so it must not be a
+        // focus stop. Before #216 this path bound OnAdornmentClick unconditionally, so MudBlazor
+        // drew a real <button>: inert to click, but in the tab order for keyboard and screen-reader
+        // users. The collection path has always drawn a plain icon here.
         var config = FormBuilder<TestModel>
             .Create()
             .AddField(x => x.Email, field => field
@@ -330,8 +333,12 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
             .Add(p => p.Model, new TestModel { Email = "someone@example.com" })
             .Add(p => p.Configuration, config));
 
-        // Act & Assert
-        Should.NotThrow(() => component.Find(AdornmentButton).Click());
+        // Assert - the adornment still renders; it just isn't clickable or focusable
+        var textField = component.FindComponent<MudTextField<string>>().Instance;
+        textField.Adornment.ShouldBe(Adornment.Start);
+        textField.AdornmentIcon.ShouldBe(Icons.Material.Filled.Email);
+        textField.OnAdornmentClick.HasDelegate.ShouldBeFalse();
+        component.FindAll(AdornmentButton).ShouldBeEmpty();
     }
 
     [Fact]
@@ -352,10 +359,10 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
             .Add(p => p.Model, new TestModel { Email = "someone@example.com" })
             .Add(p => p.Configuration, config));
 
-        // Act
-        component.Find(AdornmentButton).Click();
-
-        // Assert - the second call described a plain icon, so nothing runs
+        // Assert - the second call described a plain icon, so there is nothing left to click and
+        // the first handler cannot run. Before #216 a button survived the reconfiguration and this
+        // asserted the weaker "clicking it fires nothing"; no button at all is the stronger claim.
+        component.FindAll(AdornmentButton).ShouldBeEmpty();
         received.ShouldBeEmpty();
     }
 

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
@@ -19,7 +19,7 @@
     Adornment="@(Adornment ?? MudBlazor.Adornment.None)"
     AdornmentIcon="@AdornmentIcon"
     AdornmentColor="@AdornmentColor"
-    OnAdornmentClick="@HandleAdornmentClick"
+    OnAdornmentClick="@AdornmentClick"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
@@ -100,6 +102,22 @@ public partial class MudBlazorTextFieldComponent<TModel>
         AdornmentIcon = _passwordVisible ? Icons.Material.Filled.VisibilityOff : Icons.Material.Filled.Visibility;
         StateHasChanged();
     }
+
+    /// <summary>
+    /// The adornment click callback, or <c>default</c> when the field configured no handler (#216).
+    /// </summary>
+    /// <remarks>
+    /// Binding <see cref="HandleAdornmentClick"/> directly would hand MudBlazor a method group, whose
+    /// <c>EventCallback.HasDelegate</c> is always <c>true</c> — and MudBlazor draws a real
+    /// <c>&lt;button&gt;</c> for that. A decorative icon then becomes a focus stop for keyboard and
+    /// screen-reader users, even though clicking it does nothing. Returning <c>default</c> mirrors
+    /// <c>CollectionFieldComponent.BuildAdornmentClick</c>, which has always done this, and is what
+    /// closes the last markup divergence between the two render paths.
+    /// </remarks>
+    private EventCallback<MouseEventArgs> AdornmentClick =>
+        OnAdornmentClick is null
+            ? default
+            : EventCallback.Factory.Create<MouseEventArgs>(this, HandleAdornmentClick);
 
     private void HandleAdornmentClick()
     {

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **A decorative adornment no longer renders as a focusable button.** An adornment configured with `.WithAdornment(...)` and *no* `onClick` was drawn as a real `<button>` on ordinary fields — inert to click, but a stop in the tab order, so keyboard and screen-reader users landed on a control that does nothing. The component path bound its click callback unconditionally; the collection path never did, so the same configuration produced different markup inside and outside `.WithItemForm(...)`. Both now render a plain icon (#216)
+
+  **Worth knowing if you assert on markup.** A handler-less adornment no longer matches `button.mud-input-adornment-icon-button`. Adornments configured *with* a handler are unchanged — still a real button, still clickable.
+
 - **Password fields inside collection item forms were rendering in clear text. They now mask.** A field configured with `.AsPassword()` inside `.WithItemForm(...)` rendered as a plain-text input: the characters the user typed were displayed on screen. The identical call on an ordinary field masked correctly. The collection render path never emitted `InputType` at all, so nothing failed and nothing warned — the credential was simply visible (#189)
 
   ```csharp


### PR DESCRIPTION
Closes #216.

## Problem

`MudBlazorTextFieldComponent.razor` bound `OnAdornmentClick` to a **method group**:

```razor
OnAdornmentClick="@HandleAdornmentClick"
```

so `EventCallback.HasDelegate` was always `true`, and MudBlazor draws a real `<button>` for that. A
purely decorative adornment — `.WithAdornment(icon, position)` with no `onClick` — was therefore a
**stop in the tab order**: keyboard and screen-reader users focus a control that does nothing.

`CollectionFieldComponent.BuildAdornmentClick` has always returned `default` for the handler-less case,
so MudBlazor drew a plain icon there. Same configuration, different markup inside and outside
`.WithItemForm(...)`.

## Fix

The binding is now conditional, mirroring the collection path exactly:

```csharp
private EventCallback<MouseEventArgs> AdornmentClick =>
    OnAdornmentClick is null
        ? default
        : EventCallback.Factory.Create<MouseEventArgs>(this, HandleAdornmentClick);
```

Adornments configured **with** a handler are untouched — still a real button, still clickable.

## The two tests that pinned the bug

Worth calling out, because it's why this wasn't caught earlier: both existing handler-less tests called
`component.Find(AdornmentButton).Click()`, which **requires the button to exist**. They asserted the
adornment was click-*inert*, and in doing so froze the markup that made it focusable.

Both were rewritten to assert the button is **absent** — the stronger claim. In particular
`TextField_Adornment_Reconfigured_Without_A_Handler_Should_Not_Fire_The_Old_One` no longer asks whether
clicking runs a stale handler; it asserts there is nothing to click.

`RenderPipelineParityTests`' `Presentation()` XML doc described this divergence as accepted. That
paragraph now records it as closed, and points at the two per-path tests that keep it closed — a
regression on either side fails on its own rather than only as a parity mismatch.

## Verification

```
before the fix:  Failed: 2, Passed: 269   (exactly the two rewritten tests)
after the fix:   Failed: 0, Passed: 271   FormCraft.ForMudBlazor.UnitTests
                 Failed: 0, Passed: 748, Skipped: 1   FormCraft.UnitTests

dotnet build -c Release → Build succeeded. 0 Warning(s), 0 Error(s)
```

Full suite each time — this repo's test projects run on Microsoft.Testing.Platform, which silently
ignores `--filter`. Every other test passes unmodified.

## Why now

#216 was triaged as a **prerequisite** for #203 (converging the two render paths). #203 makes item
fields render through this component — which, unfixed, would have given *every* collection item field
the focusable inert button. Converging would have closed a parity gap by spreading the a11y defect
rather than removing it. Fixing this side first means #203 inherits the correct behaviour.

## Note

`README.md`'s `## 🎉 Unreleased` gains an entry, including the one thing a consumer could notice: a
handler-less adornment no longer matches `button.mud-input-adornment-icon-button`.
