### PR TITLE
ci(release): fail loudly when a created release cannot publish (#226)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,8 +94,8 @@ jobs:
     permissions:
       contents: write # upload the .nupkg files as release assets
       id-token: write # request the GitHub OIDC token for NuGet Trusted Publishing
-    # Job-level so the login step's own `if` can read it — a STEP-level env is NOT visible to that
-    # same step's `if` conditional.
+    # Feeds the login step's `user:` input below. Job-level rather than step-level so the name is
+    # declared once, next to the job that needs it.
     env:
       NUGET_USER: ${{ secrets.NUGET_USER }}
     steps:
@@ -117,9 +117,23 @@ jobs:
       # secret is stored. Nuke reads it from the NUGET_API_KEY environment variable exactly as
       # before, so build/Build.cs is unchanged — it neither knows nor cares that the key expires.
       # Kept adjacent to the run step below so the ~1h key cannot expire before it is used.
+      #
+      # Gated on `release_created` ONLY, and deliberately NOT on `env.NUGET_USER != ''` (#226).
+      # Those two guards fail in opposite directions. `release_created == false` means nothing was
+      # meant to publish, so skipping is correct. A missing NUGET_USER means a release WAS meant to
+      # publish and could not — and skipping there would leave the key output empty, gate Nuke's
+      # Publish off, and still report this run green, on a version whose tag, changelog and GitHub
+      # Release already exist. Silently released-but-unpublished is the worst outcome for a path
+      # exercised a handful of times a year, so a missing secret must fail this step instead.
+      # The dry-run ergonomics a NUGET_USER guard would buy are already bought by `release_created`,
+      # which is false on every workflow_dispatch that has no merged release PR to finish.
+      # Failing after the tag exists is safe: Publish uses --skip-duplicate (EnableSkipDuplicate in
+      # build/Build.cs), so re-running this job once the secret is restored is idempotent.
+      # ⛔ Do not "simplify" the NUGET_USER clause back in — pinned by
+      # TrustedPublishingWorkflowTests.ReleaseWorkflow_Should_Not_Gate_The_Login_On_The_NuGetUser_Secret.
       - name: NuGet login (OIDC -> short-lived key)
         id: login
-        if: ${{ needs.release-please.outputs.release_created == 'true' && env.NUGET_USER != '' }}
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ env.NUGET_USER }}

--- a/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
+++ b/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
@@ -70,6 +70,22 @@ public class TrustedPublishingWorkflowTests
         return string.Join('\n', lines[start..end]);
     }
 
+    /// <summary>
+    /// The <c>if:</c> expression of a single step, so a claim about what a step is *gated on* cannot
+    /// be satisfied — or contradicted — by the same name appearing in its <c>with:</c> block. #226
+    /// turns entirely on that distinction: the login step legitimately *reads* <c>NUGET_USER</c>,
+    /// and only *gating* on it is the defect.
+    /// </summary>
+    private static string StepCondition(string workflowFile, string stepId)
+    {
+        var condition = StepWithId(workflowFile, stepId)
+            .Split('\n')
+            .FirstOrDefault(l => l.TrimStart().StartsWith("if:", StringComparison.Ordinal));
+
+        condition.ShouldNotBeNull($"the `{stepId}` step of {workflowFile} no longer has an `if:` condition");
+        return condition;
+    }
+
     [Fact]
     public void ReleaseWorkflow_Should_Request_The_OidcToken()
     {
@@ -98,6 +114,24 @@ public class TrustedPublishingWorkflowTests
         // Scoped to the login step: the same condition on an unrelated step would leave a real
         // nuget.org key minted on runs that publish nothing.
         StepWithId("release-please.yml", "login").ShouldContain("release_created");
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_Should_Not_Gate_The_Login_On_The_NuGetUser_Secret()
+    {
+        // #226. A guard on the *trigger* and a guard on a *secret* fail in opposite directions.
+        // `release_created == false` means nothing was meant to publish, so a skip is correct.
+        // An empty NUGET_USER means a release *was* meant to publish and could not — and skipping
+        // the login there leaves steps.login.outputs.NUGET_API_KEY empty, which gates Nuke's
+        // Publish off while release-please has already cut the tag, the changelog and the GitHub
+        // Release. The run is then GREEN on a version that never reached nuget.org, on a path this
+        // repo exercises a handful of times a year. So the secret must fail the job, not skip it.
+        //
+        // Asserted on the `if:` alone: `with: user: ${{ env.NUGET_USER }}` is the legitimate read.
+        var condition = StepCondition("release-please.yml", "login");
+
+        condition.ShouldContain("release_created");
+        condition.ShouldNotContain("NUGET_USER");
     }
 
     [Fact]


### PR DESCRIPTION
Implements #226.

Closes #226.

**Decision (plan Task 1 / Step 1): approach A — drop `&& env.NUGET_USER != ''` from the login step's
`if:`.** Full reasoning [on the issue](https://github.com/phmatray/FormCraft/issues/226#issuecomment-5259388439).

A guard on the *trigger* and a guard on a *secret* fail in opposite directions. `release_created ==
false` means nothing was meant to publish, so a skip is correct. An empty `NUGET_USER` means a
release *was* meant to publish and could not — and skipping there left `steps.login.outputs.NUGET_API_KEY`
empty, gated Nuke's `Publish` off, and still reported the run **green**, on a version whose tag,
changelog and GitHub Release release-please had already created. That is a released-but-unpublished
version with nothing anywhere reporting it, on a path exercised a handful of times a year.

The dry-run ergonomics the clause bought are already bought by `release_created`, which is false on
every `workflow_dispatch` with no merged release PR to finish. Failing *after* the tag exists is safe
and recoverable: `Publish` runs with `--skip-duplicate` (`EnableSkipDuplicate()` in `build/Build.cs`),
so re-running the job once the secret is restored publishes the same version idempotently.

### Plan
- [x] Task 1: Record the decision, then encode it

### Changes
- `.github/workflows/release-please.yml` — login step gated on `release_created` only, with a comment
  recording *why* the secret clause is absent so it is not "simplified" back in.
- `FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs` — new
  `ReleaseWorkflow_Should_Not_Gate_The_Login_On_The_NuGetUser_Secret`, plus a `StepCondition(...)`
  helper that scopes the assertion to the step's `if:` alone. That scoping is the point: the step
  still legitimately *reads* `NUGET_USER` in its `with:`, and only *gating* on it is the defect — a
  whole-step assertion could not tell those apart.

Verified red before green: the new test failed against the old condition, and the full suite is
green after the change (1028 tests, 0 warnings under `TreatWarningsAsErrors`).

### Follow-ups
- A post-publish probe of the **nuget.org index** (approach B) catches a missed publish from *any*
  cause, not just a missing secret, and would cover both package ids. Deliberately not done here —
  #198's Task 4 already owns end-to-end publish verification, and duplicating it in this narrow PR
  would put two half-checks in the tree.
