### PR TITLE
fix(mudblazor): keep a password field masked when it also configures multiple lines (#207)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -405,9 +405,13 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         //   start adornment below with its own eye icon, failing this test for a reason it does not
         //   exist to test.
         // - Lines stays at its default 1, and is covered by the multiline test below instead.
-        //   MudBlazor renders a <textarea> once Lines > 1, and a textarea has no `type` attribute —
-        //   so combining Lines with AsPassword would make InputType inert and this test's headline
-        //   masking assertion vacuous: it would compare a parameter that changes nothing.
+        //   MudBlazor renders a <textarea> once Lines > 1, and a textarea has no `type` attribute.
+        //   Until #207 that made the combination genuinely unsafe to assert here: InputType went
+        //   inert and this test's headline masking assertion became vacuous, comparing a parameter
+        //   that changed nothing. That is no longer why Lines is excluded — the combination is now
+        //   defined behaviour (masking wins, the field renders on one line) and is asserted by
+        //   PasswordCollectionItemField_... below. Lines stays out of THIS field only because a
+        //   password field always renders Lines=1, so putting it here would compare a constant.
         static void Configure<TOwner>(FieldBuilder<TOwner, string> field)
             where TOwner : new()
             => field
@@ -617,6 +621,56 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         standaloneRender.FindAll("textarea").Count.ShouldBe(1);
         itemRender.FindAll("textarea").Count.ShouldBe(1);
         standaloneRender.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(4);
+    }
+
+    [Fact]
+    public void PasswordCollectionItemField_With_Lines_Should_Stay_Masked_Like_A_Standalone_One()
+    {
+        // Arrange - #207, the counterpart to the test above. `.AsPassword()` plus a multi-line
+        // setting used to render the credential in clear text on BOTH paths: past Lines > 1
+        // MudBlazor emits a <textarea>, which carries no `type` attribute, so the masking was
+        // dropped without a word. It was never a drift between the two paths — it was a shared gap,
+        // which is why the parity comparison could not have caught it and this case is asserted on
+        // the rendered element rather than on parameters.
+        //
+        // A masked textarea does not exist, so the combination can never be honoured as written:
+        // masking wins and the field renders on one line. Both paths must agree on that, and on the
+        // fact that they collapse it to the same single line rather than one of them keeping four.
+        static void Configure<TOwner>(FieldBuilder<TOwner, string> field)
+            where TOwner : new()
+            => field
+                .WithLabel("Secret")
+                .AsPassword(enableVisibilityToggle: false)
+                .AsTextArea(lines: 4);
+
+        var standaloneConfig = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Status, Configure)
+            .Build();
+
+        var collectionConfig = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item.AddField(x => x.ProductName, Configure)))
+            .Build();
+
+        // Act
+        var standaloneRender = RenderForm(standaloneConfig);
+        var itemRender = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, collectionConfig));
+
+        // Assert - neither path renders a textarea, both mask, and both agree on the line count.
+        standaloneRender.FindAll("textarea").ShouldBeEmpty();
+        itemRender.FindAll("textarea").ShouldBeEmpty();
+
+        standaloneRender.Find("input").GetAttribute("type").ShouldBe("password");
+        itemRender.Find("input").GetAttribute("type").ShouldBe("password");
+
+        itemRender.FindComponent<MudTextField<string>>().Instance.Lines
+            .ShouldBe(standaloneRender.FindComponent<MudTextField<string>>().Instance.Lines);
+        standaloneRender.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedLinesDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedLinesDiagnosticTests.cs
@@ -1,0 +1,171 @@
+using FormCraft.ForMudBlazor.UnitTests.TestSupport;
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor.UnitTests.Diagnostics;
+
+/// <summary>
+/// Tests the diagnostic that reports a multi-line setting dropped to keep a field masked (#207).
+/// <para>
+/// The render fix alone is silent: the developer wrote <c>.AsTextArea(...)</c> and gets a one-line
+/// field, with nothing saying why. These tests assert FormCraft says so on both render paths, and —
+/// just as important — that it stays quiet for an ordinary multi-line field and for a password
+/// field that asked for no extra lines.
+/// </para>
+/// </summary>
+public class MaskedLinesDiagnosticTests : MudBlazorTestBase
+{
+    private readonly CapturingLoggerProvider _logs = new();
+
+    public MaskedLinesDiagnosticTests()
+    {
+        Services.AddLogging(builder => builder.AddProvider(_logs));
+    }
+
+    [Fact]
+    public void Should_Warn_When_A_Password_Field_Also_Asks_For_Multiple_Lines()
+    {
+        // Arrange
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Secret, f => f
+                .WithLabel("Password")
+                .AsPassword()
+                .AsTextArea(lines: 4))
+            .Build();
+
+        // Act
+        RenderStandalone(config);
+
+        // Assert - names the field and both settings, so a form of many fields points at the right
+        // one and the developer can see which of the two lost.
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Password");
+        warnings[0].ShouldContain("masked");
+    }
+
+    [Fact]
+    public void Should_Warn_For_An_Item_Field_Too()
+    {
+        // Arrange - the collection path builds its tree with RenderTreeBuilder rather than through
+        // MudBlazorFieldComponentBase, so it needs its own wiring and its own coverage. The clear
+        // text bug was identical on both paths; the diagnostic must be too.
+        var config = BuildItemFormConfiguration(f => f.AsPassword().AsTextArea(lines: 4));
+
+        // Act
+        RenderItemForm(config);
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Secret");
+        warnings[0].ShouldContain("masked");
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_A_Password_Field_With_No_Lines()
+    {
+        // Arrange - nothing was dropped, so there is nothing to report. The overwhelmingly common
+        // password field must not start emitting a warning.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Secret, f => f.WithLabel("Password").AsPassword())
+            .Build();
+
+        // Act
+        RenderStandalone(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_An_Ordinary_Multiline_Field()
+    {
+        // Arrange - a textarea that is not masked is exactly what the developer asked for.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Secret, f => f.WithLabel("Notes").AsTextArea(lines: 4))
+            .Build();
+
+        // Act
+        RenderStandalone(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Warn_Only_Once_Even_After_A_Rerender()
+    {
+        // Arrange - the conflict is a configuration fact, not an event. Re-reporting it on every
+        // parameter change would flood the console as the user types, which is how a useful
+        // diagnostic gets muted by the people it is meant to help.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Secret, f => f
+                .WithLabel("Password")
+                .AsPassword()
+                .AsTextArea(lines: 4))
+            .Build();
+
+        // Act
+        var component = RenderStandalone(config);
+        component.Render();
+        component.Render();
+
+        // Assert
+        _logs.Warnings.Count.ShouldBe(1);
+    }
+
+    private IRenderedComponent<FormCraftComponent<TestModel>> RenderStandalone(
+        IFormConfiguration<TestModel> config)
+    {
+        var model = new TestModel();
+
+        return Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+    }
+
+    private IRenderedComponent<FormCraftComponent<CredentialsModel>> RenderItemForm(
+        IFormConfiguration<CredentialsModel> config)
+    {
+        var model = new CredentialsModel { Items = { new Credential { Secret = "hunter2" } } };
+
+        return Render<FormCraftComponent<CredentialsModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+    }
+
+    private static IFormConfiguration<CredentialsModel> BuildItemFormConfiguration(
+        Action<FieldBuilder<Credential, string>> configureItemField)
+    {
+        return FormBuilder<CredentialsModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Credentials")
+                .WithItemForm(item => item
+                    .AddField(x => x.Secret, field =>
+                    {
+                        field.WithLabel("Secret");
+                        configureItemField(field);
+                    })))
+            .Build();
+    }
+
+    private class TestModel
+    {
+        public string Secret { get; set; } = string.Empty;
+    }
+
+    private class CredentialsModel
+    {
+        public List<Credential> Items { get; set; } = new();
+    }
+
+    private class Credential
+    {
+        public string Secret { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
@@ -219,6 +219,38 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         component.FindComponent<MudTextField<string>>().Instance.Mask.ShouldBeNull();
     }
 
+    [Fact]
+    public void ItemField_With_AsPassword_And_Lines_Should_Stay_Masked()
+    {
+        // Arrange & Act - #207. Past Lines > 1 MudBlazor emits a <textarea>, and a textarea has no
+        // `type` attribute at all, so the masking was silently dropped and the credential was
+        // displayed. There is no such thing as a masked textarea, so the security-relevant half of
+        // the configuration wins and the field renders as a single-line password input.
+        var component = RenderOrderForm(BuildConfiguration(field =>
+            field.AsPassword().AsTextArea(lines: 4)));
+
+        // Assert - the markup, not just the parameter: asserting only MudTextField.InputType would
+        // pass while MudBlazor still rendered a <textarea>, which is exactly how this bug hid.
+        component.FindAll("textarea").ShouldBeEmpty();
+        component.Find("input").GetAttribute("type").ShouldBe("password");
+        component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ItemField_With_Lines_Then_AsPassword_Should_Stay_Masked()
+    {
+        // Arrange & Act - order-independence is not a nicety here: AsTextArea lives in the core
+        // FormCraft project and AsPassword in FormCraft.ForMudBlazor, so neither builder method
+        // ever sees the other's setting. Only the render path can reconcile them.
+        var component = RenderOrderForm(BuildConfiguration(field =>
+            field.AsTextArea(lines: 4).AsPassword()));
+
+        // Assert
+        component.FindAll("textarea").ShouldBeEmpty();
+        component.Find("input").GetAttribute("type").ShouldBe("password");
+        component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
+    }
+
     private IRenderedComponent<FormCraftComponent<CredentialsModel>> RenderOrderForm(
         IFormConfiguration<CredentialsModel> config)
     {

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
@@ -671,6 +671,84 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
         input.HasAttribute("autocomplete").ShouldBeFalse();
     }
 
+    [Fact]
+    public void TextField_With_AsPassword_And_Lines_Should_Stay_Masked()
+    {
+        // Arrange - #207. MudBlazor swaps to a <textarea> past Lines > 1, and a textarea carries no
+        // `type` attribute, so the masking vanished and the password was rendered in clear text.
+        // A masked textarea does not exist, so `.AsPassword()` — an explicit security request —
+        // wins over `Lines`, which is presentation.
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Password, field => field
+                .WithLabel("Password")
+                .AsPassword()
+                .AsTextArea(lines: 4))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert - assert the rendered element, not merely MudTextField.InputType: the parameter
+        // was already being forwarded correctly before this fix, and the field still displayed the
+        // characters, because the element MudBlazor chose ignored it.
+        component.FindAll("textarea").ShouldBeEmpty();
+        component.Find("input").GetAttribute("type").ShouldBe("password");
+        component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TextField_With_Lines_Then_AsPassword_Should_Stay_Masked()
+    {
+        // Arrange - the other call order. AsTextArea lives in the core FormCraft project and
+        // AsPassword in FormCraft.ForMudBlazor, so no builder method ever observes both settings;
+        // reconciling them is necessarily the render path's job, and it must not depend on order.
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Password, field => field
+                .WithLabel("Password")
+                .AsTextArea(lines: 4)
+                .AsPassword())
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindAll("textarea").ShouldBeEmpty();
+        component.Find("input").GetAttribute("type").ShouldBe("password");
+        component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TextField_With_Lines_And_No_Password_Should_Still_Render_A_Textarea()
+    {
+        // Arrange - the guard on the guard. The fix must be scoped to masked fields only; an
+        // ordinary multi-line field is the overwhelmingly common case and must be untouched.
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Description, field => field
+                .WithLabel("Description")
+                .AsTextArea(lines: 4))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(4);
+        component.FindAll("textarea").Count.ShouldBe(1);
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = string.Empty;

--- a/FormCraft.ForMudBlazor.UnitTests/TestSupport/CapturingLoggerProvider.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/TestSupport/CapturingLoggerProvider.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor.UnitTests.TestSupport;
+
+/// <summary>
+/// Collects warning-level log messages so a diagnostic can be asserted on.
+/// </summary>
+/// <remarks>
+/// Two private copies of this already exist (<c>ShrinkLabelDiagnosticsTests</c> and
+/// <c>ShrinkLabelDiagnosticCollectorTests</c>); this is the shared one, added rather than making a
+/// third. The existing copies are deliberately left alone here — folding them in is #205's job, and
+/// rewriting two unrelated suites inside a security fix would bury the change that matters.
+/// <para>
+/// The list is lock-guarded because a diagnostic may be emitted from a render that bUnit runs on its
+/// own dispatcher thread, and an unsynchronised <see cref="List{T}"/> can tear under that.
+/// </para>
+/// </remarks>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly List<string> _warnings = [];
+
+    /// <summary>A snapshot of the warnings captured so far.</summary>
+    public IReadOnlyList<string> Warnings
+    {
+        get
+        {
+            lock (_warnings)
+            {
+                return _warnings.ToList();
+            }
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(_warnings);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(List<string> warnings) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Warning)
+            {
+                return;
+            }
+
+            lock (warnings)
+            {
+                warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor/Diagnostics/MaskedLinesDiagnostic.cs
+++ b/FormCraft.ForMudBlazor/Diagnostics/MaskedLinesDiagnostic.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace FormCraft.ForMudBlazor;
+
+/// <summary>
+/// Reports a multi-line setting that was dropped so a field could stay masked (#207).
+/// </summary>
+/// <remarks>
+/// The render fix in <see cref="TextInputTypeMap.EffectiveLines"/> closes the security hole but is
+/// otherwise silent: the developer wrote <c>.AsTextArea(...)</c> and gets a one-line field with
+/// nothing saying why. This is the other half — it tells them which of their two settings lost, and
+/// that the reason is that a <c>&lt;textarea&gt;</c> cannot mask.
+/// <para>
+/// Both render paths call this, so the rule for *whether* to warn lives in <see cref="Applies"/>
+/// rather than being re-derived at each call site — the same single-implementation discipline as
+/// <c>ShrinkLabelDiagnostic.Conflict</c>. Unlike the ShrinkLabel diagnostic there is no aggregating
+/// collector: this conflict is rare and specific enough that one warning per field is the clearer
+/// signal, where ShrinkLabel's could name a dozen fields at once.
+/// </para>
+/// </remarks>
+internal static class MaskedLinesDiagnostic
+{
+    /// <summary>Logger category for the password-masking diagnostic.</summary>
+    internal const string Category = "FormCraft.ForMudBlazor.PasswordMasking";
+
+    /// <summary>
+    /// Whether this field configured a combination that had to be reconciled: masked *and*
+    /// multi-line.
+    /// </summary>
+    /// <param name="resolved">The field's resolved input type.</param>
+    /// <param name="configuredLines">The <c>Lines</c> the field asked for, before reconciliation.</param>
+    internal static bool Applies(InputType resolved, int configuredLines) =>
+        resolved == InputType.Password && configuredLines > 1;
+
+    /// <summary>
+    /// Emits the warning, degrading silently when no logging stack is registered.
+    /// </summary>
+    /// <param name="services">Provider used to resolve an optional <see cref="ILoggerFactory"/>.</param>
+    /// <param name="fieldName">The field's name, used when it has no label.</param>
+    /// <param name="label">Display name for the message.</param>
+    /// <param name="configuredLines">The dropped line count, quoted back so the message is concrete.</param>
+    internal static void Warn(
+        IServiceProvider? services,
+        string fieldName,
+        string? label,
+        int configuredLines)
+    {
+        // A diagnostic must never break a render, so everything here — including the service
+        // resolution, which is the one call that can realistically fail on a torn-down circuit —
+        // is inside the guard.
+        try
+        {
+            var logger = services?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(Category);
+
+            logger?.LogWarning(
+                "Field '{Field}' is a password field and also asks for {Lines} lines. MudBlazor " +
+                "renders a <textarea> past one line, and a textarea has no `type` attribute — so " +
+                "honouring the line count would display the value in clear text. The field is " +
+                "rendered masked on a single line instead. Drop the multi-line setting to silence " +
+                "this, or drop .AsPassword() if the value is not a secret.",
+                string.IsNullOrWhiteSpace(label) ? fieldName : label,
+                configuredLines);
+        }
+        catch
+        {
+            // Ignored: a failing diagnostic must not take the form down with it.
+        }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -70,6 +70,16 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private readonly HashSet<string> _warnedItemFields = [];
 
     /// <summary>
+    /// Item fields already reported for a dropped multi-line setting (#207).
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="_warnedItemFields"/> on purpose: the two diagnostics are
+    /// independent, and a shared latch would let whichever fired first silence the other on the
+    /// same field.
+    /// </remarks>
+    private readonly HashSet<string> _maskedLinesWarnedFields = [];
+
+    /// <summary>
     /// Gets or sets the parent form's EditContext, cascaded from the surrounding EditForm.
     /// When present, item field changes raise <see cref="EditContext.NotifyFieldChanged(in FieldIdentifier)"/>
     /// with a nested field identifier (e.g. <c>Items[0].ProductName</c>) on the root model, so
@@ -246,6 +256,32 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(CallerAttributeStart + 2, "Immediate", true);
         AddTextInputAttributes(builder, field, TextAttributeStart);
         builder.CloseComponent();
+
+        WarnIfMaskedLinesDropped(field);
+    }
+
+    /// <summary>
+    /// Reports a multi-line setting dropped so an item field could stay masked (#207), using the
+    /// same rule as the component render path.
+    /// </summary>
+    /// <remarks>
+    /// Once per field name for the lifetime of this component: <see cref="RenderTextField"/> runs
+    /// for every row and on every re-render, so an unguarded call would emit one warning per row per
+    /// keystroke. Reuses <see cref="_warnedItemFields"/>' sibling set rather than that set itself —
+    /// the two diagnostics are independent, and sharing one latch would let whichever fired first
+    /// silence the other on the same field.
+    /// </remarks>
+    private void WarnIfMaskedLinesDropped(IFieldConfiguration<TItem, object> field)
+    {
+        var configuredLines = GetItemFieldAttribute(field, "Lines", 1);
+
+        if (!MaskedLinesDiagnostic.Applies(GetItemFieldInputType(field), configuredLines)
+            || !_maskedLinesWarnedFields.Add(field.FieldName))
+        {
+            return;
+        }
+
+        MaskedLinesDiagnostic.Warn(DiagnosticServices, field.FieldName, field.Label, configuredLines);
     }
 
     private void RenderNumericField<T>(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, T value, int itemIndex)

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -267,9 +267,10 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// <remarks>
     /// Once per field name for the lifetime of this component: <see cref="RenderTextField"/> runs
     /// for every row and on every re-render, so an unguarded call would emit one warning per row per
-    /// keystroke. Reuses <see cref="_warnedItemFields"/>' sibling set rather than that set itself —
-    /// the two diagnostics are independent, and sharing one latch would let whichever fired first
-    /// silence the other on the same field.
+    /// keystroke — a collection of 50 items would produce 50 identical warnings before the user
+    /// typed anything. Latched on its own set rather than <see cref="_warnedItemFields"/>: the two
+    /// diagnostics are independent, and sharing one latch would let whichever fired first silence
+    /// the other on the same field.
     /// </remarks>
     private void WarnIfMaskedLinesDropped(IFieldConfiguration<TItem, object> field)
     {

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -352,7 +352,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         int startIndex)
     {
         builder.AddAttribute(startIndex++, "InputType", GetItemFieldInputType(field));
-        builder.AddAttribute(startIndex++, "Lines", GetItemFieldAttribute(field, "Lines", 1));
+        builder.AddAttribute(startIndex++, "Lines", GetItemFieldLines(field));
         builder.AddAttribute(startIndex++, "MaxLength", GetItemFieldMaxLength(field));
 
         // Lowercase on purpose: MudTextField has no Autocomplete parameter, so this rides through
@@ -362,6 +362,21 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex, "autocomplete",
             GetItemFieldAttribute<string?>(field, "autocomplete", null));
     }
+
+    /// <summary>
+    /// Resolves the rendered line count for an item field: the configured value, forced back to 1
+    /// when the field is masked (#207).
+    /// </summary>
+    /// <remarks>
+    /// The rule itself lives in <see cref="TextInputTypeMap.EffectiveLines"/> so this path and the
+    /// component path cannot drift apart on it — the same reason #189 moved the input-type mapping
+    /// there. Both call <see cref="GetItemFieldInputType"/>/<c>Resolve</c> first, so both ask the
+    /// question of the *configured* type.
+    /// </remarks>
+    private static int GetItemFieldLines(IFieldConfiguration<TItem, object> field)
+        => TextInputTypeMap.EffectiveLines(
+            GetItemFieldInputType(field),
+            GetItemFieldAttribute(field, "Lines", 1));
 
     /// <summary>
     /// Resolves the maximum length for an item field, mirroring the component path: a configured

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -128,6 +128,18 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     private IServiceProvider? DiagnosticServices { get; set; }
 
     /// <summary>
+    /// The same provider, exposed to derived components that emit a diagnostic of their own
+    /// (<see cref="MaskedLinesDiagnostic"/>, #207).
+    /// </summary>
+    /// <remarks>
+    /// Deliberately named differently from the injected property above rather than simply making
+    /// that one protected: derived components inject their own <c>ServiceProvider</c>
+    /// (<c>MudBlazorLovFieldComponent</c> does), and a protected member sharing a name with theirs
+    /// would hide it (CS0108) — which under <c>TreatWarningsAsErrors</c> is a build break.
+    /// </remarks>
+    protected IServiceProvider? DiagnosticServiceProvider => DiagnosticServices;
+
+    /// <summary>
     /// The form's diagnostic collector, when this field is rendered inside a
     /// <see cref="FormCraftComponent{TModel}"/>. Null for a standalone field.
     /// </summary>

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -43,7 +43,19 @@ public partial class MudBlazorTextFieldComponent<TModel>
         // <textarea>, which has no `type` attribute and therefore cannot mask (#207). Resolved from
         // the CONFIGURED input type, so revealing a password with the toggle does not reflow the
         // field from one line to four.
-        Lines = TextInputTypeMap.EffectiveLines(TextInputTypeMap.Resolve(InputType), ConfiguredLines);
+        var configuredInputType = TextInputTypeMap.Resolve(InputType);
+        Lines = TextInputTypeMap.EffectiveLines(configuredInputType, ConfiguredLines);
+
+        // Emitted from OnInitialized, so once per component instance: the conflict is a
+        // configuration fact and re-reporting it on every keystroke would drown the console.
+        if (MaskedLinesDiagnostic.Applies(configuredInputType, ConfiguredLines))
+        {
+            MaskedLinesDiagnostic.Warn(
+                DiagnosticServiceProvider,
+                Context.Field.FieldName,
+                Label,
+                ConfiguredLines);
+        }
         Autocomplete = GetAttribute<string?>("autocomplete");
         Mask = GetAttribute<string?>("Mask");
 

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -10,6 +10,14 @@ public partial class MudBlazorTextFieldComponent<TModel>
     private string? _localValue;
 
     public int Lines { get; set; } = 1;
+
+    /// <summary>
+    /// The <c>Lines</c> the field asked for, before the password rule in
+    /// <see cref="TextInputTypeMap.EffectiveLines"/> may have reduced it to 1 (#207). Kept so the
+    /// diagnostic can report what was dropped rather than what was rendered.
+    /// </summary>
+    internal int ConfiguredLines { get; private set; } = 1;
+
     public int? MaxLength { get; set; }
     public string InputType { get; set; } = "text";
     public string? Autocomplete { get; set; }
@@ -27,9 +35,15 @@ public partial class MudBlazorTextFieldComponent<TModel>
         _localValue = CurrentValue;
 
         // Load configuration - prioritize field.InputType over AdditionalAttributes
-        Lines = GetAttribute("Lines", 1);
+        ConfiguredLines = GetAttribute("Lines", 1);
         MaxLength = GetAttribute<int?>("MaxLength");
         InputType = Context.Field.InputType ?? GetAttribute("InputType", "text") ?? "text";
+
+        // A masked field is forced back to a single line: past Lines > 1 MudBlazor renders a
+        // <textarea>, which has no `type` attribute and therefore cannot mask (#207). Resolved from
+        // the CONFIGURED input type, so revealing a password with the toggle does not reflow the
+        // field from one line to four.
+        Lines = TextInputTypeMap.EffectiveLines(TextInputTypeMap.Resolve(InputType), ConfiguredLines);
         Autocomplete = GetAttribute<string?>("autocomplete");
         Mask = GetAttribute<string?>("Mask");
 
@@ -173,4 +187,30 @@ internal static class TextInputTypeMap
             "search" => InputType.Search,
             _ => InputType.Text,
         };
+
+    /// <summary>
+    /// The number of lines a field actually renders with: always 1 for a masked field, otherwise
+    /// whatever was configured.
+    /// </summary>
+    /// <remarks>
+    /// #207. MudBlazor emits a <c>&lt;textarea&gt;</c> once <c>Lines &gt; 1</c>, and a textarea has
+    /// no <c>type</c> attribute — so honouring <c>Lines</c> on a password field silently defeats the
+    /// masking and renders the credential in clear text. That happened identically on both render
+    /// paths, so it was a shared gap rather than a drift.
+    /// <para>
+    /// Masking wins because there is no such thing as a masked textarea: the combination can never
+    /// be honoured as written, and of the two settings <c>.AsPassword()</c> is an explicit security
+    /// request while <c>Lines</c> is presentation. Rejecting the combination at build time was the
+    /// alternative, but <c>AsTextArea</c> lives in the core project and <c>AsPassword</c> here, so
+    /// neither builder method ever sees both — the check would have to throw from
+    /// <c>Build()</c>, turning an insecure-but-working form into a startup crash.
+    /// </para>
+    /// <para>
+    /// Callers must pass the **configured** input type, not the one currently rendered: the
+    /// visibility toggle flips a revealed password to <see cref="InputType.Text"/>, and a field
+    /// that reflowed from one line to four on reveal would be a second surprise.
+    /// </para>
+    /// </remarks>
+    internal static int EffectiveLines(InputType resolved, int configuredLines) =>
+        resolved == InputType.Password ? 1 : configuredLines;
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **A password field combined with a multi-line setting was rendering in clear text — on both render paths. Masking now wins.** `.AsPassword()` together with `.AsTextArea(...)` (or any `Lines > 1`) made MudBlazor emit a `<textarea>`, and a textarea has no `type` attribute, so the masking was silently dropped and the credential was displayed. Unlike #189 this was not a drift between the two render paths — both had the same gap. Such a field now renders **masked, on a single line**, and FormCraft logs a warning naming the field and the line count it dropped (#207)
+
+  ```csharp
+  .AddField(x => x.Secret, f => f
+      .WithLabel("Password")
+      .AsPassword()
+      .AsTextArea(lines: 4))   // ← was clear text; now masked on one line, with a warning
+  ```
+
+  **Why masking wins rather than the line count.** There is no such thing as a masked `<textarea>`, so the combination can never be honoured as written — and of the two settings, `.AsPassword()` is an explicit security request while the line count is presentation. Rejecting the combination at build time was the alternative, but `.AsTextArea(...)` and `.AsPassword()` live in different assemblies and either may be called first, so no builder method ever sees both; the check would have had to throw from `Build()`, turning an insecure-but-working form into a startup crash. The warning is logged under the `FormCraft.ForMudBlazor.PasswordMasking` category — filter it out if you have a reason to keep the combination.
+
 - **A decorative adornment no longer renders as a focusable button.** An adornment configured with `.WithAdornment(...)` and *no* `onClick` was drawn as a real `<button>` on ordinary fields — inert to click, but a stop in the tab order, so keyboard and screen-reader users landed on a control that does nothing. The component path bound its click callback unconditionally; the collection path never did, so the same configuration produced different markup inside and outside `.WithItemForm(...)`. Both now render a plain icon (#216)
 
   **Worth knowing if you assert on markup.** A handler-less adornment no longer matches `button.mud-input-adornment-icon-button`. Adornments configured *with* a handler are unchanged — still a real button, still clickable.


### PR DESCRIPTION
Implements #207.

Closes #207.

`.AsPassword()` combined with a multi-line setting rendered the credential **in clear text, on both
render paths**. Past `Lines > 1` MudBlazor emits a `<textarea>`, and a textarea has no `type`
attribute — so the masking was silently dropped. Unlike #189, this was not a drift between the two
paths: both had the same gap, which is why `RenderPipelineParityTests` could not have caught it (it
compares the paths against each other, and they agreed — on being wrong).

### Plan
- [x] Task 1: Make masking win over `Lines` on both render paths
- [x] Task 2: Report the dropped `Lines` through the diagnostics channel
- [x] Task 3: Pin it in the parity suite and document the precedence

### The design decision, and why not the two the issue proposed

The issue offered *reject at build time* or *warn at render*. This takes a third option that
dominates both:

- **Not a build-time throw.** `AsTextArea(lines:)` lives in core (`FormCraft`) and `AsPassword()` in
  `FormCraft.ForMudBlazor`, and either may be called first — so **no builder method ever sees both
  settings**. The check would have to live in `Build()`, and throwing there turns an insecure but
  working form into a startup crash for anyone already using the combination. Both call orders are
  covered by tests for exactly this reason.
- **Not a warning alone.** A warning tells the developer while the form keeps displaying the
  password. The defect is a visible credential; a diagnostic does not close it.
- **So: masking wins, and the dropped setting is reported.** There is no such thing as a masked
  `<textarea>`, so the combination can never be honoured as written; of the two, `.AsPassword()` is an
  explicit security request and `Lines` is presentation.

The precedence rule lives **once**, in `TextInputTypeMap.EffectiveLines` — the same shared home #189
created for the input-type mapping, and for the same reason: a second copy is the next divergence.
It is resolved from the **configured** input type, not the rendered one, so revealing a password with
the visibility toggle does not reflow the field from one line to four.

### Verification

Red before green at every step. The four masking tests failed by finding a `<textarea>` where an
`<input>` was expected — asserting on `component.Find("input").GetAttribute("type")` rather than on
`MudTextField.InputType`, because the parameter was already being forwarded correctly while the field
still displayed the characters. That is exactly how this bug hid, and a parameter-only assertion
would have passed throughout.

Full suite green: **1039 tests**, 0 warnings under `TreatWarningsAsErrors`.

### Follow-ups
- **`CapturingLoggerProvider` now exists three times** — this PR added a shared one under
  `TestSupport/` rather than a third private copy, but the two originals in
  `ShrinkLabelDiagnosticsTests` and `ShrinkLabelDiagnosticCollectorTests` are deliberately left
  alone. Folding them in belongs to #205; rewriting two unrelated suites inside a security fix would
  bury the change that matters.
- **`Mask` is still silently inert on both paths** (`GetMask()` is an unimplemented stub that always
  returns `null` and is never called) — already tracked as #211, and pinned by an existing test.
