### PR TITLE
build(deps): pin System.Security.Cryptography.Xml to clear 8 transitive advisories (#228)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,14 @@
   <ItemGroup>
     <!-- Epinglee directement : bunit tire AngleSharp 1.4.0, vulnerable (GHSA-pgww-w46g-26qg). -->
     <PackageVersion Include="AngleSharp" Version="1.7.1" />
+    <!--
+      Pinned directly for the same reason as AngleSharp above: Nuke.Common 10.1.0 (the latest
+      published version — a bump does not help) pulls System.Security.Cryptography.Xml 9.0.0
+      transitively, which carries 8 high-severity advisories (#228). A transitive edge can only be
+      overridden by a direct reference at a higher version, so build/_build.csproj references this
+      explicitly. Do not remove either half.
+    -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
     <!-- UI Framework packages -->
     <PackageVersion Include="MudBlazor" Version="9.8.0" />
     <!-- Testing packages -->

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,6 +14,27 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Nuke.Common" />
+    <!--
+      ⛔ NOT an unused reference — do not delete it (#228).
+
+      Nuke.Common 10.1.0 resolves System.Security.Cryptography.Xml 9.0.0 transitively, and that
+      version carries 8 high-severity advisories (GHSA-23rf-6693-g89p, GHSA-37gx-xxp4-5rgx,
+      GHSA-6588-8gv4-xfgh, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f,
+      GHSA-mmjf-rqrv-855v, GHSA-w3x6-4m5h-cxqf). 10.1.0 is the latest Nuke.Common, so there is no
+      bump that clears them.
+
+      No code here uses this package: it is referenced solely to raise the resolved version. That is
+      the only mechanism that works — removing a reference does NOT remove a package that is also
+      reached transitively, it just lets the vulnerable version resolve again in silence. The version
+      lives in Directory.Packages.props (central package management).
+
+      Verify with a COLD restore, never a warm build — restore advisories are not re-emitted on a
+      warm restore, so `dotnet build` reports "0 Warning(s)" whether or not this is here. Run
+      `dotnet restore build/_build.csproj` with the force flag and count NU1903: expect zero. Read
+      the count together with the restore's exit status, because a restore that fails outright also
+      prints no NU1903 lines and so looks identical to a clean one.
+    -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implements #228.

Closes #228.

Clears the 8 high-severity advisories in the Nuke build host's dependency graph, verified against the
**resolved graph** and a cold restore rather than a CLI summary.

### Plan
- [x] Task 1: Establish the baseline from the resolved graph
- [x] Task 2: Remove the advisories and prevent the fix from being undone

### Result

| | before | after |
|---|--:|--:|
| `NU1903` (high) on a cold restore | **8** | **0** |
| `System.Security.Cryptography.Xml` in `project.assets.json` | `9.0.0` | `10.0.11` |

The edge is `Microsoft.Build.Tasks.Core/18.0.2 → System.Security.Cryptography.Xml 9.0.0`, reached via
`Nuke.Common`. **A Nuke bump cannot fix it** — `10.1.0` is the newest published version and is
already in use — so the only mechanism is a direct reference at a higher version, since removing a
reference does not remove a package that is also reached transitively. Both halves (the
`PackageVersion` and the `PackageReference`) carry comments saying why they must stay, so the next
"unused reference" cleanup does not silently reopen the vulnerability.

### A near-miss worth reading

My first verification reported `NU1903 → 0` while the graph **still resolved 9.0.0**. The comment I
added to `build/_build.csproj` quoted a `--force` flag, and `--` is illegal inside an XML comment —
so the restore failed with `MSB4025` and printed no NU1903 lines at all.

**A failed restore and a clean one produce the same count: zero.** The verification now reads the
count together with the restore's exit status *and* the resolved version, and that caveat is written
into the comment next to the reference.

### Step 5 decision: no `NU1903`-as-error gate

Recorded on the issue in full. Briefly: restore advisories only surface on a *cold* restore, so such
a gate would fire in `ci.yml` (no NuGet cache) and stay silent in `continuous.yml` (cached) for the
same commit — a red that looks flaky is worse than none. It would also redden `dev` when a new
advisory is published against an unchanged tree. A scheduled *reporting* audit is the better shape.

### Follow-ups
- **A scheduled forced-restore audit** that reports high-severity findings instead of gating the
  build — the alternative to the rejected `WarningsAsErrors` approach.
- **One low-severity advisory remains untouched**: `NuGet.Packaging 6.12.1` (GHSA-g4vj-cjjj-v7hg,
  `NU1901`), also via `Nuke.Common`. Out of this issue's scope (the 8 high-severity findings); the
  same pinning technique clears it if wanted.
