### PR TITLE
test(build): pin the version-tag publish rule and document its deliberate looseness (#227)

### DIFF
--- a/FormCraft.UnitTests/Ci/VersionTagRuleTests.cs
+++ b/FormCraft.UnitTests/Ci/VersionTagRuleTests.cs
@@ -1,0 +1,92 @@
+using FormCraft.Build;
+
+namespace FormCraft.UnitTests.Ci;
+
+/// <summary>
+/// Pins the rule that decides whether a git tag is a release tag (#227).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>BuildVersioning.IsVersionTag</c> is the static gate behind Nuke's <c>PublishIfNeeded</c>
+/// (<c>OnlyWhenStatic(() =&gt; IsOnVersionTag())</c>). It runs a handful of times a year, on the one
+/// path where being wrong is expensive in both directions: too strict and a release publishes
+/// nothing while reporting green; too loose and a stray tag pushes to nuget.org, which delists but
+/// never deletes.
+/// </para>
+/// <para>
+/// The source lives in <c>build/BuildVersioning.cs</c> and is <b>linked</b> into this project rather
+/// than referenced, deliberately: a <c>ProjectReference</c> to <c>_build.csproj</c> would pull Nuke
+/// and its whole dependency graph into the library test assemblies.
+/// </para>
+/// </remarks>
+public class VersionTagRuleTests
+{
+    [Theory]
+    [InlineData("v3.1.0")]                 // the ordinary release tag
+    [InlineData("v10.20.30")]              // multi-digit components
+    [InlineData("v0.0.1")]                 // zeros are legal semver components
+    [InlineData("v3.1.1-rc.1")]            // prerelease rehearsal — #198 depends on this publishing
+    [InlineData("v4.0.0-preview.2")]
+    [InlineData("v1.0.0+build.5")]         // build metadata is legal semver
+    [InlineData("v1.0.0-rc.1+build.5")]
+    public void Should_Accept_A_Release_Tag(string tag)
+    {
+        BuildVersioning.IsVersionTag(tag).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Should_Accept_A_Nonsense_Prerelease_Label()
+    {
+        // #227 Task 1, decided deliberately rather than by omission. `-donotship` is a *legal*
+        // semver prerelease identifier, so anchoring to semver does not exclude it; excluding it
+        // would need an allow-list of labels (rc, preview, beta...).
+        //
+        // No allow-list, for two reasons. Since #197 nothing publishes off a pushed tag —
+        // release-please creates the tag and runs the publish in the same job — so this predicate is
+        // defence in depth, not the control that decides to release; an allow-list would look like a
+        // safety net while the real one lives elsewhere. And it answers the wrong question: "is this
+        // a release tag" is decidable from the string, "did the human mean it" is not, and guessing
+        // would break the first rehearsal to use an unforeseen label.
+        BuildVersioning.IsVersionTag("v1.0.0-donotship").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("   ")]
+    [InlineData("3.1.0")]                  // no `v` prefix — MinVerTagPrefix is `v`
+    [InlineData("v3.1")]                   // incomplete
+    [InlineData("v3")]
+    [InlineData("vNext")]
+    [InlineData("release-3.1.0")]
+    [InlineData("v3.1.0-")]                // empty prerelease is not legal semver
+    public void Should_Reject_A_Tag_That_Is_Not_A_Version(string? tag)
+    {
+        BuildVersioning.IsVersionTag(tag).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("v1.0.0.0")]               // four components is not a version tag
+    [InlineData("v1.0.0garbage")]          // a suffix that is not a legal prerelease
+    [InlineData("v01.0.0")]                // leading zeros are not semver
+    [InlineData("v1.0.0_hotfix")]          // `_` is not legal in a semver identifier
+    public void Should_Reject_A_Malformed_Tag_That_The_Unanchored_Rule_Used_To_Accept(string tag)
+    {
+        // These are the cases #227 changed. The missing `$` in the old `^v\d+\.\d+\.\d+` was
+        // deliberate for *prerelease* suffixes — that is what lets a rehearsal exercise the real
+        // publish path — but it accepted these too, which nobody chose. Looseness by accident,
+        // riding along with looseness by design.
+        BuildVersioning.IsVersionTag(tag).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("v3.1.0\n")]
+    [InlineData("  v3.1.0  ")]
+    public void Should_Tolerate_Surrounding_Whitespace(string tag)
+    {
+        // The predicate is fed by `git describe --exact-match --tags HEAD`. A stray newline would
+        // pass the old prefix-only pattern and fail a fully anchored one — the single way anchoring
+        // could have broken a real release, so it is trimmed and pinned here.
+        BuildVersioning.IsVersionTag(tag).ShouldBeTrue();
+    }
+}

--- a/FormCraft.UnitTests/FormCraft.UnitTests.csproj
+++ b/FormCraft.UnitTests/FormCraft.UnitTests.csproj
@@ -16,6 +16,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      The version-tag publish rule, compiled into this assembly so VersionTagRuleTests can reach it
+      (#227). Linked source, NOT a ProjectReference to build/_build.csproj: that would pull Nuke and
+      its whole dependency graph into the library test assemblies. BuildVersioning.cs depends on
+      nothing but System.Text.RegularExpressions so that this stays a single-file link.
+    -->
+    <Compile Include="..\build\BuildVersioning.cs" Link="Ci\BuildVersioning.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using FormCraft.Build;
 using Nuke.Common;
 using Nuke.Common.CI;
 using Nuke.Common.CI.GitHubActions;
@@ -261,9 +261,14 @@ class Build : NukeBuild
         return null;
     }
 
-    bool IsOnVersionTag()
-    {
-        var tag = GetCurrentTag();
-        return !string.IsNullOrEmpty(tag) && Regex.IsMatch(tag, @"^v\d+\.\d+\.\d+");
-    }
+    /// <summary>
+    /// Whether HEAD carries a release tag — the static gate behind <see cref="PublishIfNeeded"/>.
+    /// </summary>
+    /// <remarks>
+    /// The rule itself lives in <see cref="FormCraft.Build.BuildVersioning.IsVersionTag"/> so it can
+    /// be tested without instantiating this class; <c>VersionTagRuleTests</c> pins its accept and
+    /// reject sets, including why a prerelease tag must keep publishing (#198's rehearsal) and why a
+    /// legal-but-nonsense prerelease label is not excluded (#227).
+    /// </remarks>
+    bool IsOnVersionTag() => BuildVersioning.IsVersionTag(GetCurrentTag());
 }

--- a/build/BuildVersioning.cs
+++ b/build/BuildVersioning.cs
@@ -1,0 +1,65 @@
+using System.Text.RegularExpressions;
+
+namespace FormCraft.Build;
+
+/// <summary>
+/// The rule that decides whether a git tag is a release tag, extracted from <c>Build.IsOnVersionTag</c>
+/// so it can be tested without instantiating Nuke's <c>Build</c> (#227).
+/// </summary>
+/// <remarks>
+/// This file is <b>linked</b> into <c>FormCraft.UnitTests</c> rather than referenced. A
+/// <c>ProjectReference</c> to <c>_build.csproj</c> would drag Nuke and its whole dependency graph
+/// into the library test assemblies, so it deliberately depends on nothing but
+/// <c>System.Text.RegularExpressions</c> — keep it that way.
+/// </remarks>
+internal static class BuildVersioning
+{
+    /// <summary>
+    /// Matches a release tag: <c>v</c> followed by a strict semver version, with optional prerelease
+    /// and build-metadata parts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The prerelease part is <b>deliberately permitted</b>, and that is the load-bearing looseness:
+    /// it is what lets a prerelease tag exercise the real publish path, which #198's rehearsal
+    /// depends on. A rule that accepted only <c>vX.Y.Z</c> would make every rehearsal a no-op that
+    /// still reported success — the "green run, nothing published" failure this repo keeps designing
+    /// against. ⛔ Do not restrict this to final versions.
+    /// </para>
+    /// <para>
+    /// It is, however, <b>anchored</b> at both ends. The original <c>^v\d+\.\d+\.\d+</c> had no
+    /// <c>$</c>, which bought the prerelease case above but also accepted <c>v1.0.0.0</c>,
+    /// <c>v1.0.0garbage</c> and <c>v01.0.0</c> — looseness nobody chose, riding along with the
+    /// looseness that was intended (#227).
+    /// </para>
+    /// <para>
+    /// A nonsense-but-legal prerelease label such as <c>v1.0.0-donotship</c> still matches, by
+    /// decision rather than omission. Excluding it would need an allow-list of labels, and that is
+    /// declined on purpose: since #197 nothing publishes off a pushed tag (release-please creates the
+    /// tag and runs the publish in the same job), so this predicate is defence in depth rather than
+    /// the control that decides to release — an allow-list would look like a safety net while the
+    /// real one lives elsewhere, and would break the first rehearsal to use an unforeseen label.
+    /// </para>
+    /// </remarks>
+    private static readonly Regex VersionTagPattern = new(
+        @"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+        + @"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+        + @"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+        RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Whether <paramref name="tag"/> is a release tag that may publish.
+    /// </summary>
+    /// <param name="tag">
+    /// The tag to test — typically the output of <c>git describe --exact-match --tags HEAD</c>, or
+    /// null/empty when HEAD carries no tag.
+    /// </param>
+    /// <remarks>
+    /// Trimmed before matching: the caller feeds this straight from git's stdout, and a trailing
+    /// newline would fail an anchored pattern while passing the old prefix-only one. That is the one
+    /// way anchoring could have broken a real release, so it is handled here rather than left to
+    /// every caller.
+    /// </remarks>
+    internal static bool IsVersionTag(string? tag) =>
+        !string.IsNullOrWhiteSpace(tag) && VersionTagPattern.IsMatch(tag.Trim());
+}


### PR DESCRIPTION
Implements #227.

Closes #227.

The rule behind Nuke's `PublishIfNeeded` gate — `^v\d+\.\d+\.\d+` — had **no test at all**, on the one
path where being wrong is expensive in both directions: too strict and a release publishes nothing
while reporting green; too loose and a stray tag reaches nuget.org, which delists but never deletes.

### Plan
- [x] Task 1: Decide the suffix policy
- [x] Task 2: Make the rule testable and pin it

### Task 1 decision: anchor to valid semver; `v1.0.0-donotship` still publishes

Full reasoning [on the issue](https://github.com/phmatray/FormCraft/issues/227).

| tag | before | after |
|---|---|---|
| `v3.1.0`, `v10.20.30`, `v0.0.1` | accept | accept |
| `v3.1.1-rc.1`, `v4.0.0-preview.2` | accept | **accept** — #198's rehearsal depends on it |
| `v1.0.0+build.5` | accept | accept |
| `v1.0.0-donotship` | accept | **accept** (deliberate) |
| `v1.0.0.0`, `v1.0.0garbage`, `v01.0.0`, `v1.0.0_hotfix` | **accept** | **reject** |
| `v3.1`, `3.1.0`, `vNext`, `release-3.1.0`, `""`, `null` | reject | reject |

**The missing `$` was doing two jobs.** One was intended — letting a prerelease tag exercise the real
publish path — and is kept. The other was accidental: it also accepted `v1.0.0.0` and
`v1.0.0garbage`, which nobody chose. Anchoring to strict semver keeps the first and drops the second.

**No prerelease-label allow-list**, decided rather than omitted. Since #197 nothing publishes off a
pushed tag — release-please creates the tag *and* runs the publish in the same job — so this
predicate is defence in depth, not the control that decides to release. An allow-list would look like
a safety net while the real one lives elsewhere, and would break the first rehearsal to use an
unforeseen label (`-pre` vs `-preview`).

### Notes

- The rule moved to `build/BuildVersioning.cs` and is **linked** into `FormCraft.UnitTests`, not
  referenced — a `ProjectReference` to `_build.csproj` would pull Nuke's whole dependency graph into
  the library test assemblies. Verified clean: `dotnet list package --include-transitive | grep -i
  nuke` finds nothing.
- The predicate now **trims** its input. It is fed straight from `git describe --exact-match --tags
  HEAD`, and a trailing newline would pass the old prefix-only pattern but fail a fully anchored one
  — the single way this change could have broken a real release. Pinned by its own test.
- `IsOnVersionTag()` delegates, so the build's behaviour is unchanged apart from the decided
  tightening; `./build.sh Test` verified still green, and the now-unused `System.Text.RegularExpressions`
  using was removed from `Build.cs`.

23 new tests; full suite green at 1063, 0 warnings under `TreatWarningsAsErrors`.
