### PR TITLE
fix(mudblazor): render novalidate on the form instead of applying it by script (#206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,12 @@ public interface IUIFrameworkAdapter
 
 #### Validation Behavior
 - `Required()` adds validation but NOT HTML5 required attribute
-- Browser validation disabled via `novalidate` attribute
+- Browser validation disabled via a `novalidate` attribute **rendered on the form** by
+  `FormCraftComponent` (#206). It is a real attribute in the markup, so it applies during
+  prerender/SSR, targets this component's own form rather than the first one on the page, and needs
+  no JavaScript. ⛔ Do not reintroduce the `JSRuntime.InvokeVoidAsync("eval", …)` version: it marked
+  `document.querySelector('form')` — the wrong form on any page with another form above it — never
+  ran on the server pass, failed silently, and was blocked outright by a strict CSP
 - All validation through FluentValidation
 - Validation messages from server, not browser
 - MudBlazor components don't include `Required` attribute

--- a/FormCraft.ForMudBlazor.UnitTests/Components/FormCraftComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/FormCraftComponentTests.cs
@@ -214,8 +214,16 @@ public class FormCraftComponentTests : MudBlazorTestBase
             .Add(p => p.Configuration, config));
 
         // Assert
+        // The `?.` this assertion used to carry made it VACUOUS: with the attribute absent — which
+        // it was, because it was applied by a script bUnit never runs — the whole expression was
+        // null and no assertion executed. A test named "Should_Have_Novalidate_Attribute" reported
+        // green for the entire period the attribute was missing, which is the same class of defect
+        // as #206 itself: a guarantee asserted everywhere and checked nowhere.
         var form = component.Find("form");
-        form.Attributes.FirstOrDefault(a => a.Name == "novalidate")?.Value.ShouldBe("novalidate");
+        var novalidate = form.Attributes.FirstOrDefault(a => a.Name == "novalidate");
+
+        novalidate.ShouldNotBeNull();
+        novalidate.Value.ShouldBe("novalidate");
     }
 
     [Fact]

--- a/FormCraft.ForMudBlazor.UnitTests/Components/NoValidateTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/NoValidateTests.cs
@@ -1,0 +1,146 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Components;
+
+/// <summary>
+/// Pins the guarantee that a FormCraft form renders <c>novalidate</c> (#206).
+/// </summary>
+/// <remarks>
+/// <para>
+/// "Forms render <c>novalidate</c>" is stated as fact in the README, in <c>CLAUDE.md</c> and in code
+/// comments, and real decisions rest on it — #190 removed the HTML5 <c>Required</c> attribute from
+/// collection item fields on the strength of it, and #193's <c>.WithAttribute("Required", true)</c>
+/// opt-in puts a genuine <c>required</c> attribute on an input. If the form is not marked, that
+/// attribute is enforced by the browser, and the library produces exactly the native validation
+/// bubbles it documents itself as never producing.
+/// </para>
+/// <para>
+/// The guarantee used to be applied after the fact by
+/// <c>JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?…")</c>, which missed in
+/// three ways: it marked the <b>first</b> form in the document rather than this component's, it
+/// never ran during prerender (<c>OnAfterRenderAsync</c> does not execute on the server pass), and
+/// it failed silently. These tests assert the attribute is in the rendered markup, which is the only
+/// form of the claim that holds in all three cases — and which bUnit can see at all, since it runs
+/// no JavaScript.
+/// </para>
+/// </remarks>
+public class NoValidateTests : MudBlazorTestBase
+{
+    [Fact]
+    public void FormCraft_Form_Should_Render_NoValidate()
+    {
+        // Arrange
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, new TestModel())
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Find("form").HasAttribute("novalidate").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FormCraft_Form_Should_Be_The_One_Marked_When_Another_Form_Precedes_It()
+    {
+        // Arrange - the headline defect. `document.querySelector('form')` returns the FIRST form in
+        // the document, so a page with a search or login form above the FormCraft one marked *that*
+        // one and left the FormCraft form validating. Rendering the attribute in the markup makes
+        // the form it lands on correct by construction rather than by document order.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name"))
+            .Build();
+
+        // Act - BeforeForm puts an unrelated <form> ahead of FormCraft's in the same render tree.
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, new TestModel())
+            .Add(p => p.Configuration, config)
+            .Add(p => p.BeforeForm, (RenderFragment)(builder =>
+            {
+                builder.OpenElement(0, "form");
+                builder.AddAttribute(1, "id", "unrelated-search-form");
+                builder.CloseElement();
+            })));
+
+        // Assert - the unrelated form is untouched, and FormCraft's own is marked.
+        var forms = component.FindAll("form");
+        forms.Count.ShouldBe(2);
+
+        forms[0].GetAttribute("id").ShouldBe("unrelated-search-form");
+        forms[0].HasAttribute("novalidate").ShouldBeFalse();
+        forms[1].HasAttribute("novalidate").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Two_FormCraft_Forms_Should_Both_Render_NoValidate()
+    {
+        // Arrange - the second half of the same defect: with the script, two FormCraft forms on one
+        // page meant the first was marked twice and the second never.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name"))
+            .Build();
+
+        // Act - a second FormCraftComponent rendered after the first, in one tree.
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, new TestModel())
+            .Add(p => p.Configuration, config)
+            .Add(p => p.AfterForm, (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<FormCraftComponent<TestModel>>(0);
+                builder.AddAttribute(1, "Model", new TestModel());
+                builder.AddAttribute(2, "Configuration", config);
+                builder.CloseComponent();
+            })));
+
+        // Assert
+        var forms = component.FindAll("form");
+        forms.Count.ShouldBe(2);
+        forms.ShouldAllBe(f => f.HasAttribute("novalidate"));
+    }
+
+    [Fact]
+    public void An_Opt_In_Required_Item_Field_Should_Still_Render_Required_Inside_A_NoValidate_Form()
+    {
+        // Arrange - #193's documented escape hatch must keep working: the attribute is still emitted,
+        // it is the *form* that neutralises browser enforcement. Asserting both halves together is
+        // the point — this is the exact combination that made #206 worth fixing rather than merely
+        // tidying, because on a page where the script missed, this input really was browser-enforced.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field => field
+                        .WithLabel("Product")
+                        .WithAttribute("Required", true))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Find("form").HasAttribute("novalidate").ShouldBeTrue();
+        component.Find("input").HasAttribute("required").ShouldBeTrue();
+    }
+
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class OrderModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string ProductName { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -3,9 +3,11 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// <summary>
 /// Tests that collection item fields do NOT carry the HTML5 <c>Required</c> attribute (#190).
 /// The project's validation convention is server-side only — messages come from the validator, no
-/// component-path renderer emits <c>Required</c>, and the form is marked <c>novalidate</c> (on a
-/// best-effort basis: it is applied by script to the first form in the document after the first
-/// render, so it is not a guarantee the rendered attribute can rely on). The collection
+/// component-path renderer emits <c>Required</c>, and the form is marked <c>novalidate</c>. Since
+/// #206 that last part is an actual guarantee rather than a best effort: the attribute is rendered
+/// on the form itself, so it applies during prerender and targets this component's own form. It was
+/// previously applied by script to the *first* form in the document after the first render, which is
+/// why this note used to qualify it. The collection
 /// path drove it from <c>field.IsRequired</c>, so the same <c>.Required("…")</c> call put
 /// <c>required</c> and <c>aria-required="true"</c> on the input inside <c>.WithItemForm(...)</c> and
 /// neither outside it.

--- a/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
+++ b/FormCraft.ForMudBlazor/Features/FormContainer/FormCraftComponent.razor
@@ -1,8 +1,6 @@
-@using Microsoft.JSInterop
 @namespace FormCraft.ForMudBlazor
 @typeparam TModel where TModel : new()
 @inject IFieldRendererService FieldRendererService
-@inject IJSRuntime JSRuntime
 
 @if (BeforeForm != null)
 {
@@ -12,7 +10,22 @@
 <CascadingValue TValue="Variant?" Name="@FormCraftCascadingValues.DefaultVariant" Value="@DefaultVariant">
 <CascadingValue TValue="bool?" Name="@FormCraftCascadingValues.DefaultShrinkLabel" Value="@DefaultShrinkLabel">
 <CascadingValue TValue="ShrinkLabelDiagnosticCollector" Name="@FormCraftCascadingValues.ShrinkLabelDiagnostics" Value="@_shrinkLabelDiagnostics" IsFixed="true">
-<EditForm EditContext="@_editContext" OnSubmit="@HandleSubmit">
+@* `novalidate` is rendered here, as a real attribute on the form EditForm emits (#206).
+
+   It used to be bolted on after the fact by
+   `JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?.setAttribute(…)")`, which
+   missed three ways: it marked the FIRST form in the document rather than this component's (so a
+   page with a search form above it marked the wrong one, and two FormCraft forms meant the first was
+   marked twice and the second never), it never ran during prerender because OnAfterRenderAsync does
+   not execute on the server pass, and it failed silently through `?.`. It was also `eval`, which a
+   strict CSP blocks outright — making the failure silent *and* total.
+
+   This matters beyond tidiness: FormCraft validates server-side and #190 removed the HTML5 Required
+   attribute from item fields on the strength of this guarantee, while #193 added
+   `.WithAttribute("Required", true)` as an opt-in that emits a genuine `required`. On a page where
+   the script missed, that input was browser-enforced — the native validation bubbles this library
+   documents itself as never producing. *@
+<EditForm EditContext="@_editContext" OnSubmit="@HandleSubmit" novalidate="novalidate">
     <DynamicFormValidator TModel="TModel" Configuration="@Configuration" @ref="_validator" />
     
     @if (GroupedConfiguration != null && GroupedConfiguration.UseFieldGroups && GroupedConfiguration.FieldGroups.Any())
@@ -124,15 +137,6 @@
 }
 
 @code {
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // Disable browser validation using JavaScript
-            await JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?.setAttribute('novalidate', 'novalidate')");
-        }
-    }
-    
     private RenderFragment RenderFieldGroup(FieldGroup<TModel> group)
     {
         return builder =>

--- a/FormCraft.UnitTests/Components/FormCraftComponentTests.cs
+++ b/FormCraft.UnitTests/Components/FormCraftComponentTests.cs
@@ -225,7 +225,13 @@ public class FormCraftComponentTests : BunitContext
         // The DynamicFormValidator is rendered inside the EditForm
         // We can't directly find it with FindComponents due to how Blazor handles nested components,
         // but we can verify the form structure is correct
-        editForm.Attributes.FirstOrDefault(a => a.Name == "novalidate")?.Value.ShouldBe("novalidate");
+        // The `?.` here used to make this VACUOUS — with the attribute absent the expression was
+        // null and nothing was asserted, so it stayed green throughout the period `novalidate` was
+        // applied by a script bUnit never runs (#206).
+        var novalidate = editForm.Attributes.FirstOrDefault(a => a.Name == "novalidate");
+
+        novalidate.ShouldNotBeNull();
+        novalidate.Value.ShouldBe("novalidate");
 
         // Ensure DataAnnotationsValidator is NOT present to avoid duplicate validation messages
         component.FindComponents<DataAnnotationsValidator>().Count.ShouldBe(0);

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **`novalidate` is now a rendered attribute on the form, not something applied by a script afterwards.** The library documents its forms as `novalidate` — server-side validation, messages from your configured validator, no native browser bubbles — but the attribute was bolted on after first render with `JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?.setAttribute(…)")`. That missed in three ways: it marked the **first** form in the document rather than FormCraft's (so a search or login form higher up the page got marked instead, and with two FormCraft forms the second was never marked at all), it never ran during **prerender/SSR**, and it failed silently. Being `eval`, a strict **CSP** blocked it outright — silently and totally. The attribute is now in the markup, so it targets the right form by construction, survives prerender, and needs no JavaScript (#206)
+
+  **Worth knowing if you rely on it.** This is the guarantee `.WithAttribute("Required", true)` (#193) depends on: that opt-in emits a genuine HTML5 `required`, and on a page where the script missed, the browser really did enforce it — producing exactly the native validation bubbles this library says it never produces.
+
 - **A password field combined with a multi-line setting was rendering in clear text — on both render paths. Masking now wins.** `.AsPassword()` together with `.AsTextArea(...)` (or any `Lines > 1`) made MudBlazor emit a `<textarea>`, and a textarea has no `type` attribute, so the masking was silently dropped and the credential was displayed. Unlike #189 this was not a drift between the two render paths — both had the same gap. Such a field now renders **masked, on a single line**, and FormCraft logs a warning naming the field and the line count it dropped (#207)
 
   ```csharp


### PR DESCRIPTION
Implements #206.

Closes #206.

`novalidate` is now a **rendered attribute** on the form instead of being bolted on after first render
by `JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?.setAttribute(…)")`.

### Plan
- [x] Task 1: Pin the guarantee with a failing test
- [x] Task 2: Render `novalidate` as a real attribute
- [x] Task 3: Make the documentation match the code

### Why this was worth fixing rather than tidying

The script missed in three ways — wrong form (`querySelector('form')` is the *first* form in the
document), never during prerender (`OnAfterRenderAsync` does not run on the server pass), and
silently (`?.` swallowed the miss). Being `eval`, a strict **CSP** blocked it outright, making the
failure silent *and* total.

That matters because #190 removed the HTML5 `Required` attribute from collection item fields **on the
strength of this guarantee**, and #193 added `.WithAttribute("Required", true)` as an opt-in that
emits a genuine `required`. On a page where the script missed, the browser really did enforce it —
producing exactly the native validation bubbles the library documents itself as never producing. The
last test in `NoValidateTests` asserts both halves together for that reason.

### The two tests that were guarding this were passing vacuously

Worth calling out, because it is the same disease as the issue itself:

```csharp
form.Attributes.FirstOrDefault(a => a.Name == "novalidate")?.Value.ShouldBe("novalidate");
```

With the attribute **absent** — which it always was, since bUnit runs no JavaScript — `?.`
short-circuits and **no assertion executes**. `FormCraftComponent_Should_Have_Novalidate_Attribute`
reported green for the entire period the attribute was missing. Both copies (core and MudBlazor
suites) now assert `ShouldNotBeNull()` first, so they cannot pass on an absent attribute again.

This is also why the attribute renders as `novalidate="novalidate"` rather than bare `novalidate`:
both are valid HTML, but the explicit value matches what the old script set and what those
assertions have always claimed.

### Changes
- `FormCraftComponent.razor` — `novalidate="novalidate"` on the `EditForm`; the `OnAfterRenderAsync`
  override, the `IJSRuntime` injection and the `@using Microsoft.JSInterop` are all gone (nothing
  else used them).
- `NoValidateTests` — 4 new tests: the attribute renders; a *preceding unrelated* `<form>` is left
  untouched while FormCraft's is marked; two FormCraft forms are **both** marked; and #193's opt-in
  still emits `required` inside a `novalidate` form.
- `README.md`, `CLAUDE.md`, `CollectionRequiredTests` — the guarantee is stated unqualified now that
  it holds, with a ⛔ note against reintroducing the `eval` version.

Full suite green: 1066 tests, 0 warnings under `TreatWarningsAsErrors`.
