### PR TITLE
feat(mudblazor): add a typed builder method for the native required opt-in (#204)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/RenderPipelineParityTests.cs
@@ -463,12 +463,50 @@ public class RenderPipelineParityTests : MudBlazorTestBase
         standaloneRender.Find("input").GetAttribute("type").ShouldBe("password");
         itemRender.Find("input").GetAttribute("type").ShouldBe("password");
 
-        // Required is the one compared attribute whose agreed value IS the default (#190): both
-        // paths must render false for a .Required(...) field, because validation here is
-        // server-side. So unlike the others it cannot be guarded by asserting a non-default —
-        // its bite comes from the collection path, which used to render true off field.IsRequired
-        // and would diverge from this standalone false the moment that emission came back.
+        // Required is compared here at its agreed DEFAULT (#190): both paths must render false for a
+        // .Required(...) field, because validation here is server-side. Its bite comes from the
+        // collection path, which used to render true off field.IsRequired and would diverge from
+        // this standalone false the moment that emission came back. The non-default direction — the
+        // explicit .WithNativeRequired() opt-in — is guarded by the test below (#204).
         standalone.Required.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NativeRequiredOptIn_Should_Be_Honoured_Identically_On_Both_Paths()
+    {
+        // Arrange - #204. `.WithNativeRequired()` (and the raw "Required" attribute it replaces) used
+        // to be read ONLY by CollectionFieldComponent, so the escape hatch worked inside an item form
+        // and was silently ignored outside one. This is the non-default direction of the Required
+        // comparison: the test above pins that both paths agree on `false` for `.Required(...)`,
+        // this one pins that both agree on `true` when the decoration is explicitly asked for.
+        static void Configure<TOwner>(FieldBuilder<TOwner, string> field)
+            where TOwner : new()
+            => field.WithLabel("Product").WithNativeRequired();
+
+        var standaloneConfig = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Status, Configure)
+            .Build();
+
+        var collectionConfig = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item.AddField(x => x.ProductName, Configure)))
+            .Build();
+
+        // Act
+        var standaloneRender = RenderForm(standaloneConfig);
+        var itemRender = Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, collectionConfig));
+
+        // Assert - the parameter on both, and the attribute on the element the browser sees.
+        standaloneRender.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+        itemRender.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+
+        standaloneRender.Find("input").HasAttribute("required").ShouldBeTrue();
+        itemRender.Find("input").HasAttribute("required").ShouldBeTrue();
     }
 
     [Fact]
@@ -689,10 +727,12 @@ public class RenderPipelineParityTests : MudBlazorTestBase
     /// looking like coverage:
     /// </para>
     /// <list type="bullet">
-    /// <item>The raw <c>"Required"</c> attribute — collection path only. <c>.Required(...)</c> is
-    /// compared above and agrees, but <c>.WithAttribute("Required", true)</c> is read solely by
-    /// <c>CollectionFieldComponent</c>; no component-path renderer looks for that key, so the
-    /// opt-in is honoured inside an item form and ignored outside one.</item>
+    /// <item>✅ <b>Resolved in #204</b> — the native-required opt-in used to be collection-path only:
+    /// <c>.WithAttribute("Required", true)</c> was read solely by <c>CollectionFieldComponent</c>, so
+    /// it was honoured inside an item form and silently ignored outside one. Both paths now read it
+    /// (via the typed <c>.WithNativeRequired()</c>), and <c>Required</c> is compared in
+    /// <c>Presentation()</c> below. <c>.Required(...)</c> alone still renders <c>false</c> on both,
+    /// which is the #190 invariant.</item>
     /// <item><c>EnablePasswordToggle</c> — component path only: <c>.AsPassword()</c> puts a
     /// visibility eye on a standalone field and nothing on an item field. The masking itself is
     /// compared (see <c>InputType</c> below); only the toggle affordance diverges.</item>

--- a/FormCraft.ForMudBlazor.UnitTests/Extensions/NativeRequiredBuilderTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Extensions/NativeRequiredBuilderTests.cs
@@ -102,6 +102,60 @@ public class NativeRequiredBuilderTests
         Attributes(config).ContainsKey("Required").ShouldBeFalse();
     }
 
+    [Fact]
+    public void WithNativeRequired_Should_Be_Honoured_On_The_Component_Path()
+    {
+        // Arrange - #204 Task 3, decided rather than left open. Before this the opt-in reached the
+        // collection item path only, so `.WithNativeRequired()` on an ordinary field silently did
+        // nothing. An escape hatch that works on one render path and not the other is the exact
+        // divergence class this library keeps re-filing (#146, #177, #184, #189).
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name").WithNativeRequired())
+            .Build();
+
+        // Act
+        var component = new TestHost().Render(config);
+
+        // Assert - the component property, the class MudBlazor's asterisk hangs off, and the
+        // attribute on the element the user's browser and screen reader actually see.
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+        component.FindAll(".mud-input-required").ShouldNotBeEmpty();
+        component.Find("input").HasAttribute("required").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void A_Field_Without_The_Opt_In_Should_Not_Be_Decorated_On_The_Component_Path()
+    {
+        // Arrange - the guard on the guard: `.Required(...)` must still emit nothing (#190), and an
+        // unconfigured field must be untouched. This is the overwhelmingly common case.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithLabel("Name").Required("Name is required"))
+            .Build();
+
+        // Act
+        var component = new TestHost().Render(config);
+
+        // Assert
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeFalse();
+        component.Find("input").HasAttribute("required").ShouldBeFalse();
+        component.FindAll(".mud-input-required").ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// bUnit host for the two component-path cases above. The rest of this suite asserts on the
+    /// built configuration and needs no renderer, so the bUnit dependency is confined here.
+    /// </summary>
+    private sealed class TestHost : MudBlazorTestBase
+    {
+        public IRenderedComponent<FormCraftComponent<TestModel>> Render(
+            IFormConfiguration<TestModel> config) =>
+            Render<FormCraftComponent<TestModel>>(parameters => parameters
+                .Add(p => p.Model, new TestModel())
+                .Add(p => p.Configuration, config));
+    }
+
     private static IReadOnlyDictionary<string, object> Attributes(IFormConfiguration<TestModel> config) =>
         config.Fields[0].AdditionalAttributes;
 

--- a/FormCraft.ForMudBlazor.UnitTests/Extensions/NativeRequiredBuilderTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Extensions/NativeRequiredBuilderTests.cs
@@ -1,0 +1,113 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Extensions;
+
+/// <summary>
+/// Tests the typed builder method for MudBlazor's native required decoration (#204).
+/// </summary>
+/// <remarks>
+/// #193 introduced the opt-in as a documented magic string — <c>.WithAttribute("Required", true)</c> —
+/// which is undiscoverable, unchecked by the compiler, and one typo (<c>"required"</c>) away from
+/// silently doing nothing. These tests pin the typed replacement and the fact that the raw string
+/// keeps working, since this is additive rather than a breaking change.
+/// </remarks>
+public class NativeRequiredBuilderTests
+{
+    [Fact]
+    public void WithNativeRequired_Should_Write_The_Required_Attribute()
+    {
+        // Arrange & Act
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithNativeRequired())
+            .Build();
+
+        // Assert
+        Attributes(config)["Required"].ShouldBe(true);
+    }
+
+    [Fact]
+    public void WithNativeRequired_False_Should_Write_False()
+    {
+        // Arrange & Act - an explicit opt-out has to be expressible, or the method is a one-way door.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.WithNativeRequired(false))
+            .Build();
+
+        // Assert
+        Attributes(config)["Required"].ShouldBe(false);
+    }
+
+    [Fact]
+    public void WithNativeRequired_Should_Write_The_Same_Attribute_As_The_Raw_String()
+    {
+        // Arrange & Act - the typed method must be a pure alias, not a parallel mechanism: the raw
+        // form is documented and in use, and two keys meaning "required" would be a new divergence.
+        var typed = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Name, f => f.WithNativeRequired())
+            .Build();
+
+        var raw = FormBuilder<TestModel>.Create()
+            .AddField(x => x.Name, f => f.WithAttribute("Required", true))
+            .Build();
+
+        // Assert
+        Attributes(typed)["Required"].ShouldBe(Attributes(raw)["Required"]);
+    }
+
+    [Fact]
+    public void WithNativeRequired_Should_Return_The_Same_Builder_For_Chaining()
+    {
+        // Arrange
+        var config = FormBuilder<TestModel>.Create();
+        FieldBuilder<TestModel, string>? captured = null;
+        FieldBuilder<TestModel, string>? returned = null;
+
+        // Act
+        config.AddField(x => x.Name, f =>
+        {
+            captured = f;
+            returned = f.WithNativeRequired();
+        });
+
+        // Assert - the fluent contract: With* configures and returns `this`, no side effects.
+        returned.ShouldBeSameAs(captured);
+    }
+
+    [Fact]
+    public void WithNativeRequired_Should_Be_Available_On_A_Numeric_Field()
+    {
+        // Arrange & Act - declared on the general TValue overload rather than string-only, so the
+        // numeric and date item renderers can use it too. This would not compile if it were
+        // constrained to string.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Quantity, f => f.WithNativeRequired())
+            .Build();
+
+        // Assert
+        Attributes(config)["Required"].ShouldBe(true);
+    }
+
+    [Fact]
+    public void Required_Alone_Should_Not_Write_The_Native_Attribute()
+    {
+        // Arrange & Act - the #190 invariant, restated here so a regression names itself: validation
+        // is server-side, and `.Required(...)` must never start emitting the HTML5 decoration again.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f.Required("Name is required"))
+            .Build();
+
+        // Assert
+        Attributes(config).ContainsKey("Required").ShouldBeFalse();
+    }
+
+    private static IReadOnlyDictionary<string, object> Attributes(IFormConfiguration<TestModel> config) =>
+        config.Fields[0].AdditionalAttributes;
+
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Quantity { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -253,6 +253,93 @@ public class CollectionRequiredTests : MudBlazorTestBase
         textField.ErrorText.ShouldBeNullOrEmpty();
     }
 
+    [Fact]
+    public void TextItemField_With_WithNativeRequired_Should_Render_The_Decoration()
+    {
+        // Arrange & Act - #204. The same opt-in as the raw string above, through the typed method.
+        // Asserted on all three renderers fed by AddCommonFieldAttributes, because the escape hatch
+        // being text-only would be the exact divergence class this library keeps re-filing.
+        var component = RenderOrderForm(BuildConfiguration(field => field.WithNativeRequired()));
+
+        // Assert - the component property, and the class MudBlazor's asterisk hangs off.
+        component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
+        component.FindAll(".mud-input-required").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void NumericItemField_With_WithNativeRequired_Should_Render_The_Decoration()
+    {
+        // Arrange - the second renderer. WithNativeRequired is declared on the general TValue
+        // overload rather than string-only precisely so this compiles.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field
+                        .WithLabel("Quantity")
+                        .WithNativeRequired())))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Required.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DateItemField_With_WithNativeRequired_Should_Render_The_Decoration()
+    {
+        // Arrange - the third renderer, MudDatePicker.
+        var config = FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field => field
+                        .WithLabel("When")
+                        .WithNativeRequired())))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
+            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BooleanItemField_With_WithNativeRequired_Should_Be_Inert()
+    {
+        // Arrange - RenderBooleanField sets its own attributes and never calls
+        // AddCommonFieldAttributes, so the opt-in is inert here through the typed method exactly as
+        // through the raw string. Pinned rather than fixed, mirroring the adornment inertness test
+        // (#184): the claim is that configuring it is harmless, not that it works.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.IsGift, field => field
+                        .WithLabel("Gift")
+                        .WithNativeRequired())))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
+        component.FindAll(".mud-input-required").ShouldBeEmpty();
+    }
+
     private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
         IFormConfiguration<OrderModel> config)
     {

--- a/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
+++ b/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
@@ -182,6 +182,50 @@ public static class MudBlazorFieldBuilderExtensions
     }
 
     /// <summary>
+    /// Opts this field into MudBlazor's native required decoration — the HTML5 <c>required</c>
+    /// attribute and MudBlazor's required styling on the rendered input.
+    /// </summary>
+    /// <typeparam name="TModel">The model type that the form binds to.</typeparam>
+    /// <typeparam name="TValue">The type of the field value.</typeparam>
+    /// <param name="builder">The FieldBuilder instance.</param>
+    /// <param name="enabled">Whether to apply the native decoration (default: <c>true</c>).</param>
+    /// <returns>The FieldBuilder instance for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// ⚠️ **This adds no validation.** It is presentation only. <c>.Required("…")</c> is what makes a
+    /// field actually required — it registers a validator, and FormCraft's validation is server-side
+    /// with messages from the validator you configured. The two are deliberately separate: #190
+    /// removed the native attribute from <c>.Required(...)</c> because the same call emitted it
+    /// inside <c>.WithItemForm(...)</c> and not outside, and because native browser validation
+    /// contradicts the library's stance. This method is the explicit opt-in for the cases that want
+    /// the decoration anyway.
+    /// </para>
+    /// <para>
+    /// Replaces the documented magic string <c>.WithAttribute("Required", true)</c> from #193, which
+    /// is undiscoverable and one typo away from silently doing nothing (#204). The raw form still
+    /// works and writes the same attribute — this is additive.
+    /// </para>
+    /// <para>
+    /// Forms render <c>novalidate</c> (#206), so the browser does not enforce the attribute on a
+    /// FormCraft form; what it buys is the semantics and the styling, not native validation bubbles.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// .AddField(x => x.Email, field => field
+    ///     .Required("Email is required")   // the validation
+    ///     .WithNativeRequired())           // the decoration
+    /// </code>
+    /// </example>
+    public static FieldBuilder<TModel, TValue> WithNativeRequired<TModel, TValue>(
+        this FieldBuilder<TModel, TValue> builder,
+        bool enabled = true)
+        where TModel : new()
+    {
+        return builder.WithAttribute("Required", enabled);
+    }
+
+    /// <summary>
     /// Adds an adornment (icon or text) to a text field.
     /// </summary>
     /// <typeparam name="TModel">The model type that the form binds to.</typeparam>

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateOnlyFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateOnlyFieldComponent.razor
@@ -13,6 +13,7 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     DateFormat="@Format"
     Editable="true"
     MinDate="@MinDate"

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorDateTimeFieldComponent.razor
@@ -14,6 +14,7 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     DateFormat="@Format"
     Editable="true"
     MinDate="@MinDate"

--- a/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorTimeOnlyFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/DateTimeField/MudBlazorTimeOnlyFieldComponent.razor
@@ -13,5 +13,6 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     Editable="true"
     Clearable="@ShowClearButton" />

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -116,6 +116,20 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     protected Color EffectiveAdornmentColor => GetAttribute("AdornmentColor", Color.Default);
 
     /// <summary>
+    /// Whether the field opted into MudBlazor's native required decoration via
+    /// <c>.WithNativeRequired()</c> (or the equivalent raw <c>"Required"</c> attribute). Defaults to
+    /// <c>false</c> (#204).
+    /// </summary>
+    /// <remarks>
+    /// ⛔ Deliberately read from the attribute and **never** from <c>Context.Field.IsRequired</c>.
+    /// Driving it from <c>.Required(...)</c> is exactly what #190 removed: FormCraft's validation is
+    /// server-side, and the same call emitted the HTML5 attribute inside <c>.WithItemForm(...)</c>
+    /// and not outside it. This is the explicit opt-in for callers who want the decoration anyway,
+    /// and it is honoured on both render paths so the escape hatch does not work on only one of them.
+    /// </remarks>
+    protected bool EffectiveNativeRequired => GetAttribute("Required", false);
+
+    /// <summary>
     /// Service provider used to resolve an optional <see cref="ILoggerFactory"/> for the
     /// ShrinkLabel diagnostic. Diagnostics degrade silently when no logger is registered.
     /// </summary>

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
@@ -23,4 +23,5 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     Immediate="true" />

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
@@ -23,4 +23,5 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     Immediate="true" />

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor
@@ -23,4 +23,5 @@
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"
+    Required="@EffectiveNativeRequired"
     Immediate="true" />

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **`.WithNativeRequired()` replaces the `.WithAttribute("Required", true)` magic string — and now works on ordinary fields too.** #193 introduced the native-required opt-in as a documented raw string: undiscoverable by IntelliSense, unchecked by the compiler, and one typo (`"required"`) away from silently doing nothing. It is now a typed builder method, declared for every field type rather than strings only. The raw string keeps working and writes the same attribute, so this is additive (#204)
+
+  ```csharp
+  .AddField(x => x.Email, field => field
+      .Required("Email is required")   // the validation — server-side, your message
+      .WithNativeRequired())           // the decoration — asterisk + HTML5 attribute
+  ```
+
+  **The opt-in was collection-only, and no longer is.** A raw `"Required"` attribute was read solely by `CollectionFieldComponent`, so the escape hatch was honoured inside `.WithItemForm(...)` and silently ignored outside it. Both render paths now honour it, and `RenderPipelineParityTests` compares them. `.Required(...)` on its own still emits no HTML5 attribute on either path — that is the #190 behaviour and it is unchanged.
+
 - **`novalidate` is now a rendered attribute on the form, not something applied by a script afterwards.** The library documents its forms as `novalidate` — server-side validation, messages from your configured validator, no native browser bubbles — but the attribute was bolted on after first render with `JSRuntime.InvokeVoidAsync("eval", "document.querySelector('form')?.setAttribute(…)")`. That missed in three ways: it marked the **first** form in the document rather than FormCraft's (so a search or login form higher up the page got marked instead, and with two FormCraft forms the second was never marked at all), it never ran during **prerender/SSR**, and it failed silently. Being `eval`, a strict **CSP** blocked it outright — silently and totally. The attribute is now in the markup, so it targets the right form by construction, survives prerender, and needs no JavaScript (#206)
 
   **Worth knowing if you rely on it.** This is the guarantee `.WithAttribute("Required", true)` (#193) depends on: that opt-in emits a genuine HTML5 `required`, and on a page where the script missed, the browser really did enforce it — producing exactly the native validation bubbles this library says it never produces.
@@ -128,7 +138,7 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
   **⚠️ This is a visible change, not just an attribute change.** MudBlazor draws the required asterisk from a CSS rule on the `mud-input-required` class, which it only adds when `Required="true"`. So text, numeric **and date** item fields configured with `.Required(...)` lose their `*` — they now look exactly like ordinary `.Required(...)` fields, which never had one. `aria-required` likewise reports `false` on these fields as it already did on ordinary ones; identifying required fields to assistive technology is a gap the library has on **both** render paths, tracked separately rather than fixed on one side here.
 
-  **Opting back in.** `.WithAttribute("Required", true)` on a text, numeric or date item field renders `Required="true"` again, restoring both the asterisk and MudBlazor's native required semantics. The attribute is now read from that explicit opt-in rather than inferred from `.Required(...)`. Two limits worth knowing: the opt-in is **collection-only** (an ordinary field ignores a raw `"Required"` attribute — use `.Required(...)` there), and it is **inert on boolean item fields**, which render through a path that takes none of these shared attributes.
+  **Opting back in.** Use `.WithNativeRequired()` (see the note below) — or the raw `.WithAttribute("Required", true)`, which still works — on a text, numeric or date field to render `Required="true"` again, restoring both the asterisk and MudBlazor's native required semantics. The attribute is read from that explicit opt-in rather than inferred from `.Required(...)`. It is **inert on boolean item fields**, which render through a path that takes none of these shared attributes.
 
 - **`.WithAdornment(...)` now renders inside collection item forms.** A field configured with an adornment inside `.WithItemForm(...)` had the setting accepted and then silently discarded — no icon, no exception, no warning — while the identical call on an ordinary field rendered fine. Text and numeric item fields now forward `Adornment`, `AdornmentIcon` and `AdornmentColor` (#184)
 


### PR DESCRIPTION
Implements #204.

Closes #204.

Replaces #193's documented magic string with a typed, discoverable builder method — and resolves the
opt-in's render-path asymmetry deliberately rather than by omission.

### Plan
- [x] Task 1: Add the typed builder method
- [x] Task 2: Prove it drives all three item renderers
- [x] Task 3: Resolve the component-path asymmetry, then document

### `.WithNativeRequired()`

```csharp
.AddField(x => x.Email, field => field
    .Required("Email is required")   // the validation — server-side, your message
    .WithNativeRequired())           // the decoration — asterisk + HTML5 attribute
```

Declared on the general `TValue` overload rather than `string` only, so numeric and date fields can
use it — pinned by a test that would not compile otherwise. The XML docs say plainly that it adds
**no validation**: `.Required(...)` does that, and the two staying separate is the #190 behaviour.
The raw `.WithAttribute("Required", true)` still works and writes the same attribute — a test asserts
the two are equivalent, so this stays a pure alias rather than a parallel mechanism.

### Task 3 decision: the component path now honours it

Taking the plan's recommendation. Before this, a raw `"Required"` attribute was read **solely** by
`CollectionFieldComponent`, so `.WithNativeRequired()` on an ordinary field silently did nothing —
an escape hatch that works on one render path and not the other is the exact divergence class this
library keeps re-filing (#146, #177, #184, #189).

Wired through a single `EffectiveNativeRequired` on the shared component base, bound by the six
component-path renderers that have a MudBlazor `Required` parameter (text, numeric ×2, date/time ×3).
Boolean stays inert on **both** paths, which preserves parity rather than breaking it, and is pinned
by a test on each side.

### Guards

- `RenderPipelineParityTests` — the divergence bullet for the raw `"Required"` attribute is marked
  resolved, and a new case compares the opt-in **on** across both paths. The existing comparison only
  ever exercised `Required` at its agreed default (`false`); this adds the non-default direction,
  which is the one that actually bites.
- `CollectionRequiredTests` — the typed method now covered across text, numeric and date item
  renderers, plus boolean inertness, alongside the existing raw-string coverage.
- `.Required(...)` alone still emits no HTML5 attribute on either path — all pre-existing #190 tests
  pass unmodified.

Full suite green: 1079 tests, 0 warnings under `TreatWarningsAsErrors`.
