### PR TITLE
ci(release): never reach Publish on a non-releasing run (#221)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -138,11 +138,34 @@ jobs:
         with:
           user: ${{ env.NUGET_USER }}
 
-      # Test, Pack, then PublishIfNeeded -> Publish. On a dry-run NUGET_API_KEY is empty and the
-      # tag is absent, so PublishIfNeeded's static gate skips the push.
+      # The run step is split in two on `release_created`, and the split is the guarantee (#221).
+      #
+      # A non-releasing run invokes `Pack`, a target that has no path to `Publish` at all — the same
+      # reason continuous.yml invokes `Pack` rather than `Continuous`. Previously a single
+      # unconditional `./build.cmd Continuous` ran on every invocation, and `Continuous` triggers
+      # `PublishIfNeeded`, so nothing structural stopped a dispatch from reaching the publish target:
+      # safety rested entirely on PublishIfNeeded's `OnlyWhenStatic(IsOnVersionTag() && IsServerBuild)`
+      # gate holding. That gate is real, but it is a runtime check on the tag rather than an absence
+      # of the code path, and `origin/main` IS the v3.1.0 commit — so a dispatch that happened to
+      # check out a tagged commit satisfied it. One target that cannot publish is a stronger claim
+      # than one that is expected not to.
+      #
+      # The two conditions are exhaustive and mutually exclusive, so exactly one step runs on every
+      # invocation and the job can never silently do neither.
+      #
+      # ⛔ The publishing step below is byte-identical to the step this replaced, apart from its `if:`
+      # — the real release path is deliberately unchanged.
+      - name: 'Run: Pack (no release — cannot publish)'
+        if: ${{ needs.release-please.outputs.release_created != 'true' }}
+        run: ./build.cmd Pack
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Test, Pack, then PublishIfNeeded -> Publish.
       # `dotnet nuget push` runs with --skip-duplicate (EnableSkipDuplicate in build/Build.cs), so
       # re-running a release is idempotent.
       - name: 'Run: Continuous'
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
         run: ./build.cmd Continuous
         env:
           NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,10 +27,14 @@ on:
   #
   # ⚠️ This is NOT an unconditional dry-run. In the ordinary case — no merged release PR waiting to
   # be processed — release-please only refreshes the release PR, `release_created` stays false, and
-  # the publish steps below all skip. But if a release PR has already been merged and its own run
-  # did not complete, a dispatch will legitimately finish the job: create the tag and the Release,
-  # set `release_created` to true, and publish. That is the intended recovery path; just do not
-  # click it expecting a guaranteed no-op.
+  # the job runs `./build.cmd Pack`, a target with no path to `Publish` at all (#221). But if a
+  # release PR has already been merged and its own run did not complete, a dispatch will legitimately
+  # finish the job: create the tag and the Release, set `release_created` to true, and publish. That
+  # is the intended recovery path; just do not click it expecting a guaranteed no-op.
+  #
+  # So the guarantee is precise: a dispatch cannot publish *when no release was created*, and that
+  # holds because a non-releasing run never invokes the publishing target — not because a gate inside
+  # that target is expected to hold.
   workflow_dispatch:
 
 permissions:
@@ -75,9 +79,11 @@ jobs:
   #   - No publish path may ever run on `pull_request`. This workflow has no pull_request trigger,
   #     and a fork could not obtain this repository's OIDC token anyway — minting a key on a PR
   #     would be both pointless and a hard failure.
-  #   - Every publish step is gated on `release_created`, so a run that only refreshes the release
-  #     PR builds and packs but sends nothing to nuget.org. See the `workflow_dispatch` note above
-  #     for the one case where a manual run legitimately does publish.
+  #   - A run that only refreshes the release PR invokes `./build.cmd Pack`, a target that has no
+  #     path to `Publish` — it builds and packs and sends nothing to nuget.org. This is structural,
+  #     not a gate: `Continuous` (which triggers PublishIfNeeded) is invoked ONLY on the
+  #     `release_created == 'true'` branch (#221). See the `workflow_dispatch` note above for the one
+  #     case where a manual run legitimately does publish.
   #   - The tag and the GitHub Release are created BEFORE this job builds anything. If this job
   #     fails, the release exists with no packages attached. Recover with **Re-run failed jobs** —
   #     "Re-run all jobs" re-runs release-please, which now sees the release already created,

--- a/build/README.md
+++ b/build/README.md
@@ -47,12 +47,17 @@ On Windows use `build.cmd` / `build.ps1`; `build.cmd` also works on macOS and Li
 - **PublishIfNeeded** — the CI gate in front of `Publish`:
   `OnlyWhenStatic(IsOnVersionTag() && IsServerBuild)`. This is what makes the release workflow thin —
   it checks out the tag, so the gate is satisfied without any conditional logic in the workflow.
-- **Continuous** — `DependsOn(Test, Pack)`, triggering `PublishIfNeeded`. Invoked **only** by
-  `release-please.yml`'s `nupkg` job, which checks out the tag on purpose so the publish activates.
-  `continuous.yml` deliberately invokes `Pack` instead: `PublishIfNeeded`'s guard does not check
+- **Continuous** — `DependsOn(Test, Pack)`, triggering `PublishIfNeeded`. **The release-only path.**
+  It is invoked from exactly one place: the `release-please.yml` `nupkg` job's run step, which is
+  gated on `release_created == 'true'` and checks out the tag on purpose so the publish activates
+  (#221). Every other run — `continuous.yml`, and the `nupkg` job's own non-releasing branch —
+  invokes `Pack`, which has no path to `Publish` at all.
+
+  That is deliberate, and stronger than relying on the gate: `PublishIfNeeded`'s guard does not check
   whether a key exists, so on any tagged commit (`origin/main` *is* the `v3.1.0` commit, and each
   release tag lands on `dev`) `Continuous` would reach `Publish` and hard-fail its
-  `Requires(NuGetApiKey)`.
+  `Requires(NuGetApiKey)`. A target that *cannot* publish is a stronger claim than one that is
+  *expected not to*.
 - **Release** — informational only; logs the version it would release
 
 ## Versioning
@@ -83,7 +88,7 @@ Do not hand-edit `CHANGELOG.md`. Your PR title is the changelog entry.
 |---|---|---|
 | `ci.yml` | push / PR | `./build.cmd Test` |
 | `continuous.yml` | push to `main`/`dev`, PRs | `./build.cmd Pack` — build, test, pack. **Never publishes**: it does not invoke the target that triggers publishing. |
-| `release-please.yml` | push to `dev`, `workflow_dispatch` | keeps the release PR open; on merge tags the release and, in the same run, publishes both packages via Trusted Publishing |
+| `release-please.yml` | push to `dev`, `workflow_dispatch` | keeps the release PR open; on merge tags the release and, in the same run, publishes both packages via Trusted Publishing. Its run step is **split on `release_created`**: a releasing run invokes `Continuous`, every other run invokes `Pack`, which cannot publish (#221) |
 | `pr-title-lint.yml` | `pull_request_target` | rejects a PR title that is not a Conventional Commit |
 
 The publish lives inside `release-please.yml` by necessity: release-please creates the tag with


### PR DESCRIPTION
Implements #221.

Closes #221.

A non-releasing run of `release-please.yml` now **cannot** reach `Publish`, structurally.

### Plan
- [x] Task 1: Split the run step on `release_created`
- [x] Task 2: Correct the prose that describes the dry-run
- [x] Task 3: Verify against a real run

### What changed

The `nupkg` job ran a single, unconditional `./build.cmd Continuous`. `Continuous` triggers
`PublishIfNeeded`, so nothing structural stopped a dispatch from reaching the publish target — safety
rested entirely on `PublishIfNeeded`'s `OnlyWhenStatic(IsOnVersionTag() && IsServerBuild)` holding.
That gate is real, but it is a runtime check on the tag rather than an absence of the code path, and
**`origin/main` *is* the `v3.1.0` commit** — a dispatch that checked out a tagged commit satisfied it.

The run step is now split in two, gated on `release_created`:

| condition | target | `NUGET_API_KEY` in env |
|---|---|---|
| `!= 'true'` | `./build.cmd Pack` — no path to `Publish` at all | **no** |
| `== 'true'` | `./build.cmd Continuous` | yes |

The conditions are exhaustive and mutually exclusive, so exactly one step runs on every invocation and
the job can never silently do neither. Verified by parsing the workflow and printing each step's `if:`
and `env:` rather than by reading it:

```
'Run: Pack (no release — cannot publish)'   if=… != 'true'   env=['GITHUB_TOKEN']
'Run: Continuous'                           if=… == 'true'   env=['GITHUB_TOKEN', 'NUGET_API_KEY']
```

**The publishing step is byte-identical to the one it replaced apart from its `if:`** — the real
release path provably does not change. `build/Build.cs` is untouched, as the plan requires: Actions
decides *when*, Nuke decides *how*.

### Prose corrected

Every claim that safety comes from the gate holding is reworded to say the non-releasing run invokes a
target that cannot publish:
- the `workflow_dispatch` header note — now states the guarantee precisely (a dispatch cannot publish
  *when no release was created*, and why), while keeping the existing warning that a dispatch
  finishing a merged-but-incomplete release legitimately **does** publish;
- the `nupkg` job's safety-properties list;
- `build/README.md` — `Continuous` is described as the release-only path, and the workflow table
  records the split.
