### PR TITLE
fix(mudblazor): honour Format and ShowSpinButtons on numeric fields (#208)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/NumericFormatTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/NumericFormatTests.cs
@@ -1,0 +1,182 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that <c>Format</c> and <c>ShowSpinButtons</c> reach MudBlazor on both render paths (#208).
+/// </summary>
+/// <remarks>
+/// Both were resolved in the numeric components' <c>OnInitialized</c> and then never bound in the
+/// <c>.razor</c> — read and dropped, the same defect #191 fixed for adornments three lines above
+/// them. <c>ShowSpinButtons</c> is even part of the public
+/// <c>INumericFieldComponent&lt;TModel, TValue&gt;</c> contract, so the library advertised a setting
+/// it discarded.
+/// <para>
+/// The spin-button assertions look at the rendered markup rather than the component parameter. A
+/// parameter that is set but never forwarded is exactly the failure being fixed, so asserting the
+/// parameter alone would have passed both before and after.
+/// </para>
+/// </remarks>
+public class NumericFormatTests : MudBlazorTestBase
+{
+    [Fact]
+    public void NumericField_Should_Honour_ShowSpinButtons_False()
+    {
+        // Arrange & Act
+        var component = RenderNumeric(f => f.WithAttribute("ShowSpinButtons", false));
+
+        // Assert - MudBlazor draws the spin buttons as adornment buttons inside the input; with the
+        // setting honoured there are none.
+        component.FindComponent<MudNumericField<int>>().Instance.HideSpinButtons.ShouldBeTrue();
+        component.FindAll(".mud-input-numeric-spin").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void NumericField_Should_Show_Spin_Buttons_By_Default()
+    {
+        // Arrange & Act - the default must stay MudBlazor's own `true`, so an unconfigured field is
+        // untouched by this change. That is what keeps the behaviour change scoped to forms that
+        // actually pass the attribute.
+        var component = RenderNumeric(_ => { });
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.HideSpinButtons.ShouldBeFalse();
+        component.FindAll(".mud-input-numeric-spin").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void NumericField_Should_Honour_Format()
+    {
+        // Arrange & Act
+        var component = RenderNumeric(f => f.WithAttribute("Format", "N2"));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Format.ShouldBe("N2");
+    }
+
+    [Fact]
+    public void NullableNumericField_Should_Honour_ShowSpinButtons_False()
+    {
+        // Arrange & Act - the nullable component is a separate file with its own copy of the
+        // read-and-drop, so it needs its own coverage rather than inheriting confidence.
+        var component = RenderNullableNumeric(f => f.WithAttribute("ShowSpinButtons", false));
+
+        // Assert
+        component.FindComponent<MudNumericField<int?>>().Instance.HideSpinButtons.ShouldBeTrue();
+        component.FindAll(".mud-input-numeric-spin").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void NullableNumericField_Should_Honour_Format()
+    {
+        // Arrange & Act
+        var component = RenderNullableNumeric(f => f.WithAttribute("Format", "N2"));
+
+        // Assert
+        component.FindComponent<MudNumericField<int?>>().Instance.Format.ShouldBe("N2");
+    }
+
+    [Fact]
+    public void NumericItemField_Should_Honour_ShowSpinButtons_False()
+    {
+        // Arrange & Act - the collection path builds its tree imperatively and forwards its own
+        // attribute set, so fixing only the component path would open a fresh divergence — the exact
+        // thing RenderPipelineParityTests exists to close.
+        var component = RenderNumericItem(f => f.WithAttribute("ShowSpinButtons", false));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.HideSpinButtons.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NumericItemField_Should_Honour_Format()
+    {
+        // Arrange & Act
+        var component = RenderNumericItem(f => f.WithAttribute("Format", "N2"));
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Format.ShouldBe("N2");
+    }
+
+    [Fact]
+    public void NumericItemField_Should_Show_Spin_Buttons_By_Default()
+    {
+        // Arrange & Act - parity on the default too, not just on the configured value.
+        var component = RenderNumericItem(_ => { });
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.HideSpinButtons.ShouldBeFalse();
+    }
+
+    private IRenderedComponent<FormCraftComponent<NumericModel>> RenderNumeric(
+        Action<FieldBuilder<NumericModel, int>> configure)
+    {
+        var config = FormBuilder<NumericModel>
+            .Create()
+            .AddField(x => x.Quantity, field =>
+            {
+                field.WithLabel("Quantity");
+                configure(field);
+            })
+            .Build();
+
+        return Render<FormCraftComponent<NumericModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericModel())
+            .Add(p => p.Configuration, config));
+    }
+
+    private IRenderedComponent<FormCraftComponent<NullableNumericModel>> RenderNullableNumeric(
+        Action<FieldBuilder<NullableNumericModel, int?>> configure)
+    {
+        var config = FormBuilder<NullableNumericModel>
+            .Create()
+            .AddField(x => x.Quantity, field =>
+            {
+                field.WithLabel("Quantity");
+                configure(field);
+            })
+            .Build();
+
+        return Render<FormCraftComponent<NullableNumericModel>>(parameters => parameters
+            .Add(p => p.Model, new NullableNumericModel())
+            .Add(p => p.Configuration, config));
+    }
+
+    private IRenderedComponent<FormCraftComponent<BasketModel>> RenderNumericItem(
+        Action<FieldBuilder<BasketLine, int>> configure)
+    {
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field =>
+                    {
+                        field.WithLabel("Quantity");
+                        configure(field);
+                    })))
+            .Build();
+
+        return Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+    }
+
+    private class NumericModel
+    {
+        public int Quantity { get; set; }
+    }
+
+    private class NullableNumericModel
+    {
+        public int? Quantity { get; set; }
+    }
+
+    private class BasketModel
+    {
+        public List<BasketLine> Lines { get; set; } = new();
+    }
+
+    private class BasketLine
+    {
+        public int Quantity { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -302,6 +302,22 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // fully-anchored regex here becomes invalid (e.g. "...?*"). The component's
         // default pattern already handles decimal input; only Culture is needed.
         builder.AddAttribute(CallerAttributeStart + 3, "Culture", System.Globalization.CultureInfo.InvariantCulture);
+
+        // #208. The component path resolved Format and ShowSpinButtons and then never bound them;
+        // this path never forwarded them at all. Fixing only the component path would have opened a
+        // fresh divergence, which is the failure RenderPipelineParityTests exists to close.
+        //
+        // ShowSpinButtons is FormCraft's public name (INumericFieldComponent); MudBlazor 9 takes the
+        // inverse, HideSpinButtons. The default is `true` here to match the component path's default,
+        // so an item field that configures neither renders exactly as it did before.
+        //
+        // Sequence numbers: this run now ends at CallerAttributeStart + 5 (25), still clear of
+        // TextAttributeStart (30).
+        builder.AddAttribute(CallerAttributeStart + 4, "Format",
+            GetItemFieldAttribute<string?>(field, "Format", null));
+        builder.AddAttribute(CallerAttributeStart + 5, "HideSpinButtons",
+            !GetItemFieldAttribute(field, "ShowSpinButtons", true));
+
         builder.CloseComponent();
     }
 

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
@@ -4,6 +4,9 @@
 @inherits MudBlazorFieldComponentBase<TModel, TValue?>
 @implements INumericFieldComponent<TModel, TValue>
 
+@* `Format` and `HideSpinButtons` are bound below for #208 — see the sibling non-nullable component
+   for the rationale, including why FormCraft's ShowSpinButtons is inverted into MudBlazor's
+   HideSpinButtons, and why this comment sits outside the tag (MUD0002). *@
 <MudNumericField
     T="TValue?"
     Label="@Label"
@@ -17,6 +20,8 @@
     Max="@(Max ?? GetTypeMaxValue())"
     Step="@(Step ?? GetDefaultStep())"
     Culture="@Culture"
+    Format="@Format"
+    HideSpinButtons="@(!ShowSpinButtons)"
     Adornment="@EffectiveAdornment"
     AdornmentIcon="@EffectiveAdornmentIcon"
     AdornmentColor="@EffectiveAdornmentColor"

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
@@ -4,6 +4,15 @@
 @inherits MudBlazorFieldComponentBase<TModel, TValue>
 @implements INumericFieldComponent<TModel, TValue>
 
+@* `Format` and `HideSpinButtons` are bound below for #208. Both were resolved in OnInitialized and
+   then never bound — read and dropped, the same defect #191 fixed for the three adornment parameters.
+
+   Note the inversion: FormCraft's public contract (INumericFieldComponent) exposes ShowSpinButtons,
+   while MudBlazor 9's MudNumericField takes HideSpinButtons. Keeping our name and inverting here is
+   deliberate — the contract is public API, MudBlazor's spelling is an implementation detail.
+
+   The comment lives outside the tag because MudBlazor's MUD0002 analyser rejects a razor comment
+   between component attributes as an illegal attribute. *@
 <MudNumericField
     T="TValue"
     Label="@Label"
@@ -17,6 +26,8 @@
     Max="@(Max ?? GetTypeMaxValue())"
     Step="@(Step ?? GetDefaultStep())"
     Culture="@Culture"
+    Format="@Format"
+    HideSpinButtons="@(!ShowSpinButtons)"
     Adornment="@EffectiveAdornment"
     AdornmentIcon="@EffectiveAdornmentIcon"
     AdornmentColor="@EffectiveAdornmentColor"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **`Format` and `ShowSpinButtons` now take effect on numeric fields — on both render paths.** Both were resolved in the numeric components' `OnInitialized` and then never bound, so `.WithAttribute("Format", "N2")` and `.WithAttribute("ShowSpinButtons", false)` were silently discarded. `ShowSpinButtons` is part of the public `INumericFieldComponent<TModel, TValue>` contract, so the library advertised a setting it dropped. The collection item path never forwarded either, and now does (#208)
+
+  **This is a behaviour change** for any form already passing them: they start working. `ShowSpinButtons` defaults to `true`, matching MudBlazor, so a field that configures neither renders exactly as before.
+
 - **`.WithInputType("number" | "date" | "time")` now renders the type it names.** All three fell through to `type="text"`, so a string field configured with one lost its mobile numeric keypad or its native date/time picker — silently, with nothing reported. The recognised set is now `email`, `password`, `tel`/`telephone`, `url`, `search`, `number`, `date` and `time`; anything else still falls back to `text` rather than throwing (#210)
 
   **Not a change to auto-generated forms.** `AddFieldsAuto()` emits these same strings for numeric, date and time *properties*, but those render through `MudNumericField` / `MudDatePicker` / `MudTimePicker`, which never consulted this mapping — it applies to `string` fields only. Pinned by a test so the scope is measured rather than assumed.


### PR DESCRIPTION
Implements #208.

Closes #208.

`Format` and `ShowSpinButtons` were resolved in the numeric components' `OnInitialized` and then never
bound — read and dropped, the same defect #191 fixed for adornments. The collection item path never
forwarded either. Both now work, on both paths.

### Plan
- [x] Task 1: Bind both parameters on the component path
- [x] Task 2: Forward both on the collection path
- [x] Task 3: Release-note the behaviour change

### One thing the plan could not have known: MudBlazor has no `ShowSpinButtons`

The issue says to "bind both … the same way #191 bound the three adornment parameters". There is no
`ShowSpinButtons` parameter on MudBlazor 9's `MudNumericField` to bind — it takes the **inverse**,
`HideSpinButtons`. Confirmed from the shipped package's own XML docs
(`P:MudBlazor.MudNumericField\`1.HideSpinButtons`), not from memory.

`ShowSpinButtons` is FormCraft's **public** contract (`INumericFieldComponent<TModel, TValue>`), so
the name stays and the binding inverts: `HideSpinButtons="@(!ShowSpinButtons)"`. Our contract is API;
MudBlazor's spelling is an implementation detail.

### Verified against the rendered markup, not just the parameter

"Read and then dropped" is *precisely* a parameter that is set and never reaches the component, so a
parameter-only assertion would have passed before and after. The spin-button tests therefore assert
on `.mud-input-numeric-spin` in the DOM — and the class name was taken from MudBlazor's shipped CSS
after my first guess (`.mud-input-adornment button`) proved wrong and failed the default case
honestly rather than being quietly reworded.

The default case is a real discriminator: spin buttons **are** present with no configuration and
**absent** with `ShowSpinButtons=false`.

### Notes

- Sequence numbers on the collection path now run to `CallerAttributeStart + 5` (25), still clear of
  `TextAttributeStart` (30) — checked, not assumed, since they are a shared index space here.
- The hard-coded `InvariantCulture` on the numeric item path is deliberately **untouched** — that is
  #218.
- Razor comments had to go outside the component tags: MudBlazor's `MUD0002` analyser rejects a
  comment between component attributes as an illegal attribute, and this repo builds with
  `TreatWarningsAsErrors`.

Full suite green: 1105 tests, 0 warnings.
