### PR TITLE
fix(mudblazor): judge the ShrinkLabel diagnostic on the rendered adornment (#212)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -420,10 +420,84 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         });
     }
 
+    [Fact]
+    public void Should_Not_Warn_For_A_Date_Field_That_Renders_No_Adornment()
+    {
+        // Arrange - #212. MudDatePicker keeps its own calendar adornment and FormCraft's date
+        // components deliberately bind none of ours (#184, #191), so a configured start adornment is
+        // dropped. The label therefore floats exactly as asked — and the diagnostic used to tell the
+        // developer to remove a setting that was working.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.When, f => f
+                .WithLabel("When")
+                .WithAttribute("Adornment", Adornment.Start)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act - through the popover-providing host: MudDatePicker logs its own unrelated
+        // "Missing <MudPopoverProvider />" warning otherwise, which this logger would capture and
+        // which has nothing to do with ShrinkLabel.
+        RenderFormWithPopover(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Warn_For_A_Select_Field_That_Renders_No_Adornment()
+    {
+        // Arrange - a second component type that binds no adornment, so the fix is shown to be about
+        // the rule rather than about one special-cased component.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("City")
+                .WithSelectOptions([
+                    new SelectOption<string>("paris", "Paris"),
+                    new SelectOption<string>("london", "London")
+                ])
+                .WithAttribute("Adornment", Adornment.Start)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act - MudSelect also needs the popover provider; same reasoning as the date case above.
+        RenderFormWithPopover(config);
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Still_Warn_For_A_Numeric_Field_That_Does_Render_The_Adornment()
+    {
+        // Arrange - the guard on the fix. #191 made numeric adornments real, so this warning is
+        // CORRECT and must survive the removal of the false ones. Silencing everything would have
+        // been an easy way to make the negative tests above pass.
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.CityId, f => f
+                .WithLabel("City id")
+                .WithAttribute("Adornment", Adornment.Start)
+                .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search)
+                .WithShrinkLabel(false))
+            .Build();
+
+        // Act
+        RenderForm(config);
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("City id");
+        warnings[0].ShouldContain("Adornment");
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = string.Empty;
         public int CityId { get; set; }
+        public DateTime? When { get; set; }
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
+++ b/FormCraft.ForMudBlazor/Fields/MudBlazorFieldComponentBase.cs
@@ -116,6 +116,35 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     protected Color EffectiveAdornmentColor => GetAttribute("AdornmentColor", Color.Default);
 
     /// <summary>
+    /// The adornment this component actually <b>renders</b>, or <c>null</c> when it renders none of
+    /// ours. Defaults to <c>null</c>; only components that bind an adornment override it (#212).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ShrinkLabel diagnostic judges this rather than <c>GetAttribute&lt;Adornment?&gt;("Adornment")</c>.
+    /// Reading the configured value made date, select, autocomplete, lookup and file-upload fields
+    /// warn about an adornment they never draw — telling the developer to remove a
+    /// <c>ShrinkLabel=false</c> that was being honoured. A diagnostic that is wrong on most field
+    /// types trains people to ignore the channel, which costs more than the warning is worth.
+    /// </para>
+    /// <para>
+    /// This is the component-path half of the rule the collection path already states: *"the
+    /// diagnostic has to judge what this path actually RENDERS, not what was configured"* (#183).
+    /// There it is a per-call-site <c>rendersAdornment</c> flag; here it is this override.
+    /// </para>
+    /// <para>
+    /// <c>null</c> and <see cref="Adornment.None"/> are equally harmless —
+    /// <c>ShrinkLabelDiagnostic.Conflict</c> reacts only to <see cref="Adornment.Start"/>, since only
+    /// a start adornment sits where a floating label would go.
+    /// </para>
+    /// <para>
+    /// ⛔ Defaulting to <c>null</c> is deliberate: a newly added component type is silent until it
+    /// opts in. Warning wrongly is the defect this exists to fix, so the safe default is quiet.
+    /// </para>
+    /// </remarks>
+    protected virtual Adornment? RenderedAdornment => null;
+
+    /// <summary>
     /// Whether the field opted into MudBlazor's native required decoration via
     /// <c>.WithNativeRequired()</c> (or the equivalent raw <c>"Required"</c> attribute). Defaults to
     /// <c>false</c> (#204).
@@ -238,7 +267,7 @@ public abstract class MudBlazorFieldComponentBase<TModel, TValue> : FieldCompone
     /// null when the setting will be honoured.
     /// </summary>
     private string? ShrinkLabelConflict() =>
-        ShrinkLabelDiagnostic.Conflict(Placeholder, GetAttribute<Adornment?>("Adornment"));
+        ShrinkLabelDiagnostic.Conflict(Placeholder, RenderedAdornment);
 }
 
 /// <summary>

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
 
@@ -14,6 +15,12 @@ public partial class MudBlazorNullableNumericFieldComponent<TModel, TValue>
     where TValue : struct
 {
     private TValue? _localValue;
+
+    /// <summary>
+    /// This component binds <c>EffectiveAdornment</c> (#191), so the ShrinkLabel diagnostic judges
+    /// it — see the sibling non-nullable component (#212).
+    /// </summary>
+    protected override Adornment? RenderedAdornment => EffectiveAdornment;
 
     /// <inheritdoc cref="INumericFieldComponent{TModel, TValue}.Min" />
     public TValue? Min { get; set; }

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor.cs
@@ -1,10 +1,18 @@
 using System.Globalization;
+using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
 
 public partial class MudBlazorNumericFieldComponent<TModel, TValue>
 {
     private TValue _localValue;
+
+    /// <summary>
+    /// This component binds <c>EffectiveAdornment</c> (#191), so the ShrinkLabel diagnostic judges
+    /// it — a numeric field really does draw the configured adornment, and its warning is correct
+    /// (#212).
+    /// </summary>
+    protected override Adornment? RenderedAdornment => EffectiveAdornment;
 
     public TValue? Min { get; set; }
     public TValue? Max { get; set; }

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -23,6 +23,17 @@ public partial class MudBlazorTextFieldComponent<TModel>
     public string? Autocomplete { get; set; }
     public string? Mask { get; set; }
     public Adornment? Adornment { get; set; }
+
+    /// <summary>
+    /// This component binds <see cref="Adornment"/>, so the ShrinkLabel diagnostic judges that
+    /// resolved value (#212).
+    /// </summary>
+    /// <remarks>
+    /// The resolved value, not the configured attribute: <c>.AsPassword()</c> with the visibility
+    /// toggle installs a start-agnostic End adornment of its own, and a field that configured none
+    /// still renders none. Judging the configured attribute would describe a different field.
+    /// </remarks>
+    protected override Adornment? RenderedAdornment => Adornment;
     public string? AdornmentIcon { get; set; }
     public Color AdornmentColor { get; set; } = Color.Default;
     public Action<string?>? OnAdornmentClick { get; set; }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **The `ShrinkLabel` diagnostic no longer warns about an adornment the field never draws.** It judged the *configured* `Adornment` attribute regardless of whether the component binds one — so date, select, autocomplete, lookup and file-upload fields told you to remove a `ShrinkLabel=false` that was in fact being honoured. It now judges what the component actually **renders**, which is the rule the collection item path has followed since #183. Text and numeric fields do render their adornment, so their (correct) warnings are unchanged (#212)
+
 - **`Format` and `ShowSpinButtons` now take effect on numeric fields — on both render paths.** Both were resolved in the numeric components' `OnInitialized` and then never bound, so `.WithAttribute("Format", "N2")` and `.WithAttribute("ShowSpinButtons", false)` were silently discarded. `ShowSpinButtons` is part of the public `INumericFieldComponent<TModel, TValue>` contract, so the library advertised a setting it dropped. The collection item path never forwarded either, and now does (#208)
 
   **This is a behaviour change** for any form already passing them: they start working. `ShowSpinButtons` defaults to `true`, matching MudBlazor, so a field that configures neither renders exactly as before.


### PR DESCRIPTION
Implements #212.

Closes #212.

The ShrinkLabel diagnostic judged the **configured** adornment rather than the **rendered** one, so
date, select, autocomplete, lookup and file-upload fields told the developer to remove a
`ShrinkLabel=false` that was being honoured.

### Plan
- [x] Task 1: Judge the rendered adornment
- [x] Task 2: Pin the rule and document it

### The fix

A virtual `RenderedAdornment` on `MudBlazorFieldComponentBase`, defaulting to `null` — "this
component renders none of ours" — overridden only by the three components that bind one: the text
field (its resolved adornment, so `.AsPassword()`'s visibility toggle counts) and both numeric
components (`EffectiveAdornment`, real since #191).

`ShrinkLabelConflict()` now reads that instead of `GetAttribute<Adornment?>("Adornment")`. This gives
the component path the same rule the collection path has stated since #183 — *"the diagnostic has to
judge what this path actually RENDERS, not what was configured"* — one implementation on each side
rather than two different rules.

**Defaulting to `null` is deliberate:** a newly added component type is silent until it opts in.
Warning wrongly is the defect being fixed, and a diagnostic that is wrong on most field types trains
people to ignore the channel.

### Guards

The easy way to make the two negative tests pass would have been to silence the diagnostic
altogether, so the suite pins the other direction too:

- a **date** field and a **select** field with a start adornment *and* `ShrinkLabel=false` now warn
  **not at all** — both were red before the change;
- a **numeric** field with the same configuration **still warns**, because it really does draw the
  adornment. That test passed before and after, which is what makes it a guard rather than a
  restatement.

The two negative cases render through the suite's existing `RenderFormWithPopover` host: `MudDatePicker`
and `MudSelect` log their own unrelated *"Missing `<MudPopoverProvider />`"* warning, which this
capturing logger would otherwise pick up and which has nothing to do with ShrinkLabel.

`SuppressShrinkLabelDiagnostic` on the Lov field is untouched — its label is structurally pinned for a
different reason.

Full suite green: 1108 tests, 0 warnings.
