### PR TITLE
fix(mudblazor): qualify the ShrinkLabel diagnostic key so scopes cannot collide (#213)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelKeyCollisionTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelKeyCollisionTests.cs
@@ -1,0 +1,145 @@
+using FormCraft.ForMudBlazor.UnitTests.TestSupport;
+using Microsoft.Extensions.Logging;
+
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Pins that the aggregated ShrinkLabel warning counts fields from different scopes separately (#213).
+/// </summary>
+/// <remarks>
+/// <c>ShrinkLabelDiagnosticCollector</c> is form-wide and keys conflicts by field identity. The
+/// collection path passed a **bare** <c>FieldName</c>, which is unique only within one item form —
+/// so a top-level field and an item field sharing a name overwrote each other and the warning
+/// undercounted. The collector's own docs already reject keying by *label* for the same reason
+/// ("Name" in Billing and in Shipping); this is that argument applied one level up.
+/// </remarks>
+public class ShrinkLabelKeyCollisionTests : MudBlazorTestBase
+{
+    private readonly CapturingLoggerProvider _logs = new();
+
+    public ShrinkLabelKeyCollisionTests()
+    {
+        Services.AddLogging(builder => builder.AddProvider(_logs));
+    }
+
+    [Fact]
+    public void A_TopLevel_Field_And_An_Item_Field_Sharing_A_Name_Should_Both_Be_Counted()
+    {
+        // Arrange - both conflict (a placeholder pins the label), both ask for a floating label, and
+        // both are called "Name". They are different fields and must be reported as two.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddField(x => x.Name, f => f
+                .WithLabel("Customer name")
+                .WithPlaceholder("e.g. Ada")
+                .WithShrinkLabel(false))
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.Name, f => f
+                        .WithLabel("Product name")
+                        .WithPlaceholder("e.g. Widget")
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel { Items = { new OrderItem() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert - one aggregated warning, naming both fields.
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("2 field(s)");
+        warnings[0].ShouldContain("Customer name");
+        warnings[0].ShouldContain("Product name");
+    }
+
+    [Fact]
+    public void Two_Collections_With_Same_Named_Item_Fields_Should_Both_Be_Counted()
+    {
+        // Arrange - the collision this issue does not name. Each CollectionFieldComponent has its
+        // own once-per-field latch, so nothing local catches this; the clash exists only in the
+        // form-wide collector, which is why the key must carry the owning collection's name.
+        var config = FormBuilder<TwoCollectionModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.Name, f => f
+                        .WithLabel("Item name")
+                        .WithPlaceholder("e.g. Widget")
+                        .WithShrinkLabel(false))))
+            .AddCollectionField(x => x.Extras, collection => collection
+                .WithLabel("Extras")
+                .WithItemForm(item => item
+                    .AddField(x => x.Name, f => f
+                        .WithLabel("Extra name")
+                        .WithPlaceholder("e.g. Gift wrap")
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<TwoCollectionModel>>(parameters => parameters
+            .Add(p => p.Model, new TwoCollectionModel
+            {
+                Items = { new OrderItem() },
+                Extras = { new OrderItem() }
+            })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("2 field(s)");
+        warnings[0].ShouldContain("Item name");
+        warnings[0].ShouldContain("Extra name");
+    }
+
+    [Fact]
+    public void Several_Rows_Should_Still_Produce_One_Warning_For_The_Item_Field()
+    {
+        // Arrange - the property the qualified key must not break. The warning is about a field's
+        // configuration, so a collection of many rows must report it once, not once per row.
+        var config = FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.Name, f => f
+                        .WithLabel("Product name")
+                        .WithPlaceholder("e.g. Widget")
+                        .WithShrinkLabel(false))))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<OrderModel>>(parameters => parameters
+            .Add(p => p.Model, new OrderModel
+            {
+                Items = { new OrderItem(), new OrderItem(), new OrderItem() }
+            })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("1 field(s)");
+    }
+
+    private class OrderModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<OrderItem> Items { get; set; } = new();
+    }
+
+    private class TwoCollectionModel
+    {
+        public List<OrderItem> Items { get; set; } = new();
+        public List<OrderItem> Extras { get; set; } = new();
+    }
+
+    private class OrderItem
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -180,6 +180,19 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private FieldIdentifier GetItemFieldIdentifier(int itemIndex, string fieldName)
         => new(Model!, $"{Configuration.FieldName}[{itemIndex}].{fieldName}");
 
+    /// <summary>
+    /// The identity an item field is reported under by the form-wide diagnostic collectors (#213):
+    /// <c>&lt;collection&gt;[].&lt;field&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately row-agnostic — the <c>[]</c> carries no index. These diagnostics describe a
+    /// field's *configuration*, so they are emitted once per field however many rows exist;
+    /// <see cref="GetItemFieldIdentifier"/>'s row-specific form is for `EditContext` notifications,
+    /// where the row genuinely matters, and would be wrong here.
+    /// </remarks>
+    private string ItemFieldDiagnosticKey(IFieldConfiguration<TItem, object> field)
+        => $"{Configuration.FieldName}[].{field.FieldName}";
+
     private RenderFragment RenderItemFields(int itemIndex)
     {
         return builder =>
@@ -551,7 +564,19 @@ public partial class CollectionFieldComponent<TModel, TItem>
         bool shrinkLabel,
         Adornment? renderedAdornment)
     {
-        if (shrinkLabel || !_warnedItemFields.Add(field.FieldName))
+        // Qualified with the owning collection's name (#213). The collector is FORM-wide and keys by
+        // field identity, but a bare FieldName is unique only inside one item form — so a top-level
+        // "Name" and an item "Name" overwrote each other, and so did item fields of the same name in
+        // two different collections. Each CollectionFieldComponent has its own _warnedItemFields
+        // latch, so nothing local could catch that second case; the clash existed only in the
+        // collector.
+        //
+        // Row-agnostic on purpose: NOT GetItemFieldIdentifier's "Items[0].Name". The warning is about
+        // a field's configuration and is emitted once per field, so keying it to whichever row
+        // rendered first would read as though row 0 were special.
+        var diagnosticKey = ItemFieldDiagnosticKey(field);
+
+        if (shrinkLabel || !_warnedItemFields.Add(diagnosticKey))
         {
             return;
         }
@@ -566,7 +591,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // Prefer the form's collector so item fields join the single aggregated warning.
         if (ShrinkLabelDiagnostics is not null)
         {
-            ShrinkLabelDiagnostics.Report(field.FieldName, field.Label, conflict);
+            ShrinkLabelDiagnostics.Report(diagnosticKey, field.Label, conflict);
             return;
         }
 


### PR DESCRIPTION
Implements #213.

Closes #213.

`ShrinkLabelDiagnosticCollector` is form-wide and keys conflicts by field identity, but the collection
path passed a **bare** `FieldName` — unique only inside one item form. Colliding fields overwrote each
other and the aggregated warning undercounted.

### Plan
- [x] Task 1: Qualify the collector key on the collection path
- [x] Task 2: Pin the once-per-field guarantee

### A second collision the issue does not name

The issue describes a top-level field clashing with an item field. The same key is also shared by
**two different collections** in one form: `Items`' item field `Name` and `Extras`' item field `Name`
are distinct fields with one key.

Each `CollectionFieldComponent` has its own `_warnedItemFields` latch, so nothing local could catch
that — the collision existed only in the form-wide collector. Both cases were red before this change
and are covered by their own tests.

### Why not `GetItemFieldIdentifier`, as the issue suggests

That produces `Items[0].Name` — a **row** identity. This warning is about a field's *configuration*
and is emitted once per field however many rows exist, so keying it to whichever row rendered first
would read as though row 0 were special. The key is `Items[].Name`: collection-qualified,
row-agnostic. `GetItemFieldIdentifier` keeps its job — `EditContext` notifications, where the row
genuinely matters.

### Guard

`Several_Rows_Should_Still_Produce_One_Warning_For_The_Item_Field` pins the property the new key must
not break: a three-row collection still yields exactly one warning naming one field. It passed before
and after, which is what makes it a guard rather than a restatement — the obvious wrong fix here is a
key that varies per row.

Full suite green: 1111 tests, 0 warnings.
