### PR TITLE
feat(mudblazor): give numeric adornments a typed click handler (#215)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/NumericAdornmentClickTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/NumericAdornmentClickTests.cs
@@ -1,0 +1,154 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests the numeric adornment click handler (#215) on both render paths.
+/// </summary>
+/// <remarks>
+/// #191 added numeric <c>WithAdornment</c> overloads without an <c>onClick</c>, because at the time
+/// the string overload's handler was read by neither render path — mirroring a dead parameter onto
+/// new API would have been wrong. #192 made that parameter live on both paths, so the reason expired
+/// and the gap remained.
+/// <para>
+/// The handler is <c>Action&lt;TValue?&gt;</c>, not the string overload's <c>Action&lt;string?&gt;</c>:
+/// that shape is right there only because the value happens to be a string.
+/// </para>
+/// </remarks>
+public class NumericAdornmentClickTests : MudBlazorTestBase
+{
+    [Fact]
+    public void NumericField_Adornment_Should_Invoke_The_Handler_With_The_Value()
+    {
+        // Arrange
+        int? received = null;
+        var config = FormBuilder<NumericModel>
+            .Create()
+            .AddField(x => x.Quantity, field => field
+                .WithLabel("Quantity")
+                .WithAdornment(Icons.Material.Filled.Numbers, Adornment.End, onClick: v => received = v))
+            .Build();
+
+        var component = Render<FormCraftComponent<NumericModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericModel { Quantity = 7 })
+            .Add(p => p.Configuration, config));
+
+        // Act
+        component.Find(".mud-input-adornment button").Click();
+
+        // Assert - typed to the field's own value, which is the whole point of the decision.
+        received.ShouldBe(7);
+    }
+
+    [Fact]
+    public void NumericField_Adornment_Without_A_Handler_Should_Not_Render_A_Button()
+    {
+        // Arrange - the #216 invariant: a decorative icon must not become a focus stop for keyboard
+        // and screen-reader users. Binding a method group would make EventCallback.HasDelegate always
+        // true and MudBlazor would draw a real <button>, so the callback must be `default`.
+        var config = FormBuilder<NumericModel>
+            .Create()
+            .AddField(x => x.Quantity, field => field
+                .WithLabel("Quantity")
+                .WithAdornment(Icons.Material.Filled.Numbers, Adornment.End))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<NumericModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericModel())
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindAll(".mud-input-adornment").Count.ShouldBe(1);
+        component.FindAll(".mud-input-adornment button").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void NullableNumericField_Adornment_Should_Invoke_The_Handler_With_The_Value()
+    {
+        // Arrange - the nullable component is a separate file and needs its own coverage.
+        decimal? received = null;
+        var config = FormBuilder<NumericModel>
+            .Create()
+            .AddField(x => x.Discount, field => field
+                .WithLabel("Discount")
+                .WithAdornment(Icons.Material.Filled.Percent, Adornment.End, onClick: v => received = v))
+            .Build();
+
+        var component = Render<FormCraftComponent<NumericModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericModel { Discount = 12.5m })
+            .Add(p => p.Configuration, config));
+
+        // Act
+        component.Find(".mud-input-adornment button").Click();
+
+        // Assert
+        received.ShouldBe(12.5m);
+    }
+
+    [Fact]
+    public void NumericItemField_Adornment_Should_Invoke_The_Handler_With_The_Row_Value()
+    {
+        // Arrange - the collection path passed `default` for numeric item fields, so the handler was
+        // inert inside .WithItemForm(...). Fixing only the component path would have opened the
+        // divergence RenderPipelineParityTests exists to close.
+        int? received = null;
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field
+                        .WithLabel("Quantity")
+                        .WithAdornment(Icons.Material.Filled.Numbers, Adornment.End,
+                            onClick: v => received = v))))
+            .Build();
+
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine { Quantity = 3 } } })
+            .Add(p => p.Configuration, config));
+
+        // Act
+        component.Find(".mud-input-adornment button").Click();
+
+        // Assert - the ROW's value, read at click time rather than captured at render time.
+        received.ShouldBe(3);
+    }
+
+    [Fact]
+    public void NumericItemField_Adornment_Without_A_Handler_Should_Not_Render_A_Button()
+    {
+        // Arrange - the #216 invariant on the item path too.
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field => field
+                        .WithLabel("Quantity")
+                        .WithAdornment(Icons.Material.Filled.Numbers, Adornment.End))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.FindAll(".mud-input-adornment button").ShouldBeEmpty();
+    }
+
+    private class NumericModel
+    {
+        public int Quantity { get; set; }
+        public decimal? Discount { get; set; }
+    }
+
+    private class BasketModel
+    {
+        public List<BasketLine> Lines { get; set; } = new();
+    }
+
+    private class BasketLine
+    {
+        public int Quantity { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
+++ b/FormCraft.ForMudBlazor/Extensions/FieldBuilderExtensions.cs
@@ -283,6 +283,11 @@ public static class MudBlazorFieldBuilderExtensions
     /// <param name="icon">The MudBlazor icon to display (e.g., Icons.Material.Filled.Numbers).</param>
     /// <param name="position">The position of the adornment (Start or End, default: Start).</param>
     /// <param name="color">The color of the adornment icon (default: Default).</param>
+    /// <param name="onClick">
+    /// Optional click handler for the adornment icon. It receives the field's current value, typed
+    /// to the field's own value type rather than the string overload's <c>string?</c> (#215), and
+    /// fires on both render paths — an ordinary field and one inside <c>.WithItemForm(...)</c>.
+    /// </param>
     /// <returns>The FieldBuilder instance for method chaining.</returns>
     /// <remarks>
     /// <para>
@@ -317,14 +322,18 @@ public static class MudBlazorFieldBuilderExtensions
         this FieldBuilder<TModel, TValue> builder,
         string icon,
         MudBlazor.Adornment position = MudBlazor.Adornment.Start,
-        MudBlazor.Color color = MudBlazor.Color.Default)
+        MudBlazor.Color color = MudBlazor.Color.Default,
+        Action<TValue?>? onClick = null)
         where TModel : new()
         where TValue : struct, INumber<TValue>
     {
         return builder
             .WithAttribute("Adornment", position)
             .WithAttribute("AdornmentIcon", icon)
-            .WithAttribute("AdornmentColor", color);
+            .WithAttribute("AdornmentColor", color)
+            // Written unconditionally, for the reason spelled out on the string overload: a null must
+            // OVERWRITE a handler an earlier call left behind, not be skipped.
+            .WithAttribute(AdornmentClickAttribute, onClick!);
     }
 
     /// <summary>
@@ -336,6 +345,11 @@ public static class MudBlazorFieldBuilderExtensions
     /// <param name="icon">The MudBlazor icon to display (e.g., Icons.Material.Filled.Percent).</param>
     /// <param name="position">The position of the adornment (Start or End, default: Start).</param>
     /// <param name="color">The color of the adornment icon (default: Default).</param>
+    /// <param name="onClick">
+    /// Optional click handler for the adornment icon. It receives the field's current value, typed
+    /// to the field's own value type rather than the string overload's <c>string?</c> (#215), and
+    /// fires on both render paths — an ordinary field and one inside <c>.WithItemForm(...)</c>.
+    /// </param>
     /// <returns>The FieldBuilder instance for method chaining.</returns>
     /// <remarks>
     /// A separate overload because the <c>struct</c> constraint excludes nullable value types, so
@@ -353,14 +367,17 @@ public static class MudBlazorFieldBuilderExtensions
         this FieldBuilder<TModel, TValue?> builder,
         string icon,
         MudBlazor.Adornment position = MudBlazor.Adornment.Start,
-        MudBlazor.Color color = MudBlazor.Color.Default)
+        MudBlazor.Color color = MudBlazor.Color.Default,
+        Action<TValue?>? onClick = null)
         where TModel : new()
         where TValue : struct, INumber<TValue>
     {
         return builder
             .WithAttribute("Adornment", position)
             .WithAttribute("AdornmentIcon", icon)
-            .WithAttribute("AdornmentColor", color);
+            .WithAttribute("AdornmentColor", color)
+            // Unconditional, as on the sibling overloads.
+            .WithAttribute(AdornmentClickAttribute, onClick!);
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -302,10 +302,8 @@ public partial class CollectionFieldComponent<TModel, TItem>
         where T : struct
     {
         builder.OpenComponent(0, typeof(MudNumericField<>).MakeGenericType(typeof(T)));
-        // WithAdornment — and so its handler — is declared on string fields only, leaving a numeric
-        // item field's adornment inert. Numeric adornment support is tracked separately (#191).
         AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: true,
-            adornmentClick: default);
+            adornmentClick: BuildNumericAdornmentClick<T>(field, itemIndex));
         builder.AddAttribute(CallerAttributeStart, "Value", value);
         builder.AddAttribute(CallerAttributeStart + 1, "ValueChanged",
             EventCallback.Factory.Create<T>(this,
@@ -677,6 +675,60 @@ public partial class CollectionFieldComponent<TModel, TItem>
         var fieldName = field.FieldName;
         return EventCallback.Factory.Create<MouseEventArgs>(
             this, () => handler(ReadItemFieldText(itemIndex, fieldName)));
+    }
+
+    /// <summary>
+    /// Builds the adornment click callback for a numeric item field (#215), or <c>default</c> when
+    /// the field configured no handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The numeric handler is <c>Action&lt;T?&gt;</c>, not the string path's <c>Action&lt;string?&gt;</c>:
+    /// a numeric field's handler should receive the number. Both shapes live under the same attribute
+    /// key, and both readers resolve defensively — a value of the other shape reads back as "no
+    /// handler" rather than throwing at click time.
+    /// </para>
+    /// <para>
+    /// <c>default</c> when unconfigured is load-bearing (#216): an <c>EventCallback</c> with a
+    /// delegate makes MudBlazor draw a real <c>&lt;button&gt;</c>, putting a focus stop on a
+    /// decorative icon.
+    /// </para>
+    /// <para>
+    /// The value is read at CLICK time, not captured at render time — the string path does the same,
+    /// because a captured value goes stale as soon as the user types.
+    /// </para>
+    /// </remarks>
+    private EventCallback<MouseEventArgs> BuildNumericAdornmentClick<T>(
+        IFieldConfiguration<TItem, object> field,
+        int itemIndex)
+        where T : struct
+    {
+        var handler = GetItemFieldAttribute<Action<T?>?>(
+            field, MudBlazorFieldBuilderExtensions.AdornmentClickAttribute, null);
+
+        if (handler is null)
+        {
+            return default;
+        }
+
+        var fieldName = field.FieldName;
+        return EventCallback.Factory.Create<MouseEventArgs>(
+            this, () => handler(ReadItemFieldValue<T>(itemIndex, fieldName)));
+    }
+
+    /// <summary>
+    /// Reads an item field's current value as <typeparamref name="T"/>, or <c>null</c> when the row
+    /// is gone or the property does not hold one.
+    /// </summary>
+    private T? ReadItemFieldValue<T>(int itemIndex, string fieldName)
+        where T : struct
+    {
+        if (itemIndex < 0 || itemIndex >= Items.Count)
+        {
+            return null;
+        }
+
+        return typeof(TItem).GetProperty(fieldName)?.GetValue(Items[itemIndex]) as T?;
     }
 
     /// <summary>

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor
@@ -25,6 +25,7 @@
     Adornment="@EffectiveAdornment"
     AdornmentIcon="@EffectiveAdornmentIcon"
     AdornmentColor="@EffectiveAdornmentColor"
+    OnAdornmentClick="@AdornmentClick"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNullableNumericFieldComponent.razor.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
@@ -21,6 +23,22 @@ public partial class MudBlazorNullableNumericFieldComponent<TModel, TValue>
     /// it — see the sibling non-nullable component (#212).
     /// </summary>
     protected override Adornment? RenderedAdornment => EffectiveAdornment;
+
+    /// <summary>
+    /// The adornment click handler configured by <c>WithAdornment(..., onClick:)</c>, or null —
+    /// see the sibling non-nullable component (#215).
+    /// </summary>
+    private Action<TValue?>? OnAdornmentClick =>
+        GetAttribute<Action<TValue?>?>(MudBlazorFieldBuilderExtensions.AdornmentClickAttribute);
+
+    /// <summary>
+    /// The callback bound to MudBlazor, or <c>default</c> when no handler is configured (#216) —
+    /// a handler-less adornment must stay a plain icon rather than a focusable button.
+    /// </summary>
+    private EventCallback<MouseEventArgs> AdornmentClick =>
+        OnAdornmentClick is null
+            ? default
+            : EventCallback.Factory.Create<MouseEventArgs>(this, () => OnAdornmentClick(CurrentValue));
 
     /// <inheritdoc cref="INumericFieldComponent{TModel, TValue}.Min" />
     public TValue? Min { get; set; }

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor
@@ -31,6 +31,7 @@
     Adornment="@EffectiveAdornment"
     AdornmentIcon="@EffectiveAdornmentIcon"
     AdornmentColor="@EffectiveAdornmentColor"
+    OnAdornmentClick="@AdornmentClick"
     Variant="@EffectiveVariant"
     Margin="Margin.Dense"
     ShrinkLabel="@EffectiveShrinkLabel"

--- a/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/NumericField/MudBlazorNumericFieldComponent.razor.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
@@ -13,6 +15,31 @@ public partial class MudBlazorNumericFieldComponent<TModel, TValue>
     /// (#212).
     /// </summary>
     protected override Adornment? RenderedAdornment => EffectiveAdornment;
+
+    /// <summary>
+    /// The adornment click handler configured by <c>WithAdornment(..., onClick:)</c>, or null (#215).
+    /// </summary>
+    /// <remarks>
+    /// Typed <c>Action&lt;TValue?&gt;</c> rather than the string overload's <c>Action&lt;string?&gt;</c>:
+    /// that shape is right there only because the field's value is a string. Resolved defensively —
+    /// <c>AdditionalAttributes</c> is untyped, so a value of another shape reads back as "no handler"
+    /// rather than throwing at click time.
+    /// </remarks>
+    private Action<TValue?>? OnAdornmentClick =>
+        GetAttribute<Action<TValue?>?>(MudBlazorFieldBuilderExtensions.AdornmentClickAttribute);
+
+    /// <summary>
+    /// The callback bound to MudBlazor, or <c>default</c> when no handler is configured (#216).
+    /// </summary>
+    /// <remarks>
+    /// Returning <c>default</c> matters: binding a method group gives an <c>EventCallback</c> whose
+    /// <c>HasDelegate</c> is always true, and MudBlazor draws a real <c>&lt;button&gt;</c> for that —
+    /// turning a decorative icon into a focus stop for keyboard and screen-reader users.
+    /// </remarks>
+    private EventCallback<MouseEventArgs> AdornmentClick =>
+        OnAdornmentClick is null
+            ? default
+            : EventCallback.Factory.Create<MouseEventArgs>(this, () => OnAdornmentClick(CurrentValue));
 
     public TValue? Min { get; set; }
     public TValue? Max { get; set; }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **Numeric adornments now take an `onClick`, typed to the field's own value.** The numeric `WithAdornment` overloads added in #191 had no handler, because at the time the string overload's was read by neither render path. #192 made it live, so the reason expired and the gap remained. Both numeric overloads now accept `Action<TValue?>` — **not** the string overload's `Action<string?>`, which is right there only because that field's value happens to be a string — and the handler fires on both render paths, including inside `.WithItemForm(...)` (#215)
+
+  ```csharp
+  .AddField(x => x.Quantity, field => field
+      .WithAdornment(Icons.Material.Filled.Numbers, Adornment.End,
+          onClick: quantity => Recalculate(quantity)))   // receives int?, not string?
+  ```
+
+  A numeric adornment with **no** handler still renders a plain icon rather than a focusable button, matching #216.
+
 - **FormCraft now warns when the password visibility toggle discards a configured adornment.** A field has one adornment slot, and `.AsPassword(enableVisibilityToggle: true)` claims it for the show/hide eye — so an adornment configured alongside it, and any `onClick` with it, was dropped without a word. Since #192 made that handler work everywhere else, this was the last place it silently did nothing. Nothing about the rendering changes (one slot cannot hold both); the warning names the two ways out — remove the adornment, or pass `enableVisibilityToggle: false`. Logged under the `FormCraft.ForMudBlazor.PasswordAdornment` category (#219)
 
 - **The `ShrinkLabel` diagnostic no longer warns about an adornment the field never draws.** It judged the *configured* `Adornment` attribute regardless of whether the component binds one — so date, select, autocomplete, lookup and file-upload fields told you to remove a `ShrinkLabel=false` that was in fact being honoured. It now judges what the component actually **renders**, which is the rule the collection item path has followed since #183. Text and numeric fields do render their adornment, so their (correct) warnings are unchanged (#212)


### PR DESCRIPTION
Implements #215.

Closes #215.

### Plan
- [x] Task 1: Add the handler to both numeric overloads and wire the component path
- [x] Task 2: Wire the collection path
- [x] Task 3: Document

### The decision: `Action<TValue?>`, and two methods rather than one

The string overload's `Action<string?>` is right there only because the field's value *is* a string;
it is not a house shape to copy. A numeric handler should receive the number, so both numeric
overloads take `Action<TValue?>` — nullable so an empty field is expressible, which is why the string
overload's parameter is `string?` too.

**They stay two methods.** The generic constraint and the receiver differ, so a single generic method
would have to weaken the handler to `Action<object?>` and hand every caller a cast.

**One attribute key.** Both shapes are stored under the existing `AdornmentClickAttribute`. Both
readers resolve defensively (`GetAttribute<Action<T?>?>` / `GetItemFieldAttribute<Action<string?>?>`
return null for a value of another shape), so a numeric handler read by the string path — or the
reverse — degrades to "no handler" instead of an `InvalidCastException` at click time.

### Both paths, and two invariants kept

The collection path passed `adornmentClick: default` for numeric item fields, so the handler was inert
inside `.WithItemForm(...)`. Fixing only the component path would have opened the divergence
`RenderPipelineParityTests` exists to close, so both moved together.

- **#216 — a handler-less adornment must not become a `<button>`.** Both paths bind `default` when
  nothing is configured; binding a method group makes `EventCallback.HasDelegate` always true and
  MudBlazor draws a real button, putting a focus stop on a decorative icon. Pinned on both paths.
- **The value is read at click time, not captured at render time.** The string path already does this;
  a captured value goes stale the moment the user types. The item-path test asserts the *row's* value.
- The handler attribute is written **unconditionally**, as on the string overload: a null must
  overwrite a handler an earlier call left behind, or a refining caller keeps firing a helper's
  handler from an icon they believe is inert.

Full suite green: 1121 tests, 0 warnings.
