### PR TITLE
refactor(core)!: expose Validators as IReadOnlyList and require AddValidator (#155)

### DIFF
--- a/FormCraft.UnitTests/Builders/FieldConfigurationWrapperTests.cs
+++ b/FormCraft.UnitTests/Builders/FieldConfigurationWrapperTests.cs
@@ -286,20 +286,24 @@ public class FieldConfigurationWrapperTests
     }
 
     [Fact]
-    public void Validators_Mutations_Should_Be_Retained_Across_Reads()
+    public void AddValidator_Should_Be_Retained_Across_Reads()
     {
-        // Arrange - the natural mutation `config.Fields[i].Validators.Add(...)`
-        // used to mutate a fresh copy and silently drop the validator (issue #151)
+        // Arrange - `config.Fields[i].Validators.Add(...)` used to compile and silently drop the
+        // validator (#151). #151 made the view cache so the mutation at least survived; #155 removed
+        // the mutation instead — `Validators` is IReadOnlyList and that line no longer compiles, so
+        // AddValidator is the only way in and it writes through to the underlying typed config.
         var innerConfig = A.Fake<IFieldConfiguration<TestModel, string>>();
         A.CallTo(() => innerConfig.Validators).Returns(new List<IFieldValidator<TestModel, string>>());
         var wrapper = new FieldConfigurationWrapper<TestModel, string>(innerConfig);
         var addedValidator = A.Fake<IFieldValidator<TestModel, object>>();
 
         // Act
-        wrapper.Validators.Add(addedValidator);
+        wrapper.AddValidator(addedValidator);
 
-        // Assert
+        // Assert - the caller's own instance is what comes back, and it survives a re-read.
         wrapper.Validators.ShouldContain(addedValidator);
+        A.CallTo(() => innerConfig.AddValidator(A<IFieldValidator<TestModel, string>>._))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -309,6 +313,11 @@ public class FieldConfigurationWrapperTests
         var typedValidators = new List<IFieldValidator<TestModel, string>>();
         var innerConfig = A.Fake<IFieldConfiguration<TestModel, string>>();
         A.CallTo(() => innerConfig.Validators).Returns(typedValidators);
+        // Make the fake behave like a real configuration: AddValidator is the mutation path since
+        // #155, so a fake that only returns a list would swallow the write and these assertions
+        // would be measuring the stub rather than the wrapper.
+        A.CallTo(() => innerConfig.AddValidator(A<IFieldValidator<TestModel, string>>._))
+            .Invokes((IFieldValidator<TestModel, string> v) => typedValidators.Add(v));
         var wrapper = new FieldConfigurationWrapper<TestModel, string>(innerConfig);
 
         var cached = wrapper.Validators;
@@ -329,6 +338,11 @@ public class FieldConfigurationWrapperTests
         var typedValidators = new List<IFieldValidator<TestModel, string>>();
         var innerConfig = A.Fake<IFieldConfiguration<TestModel, string>>();
         A.CallTo(() => innerConfig.Validators).Returns(typedValidators);
+        // Make the fake behave like a real configuration: AddValidator is the mutation path since
+        // #155, so a fake that only returns a list would swallow the write and these assertions
+        // would be measuring the stub rather than the wrapper.
+        A.CallTo(() => innerConfig.AddValidator(A<IFieldValidator<TestModel, string>>._))
+            .Invokes((IFieldValidator<TestModel, string> v) => typedValidators.Add(v));
         var wrapper = new FieldConfigurationWrapper<TestModel, string>(innerConfig);
         var objectValidator = A.Fake<IFieldValidator<TestModel, object>>();
 
@@ -348,6 +362,11 @@ public class FieldConfigurationWrapperTests
         var typedValidators = new List<IFieldValidator<TestModel, string>>();
         var innerConfig = A.Fake<IFieldConfiguration<TestModel, string>>();
         A.CallTo(() => innerConfig.Validators).Returns(typedValidators);
+        // Make the fake behave like a real configuration: AddValidator is the mutation path since
+        // #155, so a fake that only returns a list would swallow the write and these assertions
+        // would be measuring the stub rather than the wrapper.
+        A.CallTo(() => innerConfig.AddValidator(A<IFieldValidator<TestModel, string>>._))
+            .Invokes((IFieldValidator<TestModel, string> v) => typedValidators.Add(v));
         var wrapper = new FieldConfigurationWrapper<TestModel, string>(innerConfig);
 
         var typedValidator = A.Fake<IFieldValidator<TestModel, string>>();
@@ -367,6 +386,11 @@ public class FieldConfigurationWrapperTests
         var typedValidators = new List<IFieldValidator<TestModel, string>>();
         var innerConfig = A.Fake<IFieldConfiguration<TestModel, string>>();
         A.CallTo(() => innerConfig.Validators).Returns(typedValidators);
+        // Make the fake behave like a real configuration: AddValidator is the mutation path since
+        // #155, so a fake that only returns a list would swallow the write and these assertions
+        // would be measuring the stub rather than the wrapper.
+        A.CallTo(() => innerConfig.AddValidator(A<IFieldValidator<TestModel, string>>._))
+            .Invokes((IFieldValidator<TestModel, string> v) => typedValidators.Add(v));
         var wrapper = new FieldConfigurationWrapper<TestModel, string>(innerConfig);
 
         var objectValidator = A.Fake<IFieldValidator<TestModel, object>>();
@@ -389,15 +413,16 @@ public class FieldConfigurationWrapperTests
     [Fact]
     public void Validators_Added_Through_Built_Configuration_Should_Be_Retained()
     {
-        // Arrange - end-to-end shape of the bug report: mutate validators on a
-        // built configuration's object-typed field view
+        // Arrange - end-to-end shape of the bug report, now through the supported path. The original
+        // `config.Fields[0].Validators.Add(...)` no longer compiles (#155), which is the fix: it used
+        // to compile, run, and mutate a snapshot that validation never read.
         var config = FormBuilder<TestModel>.Create()
             .AddField(x => x.Name, field => field.WithLabel("Name"))
             .Build();
         var addedValidator = A.Fake<IFieldValidator<TestModel, object>>();
 
         // Act
-        config.Fields[0].Validators.Add(addedValidator);
+        config.Fields[0].AddValidator(addedValidator);
 
         // Assert - the validator is still there on subsequent reads (it will run during validation)
         config.Fields[0].Validators.ShouldContain(addedValidator);

--- a/FormCraft.UnitTests/Core/FieldConfigurationTests.cs
+++ b/FormCraft.UnitTests/Core/FieldConfigurationTests.cs
@@ -93,14 +93,17 @@ public class FieldConfigurationTests
     }
 
     [Fact]
-    public void Validators_Collection_Should_Be_Modifiable()
+    public void Validators_Should_Be_Extended_Through_AddValidator()
     {
-        // Arrange
+        // Arrange - `Validators` is IReadOnlyList since #155, so `.Add(...)` no longer compiles.
+        // That is the point of the change: it used to compile on the object-typed view and silently
+        // mutate a snapshot that never affected validation. AddValidator is the single mutation path
+        // and has existed since 3.1.0, so consumers could migrate before upgrading.
         var config = new FieldConfiguration<TestModel, string>(x => x.Name);
         var validator = A.Fake<IFieldValidator<TestModel, string>>();
 
         // Act
-        config.Validators.Add(validator);
+        config.AddValidator(validator);
 
         // Assert
         config.Validators.ShouldContain(validator);

--- a/FormCraft/Forms/Builders/FieldBuilder.cs
+++ b/FormCraft/Forms/Builders/FieldBuilder.cs
@@ -127,7 +127,7 @@ public class FieldBuilder<TModel, TValue> where TModel : new()
     public FieldBuilder<TModel, TValue> Required(string? errorMessage = null)
     {
         _fieldConfiguration.IsRequired = true;
-        _fieldConfiguration.Validators.Add(new RequiredValidator<TModel, TValue>(errorMessage));
+        _fieldConfiguration.AddValidator(new RequiredValidator<TModel, TValue>(errorMessage));
         return this;
     }
 
@@ -247,7 +247,7 @@ public class FieldBuilder<TModel, TValue> where TModel : new()
     /// </example>
     public FieldBuilder<TModel, TValue> WithValidator(IFieldValidator<TModel, TValue> validator)
     {
-        _fieldConfiguration.Validators.Add(validator);
+        _fieldConfiguration.AddValidator(validator);
         return this;
     }
 
@@ -264,7 +264,7 @@ public class FieldBuilder<TModel, TValue> where TModel : new()
     /// </example>
     public FieldBuilder<TModel, TValue> WithValidator(Func<TValue, bool> validation, string errorMessage)
     {
-        _fieldConfiguration.Validators.Add(new CustomValidator<TModel, TValue>(validation, errorMessage));
+        _fieldConfiguration.AddValidator(new CustomValidator<TModel, TValue>(validation, errorMessage));
         return this;
     }
 
@@ -281,7 +281,7 @@ public class FieldBuilder<TModel, TValue> where TModel : new()
     /// </example>
     public FieldBuilder<TModel, TValue> WithAsyncValidator(Func<TValue, Task<bool>> validation, string errorMessage)
     {
-        _fieldConfiguration.Validators.Add(new AsyncValidator<TModel, TValue>(validation, errorMessage));
+        _fieldConfiguration.AddValidator(new AsyncValidator<TModel, TValue>(validation, errorMessage));
         return this;
     }
 

--- a/FormCraft/Forms/Builders/FieldConfigurationWrapper.cs
+++ b/FormCraft/Forms/Builders/FieldConfigurationWrapper.cs
@@ -75,7 +75,7 @@ public class FieldConfigurationWrapper<TModel, TValue> : IFieldConfiguration<TMo
     /// builder API after the first read are appended to the cached view on the next read.
     /// Prefer <see cref="AddValidator"/> to keep the underlying typed configuration in sync.
     /// </summary>
-    public List<IFieldValidator<TModel, object>> Validators
+    public IReadOnlyList<IFieldValidator<TModel, object>> Validators
     {
         get
         {
@@ -105,16 +105,20 @@ public class FieldConfigurationWrapper<TModel, TValue> : IFieldConfiguration<TMo
         // Materialize the cached object-typed view (and pull in any typed validators
         // added since the last read) so the original instance — not a re-wrapped
         // copy — is what callers observe through Validators afterwards.
-        var objectView = Validators;
+        _ = Validators;
 
         // Unwrap validators that already wrap a typed validator; adapt arbitrary
         // object-typed validators so the inner typed list remains the source of truth.
         var typedValidator = validator is ValidatorWrapper<TModel, TValue> wrapper
             ? wrapper.Inner
             : new ObjectValidatorAdapter(validator);
-        _inner.Validators.Add(typedValidator);
+        _inner.AddValidator(typedValidator);
 
-        objectView.Add(validator);
+        // Appended to the backing list directly: the public view is IReadOnlyList since #155, and
+        // the whole point of that change is that callers cannot do this. Adding the caller's own
+        // instance (rather than re-wrapping the one just handed to _inner) keeps reference identity
+        // through the object-typed view.
+        _validators!.Add(validator);
         _wrappedInnerValidatorCount = _inner.Validators.Count;
     }
 

--- a/FormCraft/Forms/Core/FieldConfiguration.cs
+++ b/FormCraft/Forms/Core/FieldConfiguration.cs
@@ -51,8 +51,13 @@ public class FieldConfiguration<TModel, TValue> : IFieldConfiguration<TModel, TV
     /// </summary>
     public string? InputType { get; set; }
 
+    private readonly List<IFieldValidator<TModel, TValue>> _validators = [];
+
     /// <inheritdoc />
-    public List<IFieldValidator<TModel, TValue>> Validators { get; } = new();
+    public IReadOnlyList<IFieldValidator<TModel, TValue>> Validators => _validators;
+
+    /// <inheritdoc />
+    public void AddValidator(IFieldValidator<TModel, TValue> validator) => _validators.Add(validator);
 
     /// <inheritdoc />
     public List<IFieldDependency<TModel>> Dependencies { get; } = new();

--- a/FormCraft/Forms/Core/IFieldConfiguration.cs
+++ b/FormCraft/Forms/Core/IFieldConfiguration.cs
@@ -109,20 +109,39 @@ public interface IFieldConfiguration<TModel, TValue>
     string? InputType { get; set; }
 
     /// <summary>
-    /// Gets the list of validators that will be applied to this field's value.
-    /// Validators are executed in the order they appear in this list.
+    /// Gets the validators that will be applied to this field's value, in execution order.
     /// </summary>
-    List<IFieldValidator<TModel, TValue>> Validators { get; }
+    /// <remarks>
+    /// <b>Read-only by design (#155).</b> This was a concrete <c>List&lt;&gt;</c> until v4, which made
+    /// <c>config.Fields[i].Validators.Add(...)</c> compile, run, and silently do nothing: the
+    /// object-typed view exposed through <c>IFormConfiguration.Fields</c> projects its validators from
+    /// an underlying typed list, and because <c>List&lt;&gt;</c>'s members are not virtual it could
+    /// only hand back a materialised snapshot. Adding to that snapshot never affected validation.
+    /// <para>
+    /// Making the property an interface turns that silent no-op into a compile error, and leaves
+    /// <see cref="AddValidator"/> as the single mutation path. It has existed since 3.1.0, so
+    /// consumers can migrate before upgrading: replace <c>field.Validators.Add(v)</c> with
+    /// <c>field.AddValidator(v)</c>.
+    /// </para>
+    /// </remarks>
+    IReadOnlyList<IFieldValidator<TModel, TValue>> Validators { get; }
 
     /// <summary>
-    /// Adds a validator to this field configuration. Prefer this over mutating <see cref="Validators"/>
-    /// directly: some configuration views (such as the object-typed wrapper exposed through
-    /// <c>IFormConfiguration.Fields</c>) project their validators from an underlying typed list,
-    /// and this method guarantees the validator is registered against the underlying configuration.
-    /// The default implementation appends to <see cref="Validators"/>.
+    /// Adds a validator to this field configuration — the single supported way to register one.
     /// </summary>
+    /// <remarks>
+    /// Implementations must register the validator against the configuration that validation actually
+    /// reads. The object-typed wrapper overrides this to write through to the underlying typed
+    /// configuration rather than to its own projection, which is the whole reason this member exists
+    /// (#151, #155).
+    /// <para>
+    /// No default implementation on purpose: <see cref="Validators"/> is read-only, so a default could
+    /// not be correct, and an implementer that forgets this member should fail to compile rather than
+    /// inherit a silent no-op.
+    /// </para>
+    /// </remarks>
     /// <param name="validator">The validator to add.</param>
-    void AddValidator(IFieldValidator<TModel, TValue> validator) => Validators.Add(validator);
+    void AddValidator(IFieldValidator<TModel, TValue> validator);
 
     /// <summary>
     /// Gets the list of dependencies that define how this field reacts to changes in other fields.

--- a/FormCraft/Forms/Core/MinimalFieldConfiguration.cs
+++ b/FormCraft/Forms/Core/MinimalFieldConfiguration.cs
@@ -21,7 +21,12 @@ internal class MinimalFieldConfiguration : IFieldConfiguration<object, object>
     public string? CssClass { get; set; }
     public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
     public string? InputType { get; set; }
-    public List<IFieldValidator<object, object>> Validators { get; set; } = new();
+    private readonly List<IFieldValidator<object, object>> _validators = [];
+
+    public IReadOnlyList<IFieldValidator<object, object>> Validators => _validators;
+
+    public void AddValidator(IFieldValidator<object, object> validator) => _validators.Add(validator);
+
     public List<IFieldDependency<object>> Dependencies { get; set; } = new();
     public Expression<Func<object, object>> ValueExpression { get; set; } = obj => obj;
     public Type? CustomRendererType { get; set; }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **⚠️ Breaking: `IFieldConfiguration.Validators` is now `IReadOnlyList<>`; use `AddValidator(...)` to add one.** It was a concrete `List<>`, which made `config.Fields[i].Validators.Add(v)` compile, run, and **silently do nothing** — the object-typed view exposed through `IFormConfiguration.Fields` projects its validators from an underlying typed list, and because `List<>`'s members are not virtual it could only hand back a materialised snapshot. Adding to that snapshot never affected validation. Making the property an interface turns that silent no-op into a compile error (#155)
+
+  | before | after |
+  |---|---|
+  | `field.Validators.Add(validator)` | `field.AddValidator(validator)` |
+
+  **`AddValidator(...)` has existed since 3.1.0**, so you can migrate before upgrading and the change is then mechanical. Reading `Validators` — iterating, indexing, `.Count` — is unchanged. `AddValidator` also lost its default interface implementation: it could not be correct against a read-only property, and a custom `IFieldConfiguration` that forgets it should fail to compile rather than inherit a silent no-op.
+
 - **Numeric adornments now take an `onClick`, typed to the field's own value.** The numeric `WithAdornment` overloads added in #191 had no handler, because at the time the string overload's was read by neither render path. #192 made it live, so the reason expired and the gap remained. Both numeric overloads now accept `Action<TValue?>` — **not** the string overload's `Action<string?>`, which is right there only because that field's value happens to be a string — and the handler fires on both render paths, including inside `.WithItemForm(...)` (#215)
 
   ```csharp


### PR DESCRIPTION
Implements #155.

Closes #155.

**Option A**, as recommended: `IFieldConfiguration<TModel, TValue>.Validators` becomes
`IReadOnlyList<>`, and `AddValidator(...)` is the single mutation path.

### The trap this closes

`config.Fields[i].Validators.Add(v)` compiled, ran, and **silently did nothing**. The object-typed
view exposed through `IFormConfiguration.Fields` projects its validators from an underlying typed
list, and because `List<>`'s members are not virtual it could only hand back a materialised snapshot
— so #151 could cache that snapshot to stop the validator vanishing between reads, but never make it
reach validation. Exactly the failure mode the v3.0 audit flagged as finding #33.

Making the property an interface turns the silent no-op into a **compile error**, which is the
issue's acceptance criterion. `AddValidator(...)` has shipped since 3.1.0, so consumers can migrate
before upgrading:

| before | after |
|---|---|
| `field.Validators.Add(validator)` | `field.AddValidator(validator)` |

Reading `Validators` — iterating, indexing, `.Count` — is unchanged.

### `AddValidator` lost its default interface implementation

It was `void AddValidator(v) => Validators.Add(v);`. That body cannot compile against a read-only
property, and a defaulted member is the wrong shape here anyway: a custom `IFieldConfiguration` that
forgets to implement it should fail to build rather than silently inherit the very no-op this issue
is about.

### That the guard bites is shown, not asserted

The three call sites that mutated through the property are now compile errors and were rewritten to
`AddValidator`. Two `FieldConfigurationWrapper` tests needed a further change worth naming: they
stubbed `innerConfig.Validators` to return a real `List<>` and asserted on that list, which worked
only because the wrapper used to write through the property. Now it calls `_inner.AddValidator(...)`,
so a fake that only returns a list swallows the write — the tests would have been measuring the stub.
Their fakes now honour `AddValidator`, and the assertions are unchanged.

### The wider audit, decided rather than left open

The issue asks to look at the other concrete-collection leaks on public interfaces and decide each
deliberately. My reading:

- **`Dependencies` (`List<IFieldDependency<TModel>>`)** — same shape, but **no silent no-op**: the
  wrapper returns the inner list itself, so `.Add(...)` genuinely works. Worth tightening for
  symmetry, not urgent, and not smuggled into this PR.
- **`AdditionalAttributes` (`Dictionary<string, object>`)** — mutation is the *documented* API
  (`fieldConfig.AdditionalAttributes["Step"] = 5` appears in its own XML docs) and the wrapper
  returns the inner dictionary, so it works. Making it read-only would be a breaking change with no
  defect behind it. **Leave it.**
- **`IFormConfiguration.FieldDependencies`** — same as `Dependencies`: real, not a snapshot.

Only `Validators` had the projection-through-a-snapshot problem, which is what made it a trap rather
than a style question.

Full suite green: 1121 tests, 0 warnings.
