### PR TITLE
fix(mudblazor): render long, float, short and byte collection item fields (#209)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionNumericTypeTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionNumericTypeTests.cs
@@ -1,0 +1,131 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that every numeric type the component path renders also renders inside
+/// <c>.WithItemForm(...)</c> (#209).
+/// </summary>
+/// <remarks>
+/// <c>RenderItemField</c> dispatched on <c>string</c>/<c>int</c>/<c>decimal</c>/<c>double</c>/
+/// <c>bool</c>/<c>DateTime</c> only, while <c>MudBlazorNumericFieldRenderer.CanRender</c> accepts
+/// <c>float</c>, <c>long</c>, <c>short</c> and <c>byte</c> as well. An item field of one of those four
+/// emitted **no frames at all** — no input, no label, no validation message. The user saw an empty
+/// row, and the identical field outside a collection worked.
+/// <para>
+/// #191 made it worse: its numeric <c>WithAdornment</c> overloads are constrained to
+/// <c>INumber&lt;T&gt;</c>, so they compile on exactly these types — an adornment could be configured,
+/// without a warning, on a field that rendered nothing.
+/// </para>
+/// </remarks>
+public class CollectionNumericTypeTests : MudBlazorTestBase
+{
+    [Fact]
+    public void LongItemField_Should_Render()
+    {
+        var component = RenderItemForm<NumericsModel>(item => item
+            .AddField(x => x.AsLong, f => f.WithLabel("Long")));
+
+        component.FindComponents<MudNumericField<long>>().ShouldNotBeEmpty();
+        component.FindAll("input").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void FloatItemField_Should_Render()
+    {
+        var component = RenderItemForm<NumericsModel>(item => item
+            .AddField(x => x.AsFloat, f => f.WithLabel("Float")));
+
+        component.FindComponents<MudNumericField<float>>().ShouldNotBeEmpty();
+        component.FindAll("input").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void ShortItemField_Should_Render()
+    {
+        var component = RenderItemForm<NumericsModel>(item => item
+            .AddField(x => x.AsShort, f => f.WithLabel("Short")));
+
+        component.FindComponents<MudNumericField<short>>().ShouldNotBeEmpty();
+        component.FindAll("input").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void ByteItemField_Should_Render()
+    {
+        var component = RenderItemForm<NumericsModel>(item => item
+            .AddField(x => x.AsByte, f => f.WithLabel("Byte")));
+
+        component.FindComponents<MudNumericField<byte>>().ShouldNotBeEmpty();
+        component.FindAll("input").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Every_Type_The_Component_Path_Accepts_Should_Render_As_An_Item_Field()
+    {
+        // Arrange - the drift guard, and the reason it is driven off CanRender rather than a
+        // hand-written list: a copied list drifts exactly the way the dispatch it mirrors did. If a
+        // type is added to the renderer and not to RenderItemField, this goes red.
+        var renderer = new MudBlazorNumericFieldRenderer();
+        var candidates = new[]
+        {
+            typeof(int), typeof(decimal), typeof(double),
+            typeof(float), typeof(long), typeof(short), typeof(byte)
+        };
+
+        var accepted = candidates.Where(t => renderer.CanRender(t, null!)).ToList();
+        accepted.Count.ShouldBe(7, "the component path's accepted set changed — update this guard");
+
+        // Act & Assert - one item form per accepted type, each must produce an input.
+        var config = FormBuilder<NumericsModel>
+            .Create()
+            .AddCollectionField(x => x.Rows, collection => collection
+                .WithLabel("Rows")
+                .WithItemForm(item => item
+                    .AddField(x => x.AsInt, f => f.WithLabel("Int"))
+                    .AddField(x => x.AsDecimal, f => f.WithLabel("Decimal"))
+                    .AddField(x => x.AsDouble, f => f.WithLabel("Double"))
+                    .AddField(x => x.AsFloat, f => f.WithLabel("Float"))
+                    .AddField(x => x.AsLong, f => f.WithLabel("Long"))
+                    .AddField(x => x.AsShort, f => f.WithLabel("Short"))
+                    .AddField(x => x.AsByte, f => f.WithLabel("Byte"))))
+            .Build();
+
+        var component = Render<FormCraftComponent<NumericsModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericsModel { Rows = { new NumericsRow() } })
+            .Add(p => p.Configuration, config));
+
+        // One input per accepted type. A missing dispatch arm emits no frames at all, so the count
+        // is what catches it — asserting "some input exists" would pass with six of seven rendered.
+        component.FindAll("input").Count.ShouldBe(accepted.Count);
+    }
+
+    private IRenderedComponent<FormCraftComponent<NumericsModel>> RenderItemForm<T>(
+        Action<FormBuilder<NumericsRow>> configureItemForm)
+    {
+        var config = FormBuilder<NumericsModel>
+            .Create()
+            .AddCollectionField(x => x.Rows, collection => collection
+                .WithLabel("Rows")
+                .WithItemForm(configureItemForm))
+            .Build();
+
+        return Render<FormCraftComponent<NumericsModel>>(parameters => parameters
+            .Add(p => p.Model, new NumericsModel { Rows = { new NumericsRow() } })
+            .Add(p => p.Configuration, config));
+    }
+
+    private class NumericsModel
+    {
+        public List<NumericsRow> Rows { get; set; } = new();
+    }
+
+    private class NumericsRow
+    {
+        public int AsInt { get; set; }
+        public decimal AsDecimal { get; set; }
+        public double AsDouble { get; set; }
+        public float AsFloat { get; set; }
+        public long AsLong { get; set; }
+        public short AsShort { get; set; }
+        public byte AsByte { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -246,6 +246,31 @@ public partial class CollectionFieldComponent<TModel, TItem>
             {
                 RenderNumericField<double>(builder, field, (double)(value ?? 0.0), itemIndex);
             }
+            // #209. These four were missing, and a missing arm here does not degrade — it emits NO
+            // frames at all: no input, no label, no validation message, just an empty row. The same
+            // field outside a collection rendered fine, because MudBlazorNumericFieldRenderer.CanRender
+            // accepts all seven numeric types. #191 made it worse by adding numeric WithAdornment
+            // overloads constrained to INumber<T>, which compile on exactly these types — so an
+            // adornment could be configured, without a warning, on a field that rendered nothing.
+            //
+            // CollectionNumericTypeTests drives its guard off CanRender rather than a copied list, so
+            // adding a type to the renderer without adding it here goes red.
+            else if (underlyingType == typeof(float))
+            {
+                RenderNumericField<float>(builder, field, (float)(value ?? 0f), itemIndex);
+            }
+            else if (underlyingType == typeof(long))
+            {
+                RenderNumericField<long>(builder, field, (long)(value ?? 0L), itemIndex);
+            }
+            else if (underlyingType == typeof(short))
+            {
+                RenderNumericField<short>(builder, field, (short)(value ?? (short)0), itemIndex);
+            }
+            else if (underlyingType == typeof(byte))
+            {
+                RenderNumericField<byte>(builder, field, (byte)(value ?? (byte)0), itemIndex);
+            }
             else if (underlyingType == typeof(bool))
             {
                 RenderBooleanField(builder, field, value ?? false, itemIndex);

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **Collection item fields typed `long`, `float`, `short` or `byte` rendered *nothing at all* — they now render.** `RenderItemField` dispatched on `string`/`int`/`decimal`/`double`/`bool`/`DateTime` only, so a field of one of those four types emitted no input, no label and no validation message: an empty row, while the identical field outside a collection worked. `MudBlazorNumericFieldRenderer` has always accepted all seven numeric types (#209)
+
+  A test now drives the collection path off `MudBlazorNumericFieldRenderer.CanRender` rather than a copied list, so a type added to one and not the other fails the build.
+
 - **⚠️ Breaking: `IFieldConfiguration.Validators` is now `IReadOnlyList<>`; use `AddValidator(...)` to add one.** It was a concrete `List<>`, which made `config.Fields[i].Validators.Add(v)` compile, run, and **silently do nothing** — the object-typed view exposed through `IFormConfiguration.Fields` projects its validators from an underlying typed list, and because `List<>`'s members are not virtual it could only hand back a materialised snapshot. Adding to that snapshot never affected validation. Making the property an interface turns that silent no-op into a compile error (#155)
 
   | before | after |


### PR DESCRIPTION
Implements #209.

Closes #209.

A `long`, `float`, `short` or `byte` field inside `.WithItemForm(...)` emitted **no frames at all** —
no input, no label, no validation message. An empty row. The identical field outside a collection
rendered fine.

### Plan
- [x] Task 1: Render the missing numeric types
- [x] Task 2: Document

### This was blocked on #203; I re-opened that decision, on the terms the block set

The blocking comment ends *"**Blocked, not closed**, deliberately … Re-open the decision if #203 is
re-scoped."* My reasoning:

- **#203 is not scheduled.** It is a full architectural refactor (delete `RenderItemField`'s dispatch,
  route item fields through `IFieldRendererService`) and nothing is holding a date for it.
- **What waits meanwhile is a high-priority "renders nothing".** That is not a cosmetic drift to park
  behind a refactor of unknown date.
- **The throwaway cost is four `else if` arms.** The block's argument — the work is paid for twice,
  once writing it and once resolving its conflict — is sound in proportion to the work's size, and
  this is four lines. The **guard test is not thrown away**: it asserts the two paths agree on which
  types they render, which is a property #203 must preserve.
- The block also notes #203 may fall back to approach **B**, under which *"this issue survives and
  must be fixed directly"* — so this fix is needed in at least one live outcome.

### Measured, then fixed

`MudBlazorNumericFieldRenderer.CanRender` accepts `int, decimal, double, float, long, short, byte`;
`RenderItemField` dispatched on `int, decimal, double` (plus `string`, `bool`, `DateTime`). The gap is
exactly the four types the issue names.

The drift guard is driven **off `CanRender` itself**, not a hand-written list — a copied list drifts
the same way the dispatch it mirrors did. It renders all seven in one item form and asserts the input
count equals the accepted-type count, because a missing arm emits nothing and "some input exists"
would pass with six of seven.

Full suite green: 1126 tests, 0 warnings.
