### PR TITLE
fix(mudblazor): honour a configured Culture on numeric item fields (#218)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionCultureTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionCultureTests.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Tests that a numeric item field honours a configured <c>Culture</c> (#218).
+/// </summary>
+/// <remarks>
+/// The collection path hard-coded <c>CultureInfo.InvariantCulture</c> while the component path read a
+/// configurable one, so the same model with the same configuration parsed decimals differently inside
+/// and outside <c>.WithItemForm(...)</c> — a user typing <c>1,5</c> in a French locale got different
+/// results depending on where the field sat.
+/// <para>
+/// Invariant remains the **default**, which is what both paths render for an unconfigured field;
+/// making it configurable must not change what existing forms do.
+/// </para>
+/// </remarks>
+public class CollectionCultureTests : MudBlazorTestBase
+{
+    private static readonly CultureInfo French = new("fr-FR");
+
+    [Fact]
+    public void NumericItemField_Should_Honour_A_Configured_Culture()
+    {
+        // Arrange & Act
+        var component = RenderBasket(field => field.WithAttribute("Culture", French));
+
+        // Assert
+        component.FindComponent<MudNumericField<decimal>>().Instance.Culture.ShouldBe(French);
+    }
+
+    [Fact]
+    public void NumericItemField_Without_A_Culture_Should_Stay_Invariant()
+    {
+        // Arrange & Act - the default must not move. Every existing collection form parses against
+        // InvariantCulture today, and making the value configurable must not change that silently.
+        var component = RenderBasket(_ => { });
+
+        // Assert
+        component.FindComponent<MudNumericField<decimal>>().Instance.Culture
+            .ShouldBe(CultureInfo.InvariantCulture);
+    }
+
+    [Fact]
+    public void Both_Render_Paths_Should_Agree_On_The_Configured_Culture()
+    {
+        // Arrange - the parity claim this issue is really about: same model, same configuration,
+        // same parsing, inside or outside a collection.
+        var standaloneConfig = FormBuilder<PriceModel>
+            .Create()
+            .AddField(x => x.Amount, f => f.WithLabel("Amount").WithAttribute("Culture", French))
+            .Build();
+
+        // Act
+        var standalone = Render<FormCraftComponent<PriceModel>>(parameters => parameters
+            .Add(p => p.Model, new PriceModel())
+            .Add(p => p.Configuration, standaloneConfig));
+
+        var item = RenderBasket(field => field.WithAttribute("Culture", French));
+
+        // Assert
+        item.FindComponent<MudNumericField<decimal>>().Instance.Culture
+            .ShouldBe(standalone.FindComponent<MudNumericField<decimal>>().Instance.Culture);
+    }
+
+    private IRenderedComponent<FormCraftComponent<BasketModel>> RenderBasket(
+        Action<FieldBuilder<BasketLine, decimal>> configure)
+    {
+        var config = FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Price, field =>
+                    {
+                        field.WithLabel("Price");
+                        configure(field);
+                    })))
+            .Build();
+
+        return Render<FormCraftComponent<BasketModel>>(parameters => parameters
+            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
+            .Add(p => p.Configuration, config));
+    }
+
+    private class BasketModel
+    {
+        public List<BasketLine> Lines { get; set; } = new();
+    }
+
+    private class BasketLine
+    {
+        public decimal Price { get; set; }
+    }
+
+    private class PriceModel
+    {
+        public decimal Amount { get; set; }
+    }
+}

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -337,7 +338,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         // MudBlazor appends '*' to Pattern before emitting the HTML attribute, so a
         // fully-anchored regex here becomes invalid (e.g. "...?*"). The component's
         // default pattern already handles decimal input; only Culture is needed.
-        builder.AddAttribute(CallerAttributeStart + 3, "Culture", System.Globalization.CultureInfo.InvariantCulture);
+        builder.AddAttribute(CallerAttributeStart + 3, "Culture", GetItemFieldCulture(field));
 
         // #208. The component path resolved Format and ShowSpinButtons and then never bound them;
         // this path never forwarded them at all. Fixing only the component path would have opened a
@@ -451,6 +452,25 @@ public partial class CollectionFieldComponent<TModel, TItem>
         builder.AddAttribute(startIndex, "autocomplete",
             GetItemFieldAttribute<string?>(field, "autocomplete", null));
     }
+
+    /// <summary>
+    /// Resolves the culture a numeric item field parses and formats with: the configured
+    /// <c>"Culture"</c> attribute, otherwise <see cref="CultureInfo.InvariantCulture"/> (#218).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the component path's
+    /// <c>GetAttribute&lt;CultureInfo&gt;("Culture") ?? CultureInfo.InvariantCulture</c>. This value
+    /// used to be hard-coded here, so the same model with the same configuration parsed decimals
+    /// differently inside and outside <c>.WithItemForm(...)</c> — a user typing <c>1,5</c> in a French
+    /// locale got different results depending on where the field sat.
+    /// <para>
+    /// Invariant stays the DEFAULT, not merely a fallback of convenience: it is what both paths have
+    /// always rendered for an unconfigured field, and making the value configurable must not change
+    /// what existing forms do.
+    /// </para>
+    /// </remarks>
+    private static CultureInfo GetItemFieldCulture(IFieldConfiguration<TItem, object> field)
+        => GetItemFieldAttribute<CultureInfo?>(field, "Culture", null) ?? CultureInfo.InvariantCulture;
 
     /// <summary>
     /// Resolves the rendered line count for an item field: the configured value, forced back to 1

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **Numeric collection item fields honour a configured `Culture`.** The collection path hard-coded `CultureInfo.InvariantCulture` while an ordinary numeric field took a configurable one, so the same model with the same configuration parsed decimals differently inside and outside `.WithItemForm(...)` — typing `1,5` in a French locale gave different results depending on where the field sat. `InvariantCulture` remains the **default**, so a form that configures nothing is unaffected (#218)
+
 - **Collection item fields typed `long`, `float`, `short` or `byte` rendered *nothing at all* — they now render.** `RenderItemField` dispatched on `string`/`int`/`decimal`/`double`/`bool`/`DateTime` only, so a field of one of those four types emitted no input, no label and no validation message: an empty row, while the identical field outside a collection worked. `MudBlazorNumericFieldRenderer` has always accepted all seven numeric types (#209)
 
   A test now drives the collection path off `MudBlazorNumericFieldRenderer.CanRender` rather than a copied list, so a type added to one and not the other fails the build.


### PR DESCRIPTION
Implements #218.

Closes #218.

The collection numeric path hard-coded `CultureInfo.InvariantCulture` while the component path took a
configurable one, so **the same model with the same configuration parsed decimals differently inside
and outside `.WithItemForm(...)`** — a user typing `1,5` in a French locale got different results
depending on where the field sat.

### Plan
- [x] Task 1: Resolve Culture for numeric item fields
- [x] Task 2: Document

### Re-opened from its #203 block, on the same terms as #209

#203 (converge the two render paths) is not scheduled and is not landing in this batch. The fix here
is one resolver mirroring an existing one, and the parity test survives #203 however it lands — it
asserts a property that refactor must preserve, not an implementation detail of the code it replaces.

### `InvariantCulture` is still the default

That is the part worth being careful about: it is what **both** paths have always rendered for an
unconfigured field, so making the value configurable must not change what any existing form does.
A test pins the unconfigured case explicitly, alongside the configured one and a direct
both-paths-agree comparison.

The neighbouring `Pattern` comment is untouched — MudBlazor appends `*` to `Pattern` before emitting
the HTML attribute, so a fully-anchored regex there becomes invalid. Different trap, still true.

Full suite green: 1129 tests, 0 warnings.
