### PR TITLE
fix(mudblazor): forward a configured adornment to date item fields (#217)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -160,6 +160,39 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         var picker = component.FindComponent<MudDatePicker>().Instance;
         picker.Adornment.ShouldBe(Adornment.End);
         picker.AdornmentIcon.ShouldNotBeNullOrEmpty();
+        picker.AdornmentIcon.ShouldBe(Icons.Material.Filled.Event);
+    }
+
+    [Fact]
+    public void DateItemField_Should_Honour_A_Configured_Adornment()
+    {
+        // Arrange - #217. The date path used to pass `rendersAdornment: false`, so `.WithAdornment(...)`
+        // on a date item field was accepted and silently dropped — the same class of silent discard
+        // #184, #191 and #192 each closed elsewhere. It now forwards a configured adornment while
+        // keeping MudDatePicker's own End + calendar icon as the DEFAULT (pinned above), so the two
+        // cases no longer trade off against each other.
+        var config = FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field => field
+                        .WithLabel("When")
+                        .WithAttribute("Adornment", Adornment.Start)
+                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search)
+                        .WithAttribute("AdornmentColor", Color.Secondary))))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
+            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
+            .Add(p => p.Configuration, config));
+
+        // Assert - the configured adornment wins over MudDatePicker's default.
+        var picker = component.FindComponent<MudDatePicker>().Instance;
+        picker.Adornment.ShouldBe(Adornment.Start);
+        picker.AdornmentIcon.ShouldBe(Icons.Material.Filled.Search);
+        picker.AdornmentColor.ShouldBe(Color.Secondary);
     }
 
     [Fact]

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/ShrinkLabelDiagnosticsTests.cs
@@ -316,12 +316,19 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
     }
 
     [Fact]
-    public void Should_Not_Warn_About_An_Adornment_On_A_Collection_Date_Item_Field()
+    public void Should_Warn_About_An_Adornment_On_A_Collection_Date_Item_Field()
     {
-        // Arrange - the date path deliberately keeps MudDatePicker's own calendar adornment rather
-        // than taking #184's forward, so a configured start adornment is still dropped there and
-        // ShrinkLabel=false IS honoured. This is #183's rule, now scoped to the one path that still
-        // needs it — the diagnostic must see what each path actually renders, not what was asked.
+        // Arrange - inverted by #217, and the inversion is the point rather than a concession.
+        //
+        // This test used to assert SILENCE, and was right to: the date path passed
+        // `rendersAdornment: false`, so a configured start adornment was dropped and ShrinkLabel=false
+        // really was honoured. #183's rule — the diagnostic must judge what a path RENDERS, not what
+        // was configured — pointed at silence given that behaviour.
+        //
+        // #217 made the date path forward a configured adornment (while keeping MudDatePicker's
+        // calendar icon as the default). The rule has not changed; what the path renders has. A start
+        // adornment is now really drawn, it really does pin the label, and warning is now the correct
+        // answer under exactly the same rule.
         var config = FormBuilder<OrderModel>
             .Create()
             .AddCollectionField(x => x.Items, collection => collection
@@ -346,7 +353,10 @@ public class ShrinkLabelDiagnosticsTests : MudBlazorTestBase
         });
 
         // Assert
-        _logs.Warnings.ShouldBeEmpty();
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Ordered on");
+        warnings[0].ShouldContain("Adornment");
     }
 
     [Fact]

--- a/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Features/CollectionField/CollectionFieldComponent.razor.cs
@@ -374,11 +374,29 @@ public partial class CollectionFieldComponent<TModel, TItem>
     private void RenderDateTimeField(RenderTreeBuilder builder, IFieldConfiguration<TItem, object> field, DateTime? value, int itemIndex)
     {
         builder.OpenComponent<MudDatePicker>(0);
-        // rendersAdornment: false — MudDatePicker defaults to Adornment.End with its calendar
-        // icon, so forwarding a field's (usually unset) adornment here would silently strip that
-        // icon on every date item field. Out of scope for #184; see the issue's non-goals.
-        AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: false,
-            adornmentClick: default);
+        // The date path DOES take the forward now (#217), with MudDatePicker's own defaults supplied
+        // rather than the text/numeric ones.
+        //
+        // It used to pass `rendersAdornment: false`, because MudDatePicker defaults to Adornment.End
+        // with a calendar icon and forwarding a field's usually-unset adornment would have stripped
+        // that icon from every date item field. The cost was that `.WithAdornment(...)` on a date item
+        // field was accepted and silently dropped — the same class of silent discard #184, #191 and
+        // #192 each closed elsewhere.
+        //
+        // Supplying the defaults resolves both: an unconfigured field still renders End + the calendar
+        // icon (measured from MudDatePicker itself, and pinned by
+        // CollectionAdornmentTests.DateItemField_Should_Keep_Its_Calendar_Icon), while a configured
+        // adornment now wins. Crucially the trio is still emitted unconditionally, so the frame layout
+        // stays per-CALL-SITE rather than per-configuration — the invariant the comment below relies on.
+        //
+        // This also settles the ShrinkLabel pairing the issue flagged: the diagnostic is handed the
+        // adornment this path RENDERS, which for a date field is now real. An unconfigured field
+        // reports End, which never conflicts with a floating label; a field that really did configure
+        // a Start adornment now warns, correctly.
+        AddCommonFieldAttributes(builder, field, CommonAttributeStart, rendersAdornment: true,
+            adornmentClick: default,
+            defaultAdornment: Adornment.End,
+            defaultAdornmentIcon: Icons.Material.Filled.Event);
         builder.AddAttribute(CallerAttributeStart, "Date", value);
         builder.AddAttribute(CallerAttributeStart + 1, "DateChanged",
             EventCallback.Factory.Create<DateTime?>(this,
@@ -534,12 +552,22 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// that forwards no handler. It is emitted with the other three adornment attributes so the set
     /// stays together; a callback with no delegate leaves the adornment a plain, inert icon.
     /// </param>
+    /// <param name="defaultAdornment">
+    /// The adornment to render when the field configures none — the target component's own default
+    /// (#217). <see cref="Adornment.None"/> for MudTextField and MudNumericField;
+    /// <see cref="Adornment.End"/> for MudDatePicker, which draws a calendar icon there.
+    /// </param>
+    /// <param name="defaultAdornmentIcon">
+    /// The icon to render when the field configures none, for the same reason.
+    /// </param>
     private void AddCommonFieldAttributes(
         RenderTreeBuilder builder,
         IFieldConfiguration<TItem, object> field,
         int startIndex,
         bool rendersAdornment,
-        EventCallback<MouseEventArgs> adornmentClick)
+        EventCallback<MouseEventArgs> adornmentClick,
+        Adornment defaultAdornment = Adornment.None,
+        string? defaultAdornmentIcon = null)
     {
         builder.AddAttribute(startIndex++, "Label", field.Label);
         builder.AddAttribute(startIndex++, "Placeholder", field.Placeholder);
@@ -563,7 +591,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
 
         // Null on a path that draws no adornment of ours — which the diagnostic below needs to
         // tell apart from "none configured".
-        var adornment = rendersAdornment ? GetItemFieldAdornment(field) : (Adornment?)null;
+        var adornment = rendersAdornment ? GetItemFieldAdornment(field, defaultAdornment) : (Adornment?)null;
 
         // The branch is per-CALL-SITE, not per-configuration: `adornment` is null exactly when the
         // caller passed rendersAdornment: false, so a given renderer always emits the same frames
@@ -573,7 +601,7 @@ public partial class CollectionFieldComponent<TModel, TItem>
         if (adornment is { } rendered)
         {
             builder.AddAttribute(startIndex++, "Adornment", rendered);
-            builder.AddAttribute(startIndex++, "AdornmentIcon", GetItemFieldAttribute<string?>(field, "AdornmentIcon", null));
+            builder.AddAttribute(startIndex++, "AdornmentIcon", GetItemFieldAttribute(field, "AdornmentIcon", defaultAdornmentIcon));
             builder.AddAttribute(startIndex++, "AdornmentColor", GetItemFieldAttribute(field, "AdornmentColor", Color.Default));
 
             // Emitted unconditionally inside the branch, like the three above: the frame layout is
@@ -676,8 +704,10 @@ public partial class CollectionFieldComponent<TModel, TItem>
     /// Resolves the adornment position for an item field (#184): the field-level "Adornment"
     /// attribute when present, otherwise none. There is no form-level default for adornments.
     /// </summary>
-    private static Adornment GetItemFieldAdornment(IFieldConfiguration<TItem, object> field)
-        => GetItemFieldAttribute(field, "Adornment", Adornment.None);
+    private static Adornment GetItemFieldAdornment(
+        IFieldConfiguration<TItem, object> field,
+        Adornment fallback)
+        => GetItemFieldAttribute(field, "Adornment", fallback);
 
     /// <summary>
     /// Reads a strongly-typed item-field attribute, returning <paramref name="fallback"/> when it

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
 
 ## 🎉 Unreleased
 
+- **Date collection item fields honour a configured adornment — and keep their calendar icon.** `.WithAdornment(...)` on a date field inside `.WithItemForm(...)` was accepted and silently dropped: the date path refused the forward because `MudDatePicker` defaults to `Adornment.End` with its own calendar icon, and forwarding an unset adornment would have erased it. Both now hold — MudDatePicker's End + calendar icon is the **default**, and a configured adornment wins (#217)
+
+  **Worth knowing if you configure a start adornment on a date item field:** it is now really rendered, so it really does pin the label — and the `ShrinkLabel` diagnostic now says so, where it used to stay quiet because the adornment was being discarded.
+
 - **Numeric collection item fields honour a configured `Culture`.** The collection path hard-coded `CultureInfo.InvariantCulture` while an ordinary numeric field took a configurable one, so the same model with the same configuration parsed decimals differently inside and outside `.WithItemForm(...)` — typing `1,5` in a French locale gave different results depending on where the field sat. `InvariantCulture` remains the **default**, so a form that configures nothing is unaffected (#218)
 
 - **Collection item fields typed `long`, `float`, `short` or `byte` rendered *nothing at all* — they now render.** `RenderItemField` dispatched on `string`/`int`/`decimal`/`double`/`bool`/`DateTime` only, so a field of one of those four types emitted no input, no label and no validation message: an empty row, while the identical field outside a collection worked. `MudBlazorNumericFieldRenderer` has always accepted all seven numeric types (#209)


### PR DESCRIPTION
Implements #217.

Closes #217.

`.WithAdornment(...)` on a date item field was accepted and silently dropped — the same class of
silent discard #184, #191 and #192 each closed elsewhere.

### Re-opened from its #203 block, on the terms the block set

Same reasoning as #209 and #218: #203 is not scheduled, and the block's own text says *"Under B this
remains a live divergence needing its own fix. Re-open the decision if #203 is re-scoped."*

### The trade-off the old code faced, and why it no longer has to

`RenderDateTimeField` passed `rendersAdornment: false` for a good reason: `MudDatePicker` defaults to
`Adornment.End` with a calendar icon, and forwarding a field's usually-unset adornment would have
stripped that icon from **every** date item field. The issue notes this needs `GetItemFieldAdornment`
to tell "unset" from "explicitly None".

Rather than make the *frames* conditional — `AddCommonFieldAttributes` deliberately emits the adornment
trio per **call-site**, not per configuration, so a given renderer always produces the same frames in
the same order — the defaults are now supplied by the caller. The date path passes
`defaultAdornment: Adornment.End, defaultAdornmentIcon: Icons.Material.Filled.Event`, so:

- an unconfigured date field renders End + the calendar icon, exactly as before;
- a configured adornment wins;
- the frame layout stays per-call-site.

**Those defaults were measured, not guessed.** A throwaway probe read them off a rendered
`MudDatePicker` (`Adornment=End`, icon = `Icons.Material.Filled.Event`, `Color=Default`); the existing
`DateItemField_Should_Keep_Its_Calendar_Icon` now asserts the icon *equals* `Event` rather than merely
being non-empty, so a MudBlazor upgrade that changes it fails loudly instead of silently swapping the
icon.

### The ShrinkLabel pairing, which the issue said to revisit together

It is settled by the same change, and one existing test **inverts**:
`Should_Not_Warn_About_An_Adornment_On_A_Collection_Date_Item_Field` becomes `Should_Warn_…`.

That is not a concession — the rule is unchanged. #183 says the diagnostic must judge what a path
*renders*, not what was configured; silence was correct while the adornment was being dropped. Now a
configured start adornment really is drawn and really does pin the label, so warning is the correct
answer under exactly the same rule. The test's comment records both states so the inversion is not
mistaken later for a regression.

Full suite green: 1130 tests, 0 warnings.
