### PR TITLE
test(mudblazor): extract a shared collection-item test fixture (#205)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -1,3 +1,5 @@
+using static FormCraft.ForMudBlazor.UnitTests.Fields.CollectionItemFixture;
+
 namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 
 /// <summary>
@@ -7,6 +9,19 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// needs its own coverage. Before #184 the three adornment attributes were silently dropped here
 /// while the component path forwarded them, so the same builder call rendered differently
 /// depending on whether the field sat inside <c>.WithItemForm(...)</c>.
+/// <para>
+/// Models and item-form builders come from <see cref="CollectionItemFixture"/> (#205). The text-path
+/// tests render <c>NewOrder("Widget")</c> — the <b>seeded</b> value — because an adornment is about
+/// what a populated field looks like; the sibling Required suite deliberately renders the blank seed
+/// instead. Passing it at each call site keeps that difference visible rather than burying it in a
+/// local helper, which is how the two suites' copies drifted in the first place.
+/// </para>
+/// <para>
+/// The reorder test at the bottom keeps its own <c>MixedModel</c> and its <c>MudPopoverProvider</c>
+/// wrapper. It needs two rows of *differing* field types in one item form, which is the opposite of
+/// what the fixture provides, and bending the fixture to absorb it would make it worse for the nine
+/// tests above.
+/// </para>
 /// </summary>
 public class CollectionAdornmentTests : MudBlazorTestBase
 {
@@ -14,7 +29,7 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     public void ItemField_Should_Render_A_Start_Adornment()
     {
         // Arrange & Act
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder("Widget"), TextItemForm(field => field
             .WithAdornment(Icons.Material.Filled.Search, Adornment.Start)));
 
         // Assert
@@ -27,7 +42,7 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     public void ItemField_Should_Render_The_Configured_Adornment_Color()
     {
         // Arrange & Act - WithAdornment always writes all three attributes, colour included
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder("Widget"), TextItemForm(field => field
             .WithAdornment(Icons.Material.Filled.Search, Adornment.Start, Color.Secondary)));
 
         // Assert
@@ -39,7 +54,7 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     public void ItemField_Without_An_Adornment_Should_Render_None()
     {
         // Arrange & Act - unchanged from before #184: no adornment configured, none rendered
-        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+        var component = this.RenderItemForm(NewOrder("Widget"), TextItemForm());
 
         // Assert
         var textField = component.FindComponent<MudTextField<string>>().Instance;
@@ -52,7 +67,7 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     {
         // Arrange & Act - a field that set "Adornment" through raw WithAttribute has no colour to
         // read, so the resolver must supply one rather than assume all three are present.
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder("Widget"), TextItemForm(field => field
             .WithAttribute("Adornment", Adornment.End)));
 
         // Assert
@@ -64,25 +79,13 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     [Fact]
     public void NumericItemField_Should_Render_An_End_Adornment()
     {
-        // Arrange - WithAdornment is declared on FieldBuilder<TModel, string> only, so a numeric
+        // Arrange & Act - WithAdornment is declared on FieldBuilder<TModel, string> only, so a numeric
         // field configures the same three attributes through raw WithAttribute. The renderer must
         // honour them either way: it reads AdditionalAttributes, not the builder method.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.Quantity, field => field
-                        .WithLabel("Quantity")
-                        .WithAttribute("Adornment", Adornment.End)
-                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Numbers)
-                        .WithAttribute("AdornmentColor", Color.Primary))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewBasket(), NumericItemForm(field => field
+            .WithAttribute("Adornment", Adornment.End)
+            .WithAttribute("AdornmentIcon", Icons.Material.Filled.Numbers)
+            .WithAttribute("AdornmentColor", Color.Primary)));
 
         // Assert
         var numeric = component.FindComponent<MudNumericField<int>>().Instance;
@@ -95,17 +98,7 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     public void NumericItemField_Without_An_Adornment_Should_Render_None()
     {
         // Arrange & Act - unchanged from before #184
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.Quantity, field => field.WithLabel("Quantity"))))
-            .Build();
-
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewBasket(), NumericItemForm());
 
         // Assert
         component.FindComponent<MudNumericField<int>>().Instance.Adornment.ShouldBe(Adornment.None);
@@ -114,23 +107,11 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     [Fact]
     public void BooleanItemField_With_An_Adornment_Should_Render_Without_One()
     {
-        // Arrange - MudCheckBox has no adornment concept at all, so RenderBooleanField sets its own
-        // attributes and takes no part in the forward. Configuring one must be inert, not a throw.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.IsGift, field => field
-                        .WithLabel("Gift")
-                        .WithAttribute("Adornment", Adornment.Start)
-                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        // Arrange & Act - MudCheckBox has no adornment concept at all, so RenderBooleanField sets its
+        // own attributes and takes no part in the forward. Configuring one must be inert, not a throw.
+        var component = this.RenderItemForm(NewBasket(), BooleanItemForm(field => field
+            .WithAttribute("Adornment", Adornment.Start)
+            .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search)));
 
         // Assert
         component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
@@ -140,21 +121,10 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     [Fact]
     public void DateItemField_Should_Keep_Its_Calendar_Icon()
     {
-        // Arrange - MudDatePicker's own default is Adornment.End with a calendar icon, unlike the
+        // Arrange & Act - MudDatePicker's own default is Adornment.End with a calendar icon, unlike the
         // text and numeric fields whose default is None. Forwarding an unset adornment onto it
         // would silently erase that icon, so the date path deliberately does not take the forward.
-        var config = FormBuilder<AppointmentModel>
-            .Create()
-            .AddCollectionField(x => x.Slots, collection => collection
-                .WithLabel("Slots")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field.WithLabel("When"))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
-            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewAppointment(), DateItemForm());
 
         // Assert
         var picker = component.FindComponent<MudDatePicker>().Instance;
@@ -166,27 +136,15 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     [Fact]
     public void DateItemField_Should_Honour_A_Configured_Adornment()
     {
-        // Arrange - #217. The date path used to pass `rendersAdornment: false`, so `.WithAdornment(...)`
+        // Arrange & Act - #217. The date path used to pass `rendersAdornment: false`, so `.WithAdornment(...)`
         // on a date item field was accepted and silently dropped — the same class of silent discard
         // #184, #191 and #192 each closed elsewhere. It now forwards a configured adornment while
         // keeping MudDatePicker's own End + calendar icon as the DEFAULT (pinned above), so the two
         // cases no longer trade off against each other.
-        var config = FormBuilder<AppointmentModel>
-            .Create()
-            .AddCollectionField(x => x.Slots, collection => collection
-                .WithLabel("Slots")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field
-                        .WithLabel("When")
-                        .WithAttribute("Adornment", Adornment.Start)
-                        .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search)
-                        .WithAttribute("AdornmentColor", Color.Secondary))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
-            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewAppointment(), DateItemForm(field => field
+            .WithAttribute("Adornment", Adornment.Start)
+            .WithAttribute("AdornmentIcon", Icons.Material.Filled.Search)
+            .WithAttribute("AdornmentColor", Color.Secondary)));
 
         // Assert - the configured adornment wins over MudDatePicker's default.
         var picker = component.FindComponent<MudDatePicker>().Instance;
@@ -202,6 +160,9 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         // row, so a mixed item form now has rows of differing frame counts in a keyless loop. If the
         // sequence numbers were computed rather than source-position constants, Blazor would pair
         // frames positionally across a reorder and a value could stay on the row it was on.
+        //
+        // Deliberately NOT on the shared fixture (#205): this needs one item form holding two fields
+        // of different types, which is exactly what the fixture's one-field-per-path models are not.
         var model = new MixedModel
         {
             Rows =
@@ -253,54 +214,6 @@ public class CollectionAdornmentTests : MudBlazorTestBase
             .ShouldBe(new DateTime?[] { new DateTime(2030, 12, 31), new DateTime(2020, 1, 1) });
     }
 
-    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
-        IFormConfiguration<OrderModel> config)
-    {
-        var model = new OrderModel { Items = { new OrderItem { ProductName = "Widget" } } };
-
-        return Render<FormCraftComponent<OrderModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, config));
-    }
-
-    private static IFormConfiguration<OrderModel> BuildConfiguration(
-        Action<FieldBuilder<OrderItem, string>> configureItemField)
-    {
-        return FormBuilder<OrderModel>
-            .Create()
-            .AddCollectionField(x => x.Items, collection => collection
-                .WithLabel("Items")
-                .WithItemForm(item => item
-                    .AddField(x => x.ProductName, field =>
-                    {
-                        field.WithLabel("Product");
-                        configureItemField(field);
-                    })))
-            .Build();
-    }
-
-    private class OrderModel
-    {
-        public List<OrderItem> Items { get; set; } = new();
-    }
-
-    private class OrderItem
-    {
-        public string ProductName { get; set; } = string.Empty;
-    }
-
-    private class BasketModel
-    {
-        public List<BasketLine> Lines { get; set; } = new();
-    }
-
-    private class BasketLine
-    {
-        public int Quantity { get; set; }
-
-        public bool IsGift { get; set; }
-    }
-
     private class MixedModel
     {
         public List<MixedRow> Rows { get; set; } = new();
@@ -310,16 +223,6 @@ public class CollectionAdornmentTests : MudBlazorTestBase
     {
         public string Name { get; set; } = string.Empty;
 
-        public DateTime When { get; set; }
-    }
-
-    private class AppointmentModel
-    {
-        public List<AppointmentSlot> Slots { get; set; } = new();
-    }
-
-    private class AppointmentSlot
-    {
         public DateTime When { get; set; }
     }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
@@ -1,0 +1,185 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// The canonical models and item-form builders the collection-item attribute suites share (#205).
+/// <para>
+/// Every such suite exercises the same handful of render paths through
+/// <c>CollectionFieldComponent</c>'s imperative RenderTreeBuilder path, and each one used to carry
+/// its own copy of the same model pairs and the same two helpers. The copies drifted in incidentals
+/// (whether <c>ProductName</c> was seeded, whether <c>BasketLine</c> declared <c>IsGift</c>) and
+/// they propagated mistakes as faithfully as they propagated code — a miscounted comment claiming
+/// <c>AddCommonFieldAttributes</c> fed "the text and numeric paths" survived a copy and hid the date
+/// path from coverage until review caught it.
+/// </para>
+/// <para>
+/// <b>The four paths.</b> The models are chosen so that a suite using this fixture covers all of them
+/// by default rather than by remembering to:
+/// <list type="bullet">
+/// <item><description><see cref="OrderItem"/> — <c>string</c>, the text path (<c>MudTextField</c>).</description></item>
+/// <item><description><see cref="BasketLine"/> — <c>int</c>, the numeric path (<c>MudNumericField</c>).</description></item>
+/// <item><description><see cref="AppointmentSlot"/> — <c>DateTime</c>, the date path (<c>MudDatePicker</c>).</description></item>
+/// <item><description><see cref="BasketLine"/> again — <c>bool</c>, the checkbox path
+/// (<c>MudCheckBox</c>), which is the one that <b>bypasses</b> <c>AddCommonFieldAttributes</c> and
+/// where attributes are therefore pinned as inert.</description></item>
+/// </list>
+/// The first three are fed by <c>AddCommonFieldAttributes</c>; the fourth is not. That asymmetry is
+/// the whole reason the boolean model lives here rather than being left to each suite.
+/// </para>
+/// <para>
+/// <b>Seeds are the caller's choice.</b> The factories default to the model's own default and take an
+/// explicit seed, because the suites genuinely disagree: <c>CollectionRequiredTests</c> needs a blank
+/// <c>ProductName</c> so its validator fails, while <c>CollectionAdornmentTests</c> renders against a
+/// populated one. Picking one for everybody would silently change a test's meaning.
+/// </para>
+/// <para>
+/// Models are deliberately dumb and stable — no behaviour, no validation attributes, no computed
+/// members. Everything a suite wants to vary goes through the <c>configure</c> callback on the item-form
+/// builders instead, so a change here cannot ripple into what an unrelated suite asserts.
+/// </para>
+/// </summary>
+internal static class CollectionItemFixture
+{
+    /// <summary>Creates an order with a single item, blank unless a <paramref name="productName"/> is given.</summary>
+    internal static OrderModel NewOrder(string productName = "") =>
+        new() { Items = { new OrderItem { ProductName = productName } } };
+
+    /// <summary>Creates a basket with a single line, blank unless seeds are given.</summary>
+    internal static BasketModel NewBasket(int quantity = 0, bool isGift = false) =>
+        new() { Lines = { new BasketLine { Quantity = quantity, IsGift = isGift } } };
+
+    /// <summary>Creates an appointment with a single slot, blank unless a <paramref name="when"/> is given.</summary>
+    internal static AppointmentModel NewAppointment(DateTime when = default) =>
+        new() { Slots = { new AppointmentSlot { When = when } } };
+
+    /// <summary>
+    /// A collection whose item form holds one <c>string</c> field labelled "Product" — the text path.
+    /// </summary>
+    internal static IFormConfiguration<OrderModel> TextItemForm(
+        Action<FieldBuilder<OrderItem, string>>? configure = null) =>
+        FormBuilder<OrderModel>
+            .Create()
+            .AddCollectionField(x => x.Items, collection => collection
+                .WithLabel("Items")
+                .WithItemForm(item => item
+                    .AddField(x => x.ProductName, field =>
+                    {
+                        field.WithLabel("Product");
+                        configure?.Invoke(field);
+                    })))
+            .Build();
+
+    /// <summary>
+    /// A collection whose item form holds one <c>int</c> field labelled "Quantity" — the numeric path.
+    /// </summary>
+    internal static IFormConfiguration<BasketModel> NumericItemForm(
+        Action<FieldBuilder<BasketLine, int>>? configure = null) =>
+        FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.Quantity, field =>
+                    {
+                        field.WithLabel("Quantity");
+                        configure?.Invoke(field);
+                    })))
+            .Build();
+
+    /// <summary>
+    /// A collection whose item form holds one <c>DateTime</c> field labelled "When" — the date path.
+    /// </summary>
+    internal static IFormConfiguration<AppointmentModel> DateItemForm(
+        Action<FieldBuilder<AppointmentSlot, DateTime>>? configure = null) =>
+        FormBuilder<AppointmentModel>
+            .Create()
+            .AddCollectionField(x => x.Slots, collection => collection
+                .WithLabel("Slots")
+                .WithItemForm(item => item
+                    .AddField(x => x.When, field =>
+                    {
+                        field.WithLabel("When");
+                        configure?.Invoke(field);
+                    })))
+            .Build();
+
+    /// <summary>
+    /// A collection whose item form holds one <c>bool</c> field labelled "Gift" — the checkbox path,
+    /// the one that never reaches <c>AddCommonFieldAttributes</c>.
+    /// </summary>
+    internal static IFormConfiguration<BasketModel> BooleanItemForm(
+        Action<FieldBuilder<BasketLine, bool>>? configure = null) =>
+        FormBuilder<BasketModel>
+            .Create()
+            .AddCollectionField(x => x.Lines, collection => collection
+                .WithLabel("Lines")
+                .WithItemForm(item => item
+                    .AddField(x => x.IsGift, field =>
+                    {
+                        field.WithLabel("Gift");
+                        configure?.Invoke(field);
+                    })))
+            .Build();
+}
+
+/// <summary>Root model for the text path.</summary>
+internal sealed class OrderModel
+{
+    public List<OrderItem> Items { get; set; } = new();
+}
+
+/// <summary>Item for the text path — one <c>string</c>, nothing else.</summary>
+internal sealed class OrderItem
+{
+    public string ProductName { get; set; } = string.Empty;
+}
+
+/// <summary>Root model for the numeric and boolean paths.</summary>
+internal sealed class BasketModel
+{
+    public List<BasketLine> Lines { get; set; } = new();
+}
+
+/// <summary>
+/// Item for the numeric and boolean paths. It carries both so a single suite can compare a field fed
+/// by <c>AddCommonFieldAttributes</c> against one that bypasses it, without a second model pair.
+/// </summary>
+internal sealed class BasketLine
+{
+    public int Quantity { get; set; }
+
+    public bool IsGift { get; set; }
+}
+
+/// <summary>Root model for the date path.</summary>
+internal sealed class AppointmentModel
+{
+    public List<AppointmentSlot> Slots { get; set; } = new();
+}
+
+/// <summary>Item for the date path — one <c>DateTime</c>, nothing else.</summary>
+internal sealed class AppointmentSlot
+{
+    public DateTime When { get; set; }
+}
+
+/// <summary>
+/// Rendering half of the fixture. It is an extension on <see cref="BunitContext"/> rather than a member
+/// of <c>MudBlazorTestBase</c> on purpose: the base class is about how to render anything, and pushing
+/// collection-specific helpers into it would burden every MudBlazor test that has nothing to do with
+/// collections.
+/// </summary>
+internal static class CollectionItemFixtureRenderExtensions
+{
+    /// <summary>
+    /// Renders <paramref name="model"/> through <c>FormCraftComponent</c> with the given configuration.
+    /// This is the shape every collection-item suite had open-coded per test.
+    /// </summary>
+    internal static IRenderedComponent<FormCraftComponent<TModel>> RenderItemForm<TModel>(
+        this BunitContext context,
+        TModel model,
+        IFormConfiguration<TModel> configuration)
+        where TModel : new() =>
+        context.Render<FormCraftComponent<TModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, configuration));
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
@@ -1,0 +1,154 @@
+namespace FormCraft.ForMudBlazor.UnitTests.Fields;
+
+/// <summary>
+/// Self-tests for <see cref="CollectionItemFixture"/> (#205).
+/// <para>
+/// The fixture exists so an attribute suite declares only the behaviour it tests, and so every such
+/// suite covers all four collection-item render paths by default instead of by remembering to. That
+/// only holds if the fixture itself is guarded: these tests pin the two properties the suites rely on
+/// and cannot check for themselves.
+/// </para>
+/// <para>
+/// <b>All four paths render.</b> Three of them — text, numeric and date — are fed by
+/// <c>AddCommonFieldAttributes</c>; the boolean path bypasses it entirely, which is why several suites
+/// pin an attribute as *inert* there. A fixture that silently stopped producing one of the four would
+/// turn those tests green for the wrong reason, so each path is asserted to reach its MudBlazor
+/// component.
+/// </para>
+/// <para>
+/// <b>The seed is the caller's choice.</b> <c>CollectionRequiredTests</c> needs a blank
+/// <c>ProductName</c> for its validation tests; <c>CollectionAdornmentTests</c> seeds it with
+/// <c>"Widget"</c>. Picking one and applying it everywhere would silently change a test's meaning —
+/// the exact failure the fixture is supposed to prevent — so the factories default to the model's own
+/// default and take an explicit seed.
+/// </para>
+/// </summary>
+public class CollectionItemFixtureTests : MudBlazorTestBase
+{
+    [Fact]
+    public void TextItemForm_Should_Render_The_Text_Path()
+    {
+        // Arrange & Act
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewOrder(),
+            CollectionItemFixture.TextItemForm());
+
+        // Assert - the string path reaches MudTextField, labelled as the suites expect
+        component.FindComponent<MudTextField<string>>().Instance.Label.ShouldBe("Product");
+    }
+
+    [Fact]
+    public void NumericItemForm_Should_Render_The_Numeric_Path()
+    {
+        // Arrange & Act
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewBasket(),
+            CollectionItemFixture.NumericItemForm());
+
+        // Assert
+        component.FindComponent<MudNumericField<int>>().Instance.Label.ShouldBe("Quantity");
+    }
+
+    [Fact]
+    public void DateItemForm_Should_Render_The_Date_Path()
+    {
+        // Arrange & Act
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewAppointment(),
+            CollectionItemFixture.DateItemForm());
+
+        // Assert
+        component.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("When");
+    }
+
+    [Fact]
+    public void BooleanItemForm_Should_Render_The_Boolean_Path()
+    {
+        // Arrange & Act - the path that bypasses AddCommonFieldAttributes
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewBasket(),
+            CollectionItemFixture.BooleanItemForm());
+
+        // Assert
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
+    }
+
+    [Fact]
+    public void Each_Item_Form_Should_Apply_The_Callers_Configuration()
+    {
+        // Arrange & Act - the callback is how a suite declares the behaviour it is testing, so it
+        // must reach the field on every path that takes one. A fixture that dropped it would leave
+        // the suites asserting against an unconfigured field.
+        var text = this.RenderItemForm(
+            CollectionItemFixture.NewOrder(),
+            CollectionItemFixture.TextItemForm(field => field.WithLabel("Renamed")));
+        var numeric = this.RenderItemForm(
+            CollectionItemFixture.NewBasket(),
+            CollectionItemFixture.NumericItemForm(field => field.WithLabel("Renamed")));
+        var date = this.RenderItemForm(
+            CollectionItemFixture.NewAppointment(),
+            CollectionItemFixture.DateItemForm(field => field.WithLabel("Renamed")));
+        var boolean = this.RenderItemForm(
+            CollectionItemFixture.NewBasket(),
+            CollectionItemFixture.BooleanItemForm(field => field.WithLabel("Renamed")));
+
+        // Assert - the callback runs after the default label, so it can override it
+        text.FindComponent<MudTextField<string>>().Instance.Label.ShouldBe("Renamed");
+        numeric.FindComponent<MudNumericField<int>>().Instance.Label.ShouldBe("Renamed");
+        date.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("Renamed");
+        boolean.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Renamed");
+    }
+
+    [Fact]
+    public void NewOrder_Should_Leave_The_Product_Name_Blank_By_Default()
+    {
+        // Arrange & Act - CollectionRequiredTests depends on this: a seeded value would satisfy the
+        // Required validator and quietly turn its validation tests into assertions about nothing.
+        var model = CollectionItemFixture.NewOrder();
+
+        // Assert
+        model.Items.ShouldHaveSingleItem();
+        model.Items[0].ProductName.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void NewOrder_Should_Honour_A_Seeded_Product_Name()
+    {
+        // Arrange & Act - CollectionAdornmentTests renders against a populated field
+        var model = CollectionItemFixture.NewOrder("Widget");
+
+        // Assert - in the model, and in what the field actually renders
+        model.Items[0].ProductName.ShouldBe("Widget");
+
+        var component = this.RenderItemForm(model, CollectionItemFixture.TextItemForm());
+        component.FindComponent<MudTextField<string>>().Instance.Value.ShouldBe("Widget");
+    }
+
+    [Fact]
+    public void NewBasket_Should_Default_Blank_And_Honour_Its_Seeds()
+    {
+        // Arrange & Act
+        var blank = CollectionItemFixture.NewBasket();
+        var seeded = CollectionItemFixture.NewBasket(quantity: 7, isGift: true);
+
+        // Assert
+        blank.Lines.ShouldHaveSingleItem();
+        blank.Lines[0].Quantity.ShouldBe(0);
+        blank.Lines[0].IsGift.ShouldBeFalse();
+        seeded.Lines[0].Quantity.ShouldBe(7);
+        seeded.Lines[0].IsGift.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NewAppointment_Should_Default_Blank_And_Honour_Its_Seed()
+    {
+        // Arrange & Act
+        var blank = CollectionItemFixture.NewAppointment();
+        var seeded = CollectionItemFixture.NewAppointment(new DateTime(2030, 12, 31));
+
+        // Assert
+        blank.Slots.ShouldHaveSingleItem();
+        blank.Slots[0].When.ShouldBe(default);
+        seeded.Slots[0].When.ShouldBe(new DateTime(2030, 12, 31));
+    }
+}

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionRequiredTests.cs
@@ -1,3 +1,5 @@
+using static FormCraft.ForMudBlazor.UnitTests.Fields.CollectionItemFixture;
+
 namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 
 /// <summary>
@@ -22,6 +24,13 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// The attribute is now resolved from an explicit <c>"Required"</c> attribute instead, so a field
 /// that opts back in with <c>.WithAttribute("Required", true)</c> still gets it.
 /// </para>
+/// <para>
+/// Models and item-form builders come from <see cref="CollectionItemFixture"/> (#205). Note that
+/// every text-path test below renders <c>NewOrder()</c> — the <b>blank</b> seed — deliberately: a
+/// populated <c>ProductName</c> would satisfy the validator and turn the two validation tests into
+/// assertions about nothing. The seed is passed at each call site rather than defaulted by a local
+/// helper so that stays visible.
+/// </para>
 /// </summary>
 public class CollectionRequiredTests : MudBlazorTestBase
 {
@@ -29,7 +38,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
     public void Required_ItemField_Should_Not_Render_The_Html5_Required_Attribute()
     {
         // Arrange & Act - the same .Required(...) call a standalone field would use
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field
             .Required("Product name is required")));
 
         // Assert - validation still runs (see the EditContext tests); the attribute does not
@@ -41,7 +50,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
     {
         // Arrange & Act - the escape hatch: dropping the IsRequired forward must not also drop the
         // ability to ask for MudBlazor's asterisk deliberately.
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field
             .WithAttribute("Required", true)));
 
         // Assert - the property, and that it actually reaches the DOM. Asserting only the property
@@ -57,7 +66,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
     public void ItemField_Without_Any_Required_Configuration_Should_Not_Render_It()
     {
         // Arrange & Act - unchanged from before #190
-        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+        var component = this.RenderItemForm(NewOrder(), TextItemForm());
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeFalse();
@@ -66,22 +75,10 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void Required_NumericItemField_Should_Not_Render_The_Html5_Required_Attribute()
     {
-        // Arrange - AddCommonFieldAttributes feeds three renderers (text, numeric and date), so the
-        // numeric one must lose the forward too rather than being fixed only where it was measured.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.Quantity, field => field
-                        .WithLabel("Quantity")
-                        .Required("Quantity is required"))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        // Arrange & Act - AddCommonFieldAttributes feeds three renderers (text, numeric and date), so
+        // the numeric one must lose the forward too rather than being fixed only where it was measured.
+        var component = this.RenderItemForm(NewBasket(), NumericItemForm(field => field
+            .Required("Quantity is required")));
 
         // Assert
         component.FindComponent<MudNumericField<int>>().Instance.Required.ShouldBeFalse();
@@ -93,7 +90,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
         // Arrange & Act - the component property is the cause; this is the effect the convention
         // actually names ("Required() adds validation but NOT the HTML5 required attribute").
         // Measured before the fix: the input carried required="" and aria-required="true".
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field
             .Required("Product name is required")));
 
         // Assert - anchored to the field under test, not to whichever input happens to be first
@@ -109,7 +106,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
         // only when Required is true. A markup search for "*" cannot see it, so the CLASS is the
         // measurable proxy. This is the user-visible half of the change: a required item field now
         // looks exactly like a required ordinary field, which never carried one.
-        var component = RenderOrderForm(BuildConfiguration(field => field
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field
             .Required("Product name is required")));
 
         // Assert
@@ -119,23 +116,11 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void DateItemField_Should_Not_Render_The_Html5_Required_Attribute()
     {
-        // Arrange - MudDatePicker is the THIRD renderer fed by AddCommonFieldAttributes, and it
+        // Arrange & Act - MudDatePicker is the THIRD renderer fed by AddCommonFieldAttributes, and it
         // derives from MudFormComponent too, so it took the same forward. Its sibling suite covers
         // the date path for adornments (#184); this keeps that parity for Required.
-        var config = FormBuilder<AppointmentModel>
-            .Create()
-            .AddCollectionField(x => x.Slots, collection => collection
-                .WithLabel("Slots")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field
-                        .WithLabel("When")
-                        .Required("When is required"))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
-            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewAppointment(), DateItemForm(field => field
+            .Required("When is required")));
 
         // Assert
         component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeFalse();
@@ -145,22 +130,10 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void DateItemField_Should_Honour_An_Explicit_Required_Attribute()
     {
-        // Arrange - the opt-in has to reach the date path too, or the escape hatch is text/numeric
+        // Arrange & Act - the opt-in has to reach the date path too, or the escape hatch is text/numeric
         // only while the README promises it for item fields generally.
-        var config = FormBuilder<AppointmentModel>
-            .Create()
-            .AddCollectionField(x => x.Slots, collection => collection
-                .WithLabel("Slots")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field
-                        .WithLabel("When")
-                        .WithAttribute("Required", true))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
-            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewAppointment(), DateItemForm(field => field
+            .WithAttribute("Required", true)));
 
         // Assert
         component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeTrue();
@@ -169,24 +142,12 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void BooleanItemField_With_An_Explicit_Required_Attribute_Should_Be_Inert()
     {
-        // Arrange - RenderBooleanField sets its own attributes and never calls
+        // Arrange & Act - RenderBooleanField sets its own attributes and never calls
         // AddCommonFieldAttributes, so the opt-in is silently inert here. Pinned rather than fixed,
         // exactly as CollectionAdornmentTests pins the same inertness for adornments (#184): the
         // point is that configuring it is harmless, not that it works.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.IsGift, field => field
-                        .WithLabel("Gift")
-                        .WithAttribute("Required", true))))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewBasket(), BooleanItemForm(field => field
+            .WithAttribute("Required", true)));
 
         // Assert - renders, does not throw, and takes no notice of the attribute
         component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
@@ -196,13 +157,14 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public async Task Blank_Required_ItemField_Should_Still_Fail_Validation_With_The_Configured_Message()
     {
-        // Arrange - dropping the attribute must not drop the validation it never drove.
-        var model = new OrderModel { Items = { new OrderItem() } };
+        // Arrange - dropping the attribute must not drop the validation it never drove. Rendered
+        // directly rather than through RenderItemForm because this test needs the EditContext hook.
+        var model = NewOrder();
         EditContext? editContext = null;
 
         var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters
             .Add(p => p.Model, model)
-            .Add(p => p.Configuration, BuildConfiguration(field => field
+            .Add(p => p.Configuration, TextItemForm(field => field
                 .Required("Product name is required")))
             .Add(p => p.OnEditContextCreated, ctx => editContext = ctx));
 
@@ -227,12 +189,8 @@ public class CollectionRequiredTests : MudBlazorTestBase
         // attribute was the only way it could ever be armed - so this pins the COUNT at one rather
         // than merely asserting the right text is present, and would catch the duplicate if that
         // wiring ever changed.
-        var model = new OrderModel { Items = { new OrderItem() } };
-
-        var component = Render<FormCraftComponent<OrderModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, BuildConfiguration(field => field
-                .Required("Product name is required"))));
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field
+            .Required("Product name is required")));
 
         // Act
         await component.InvokeAsync(() => component.Instance.ValidateAsync());
@@ -259,7 +217,7 @@ public class CollectionRequiredTests : MudBlazorTestBase
         // Arrange & Act - #204. The same opt-in as the raw string above, through the typed method.
         // Asserted on all three renderers fed by AddCommonFieldAttributes, because the escape hatch
         // being text-only would be the exact divergence class this library keeps re-filing.
-        var component = RenderOrderForm(BuildConfiguration(field => field.WithNativeRequired()));
+        var component = this.RenderItemForm(NewOrder(), TextItemForm(field => field.WithNativeRequired()));
 
         // Assert - the component property, and the class MudBlazor's asterisk hangs off.
         component.FindComponent<MudTextField<string>>().Instance.Required.ShouldBeTrue();
@@ -269,22 +227,9 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void NumericItemField_With_WithNativeRequired_Should_Render_The_Decoration()
     {
-        // Arrange - the second renderer. WithNativeRequired is declared on the general TValue
+        // Arrange & Act - the second renderer. WithNativeRequired is declared on the general TValue
         // overload rather than string-only precisely so this compiles.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.Quantity, field => field
-                        .WithLabel("Quantity")
-                        .WithNativeRequired())))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewBasket(), NumericItemForm(field => field.WithNativeRequired()));
 
         // Assert
         component.FindComponent<MudNumericField<int>>().Instance.Required.ShouldBeTrue();
@@ -293,21 +238,8 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void DateItemField_With_WithNativeRequired_Should_Render_The_Decoration()
     {
-        // Arrange - the third renderer, MudDatePicker.
-        var config = FormBuilder<AppointmentModel>
-            .Create()
-            .AddCollectionField(x => x.Slots, collection => collection
-                .WithLabel("Slots")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field
-                        .WithLabel("When")
-                        .WithNativeRequired())))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<AppointmentModel>>(parameters => parameters
-            .Add(p => p.Model, new AppointmentModel { Slots = { new AppointmentSlot() } })
-            .Add(p => p.Configuration, config));
+        // Arrange & Act - the third renderer, MudDatePicker.
+        var component = this.RenderItemForm(NewAppointment(), DateItemForm(field => field.WithNativeRequired()));
 
         // Assert
         component.FindComponent<MudDatePicker>().Instance.Required.ShouldBeTrue();
@@ -316,85 +248,14 @@ public class CollectionRequiredTests : MudBlazorTestBase
     [Fact]
     public void BooleanItemField_With_WithNativeRequired_Should_Be_Inert()
     {
-        // Arrange - RenderBooleanField sets its own attributes and never calls
+        // Arrange & Act - RenderBooleanField sets its own attributes and never calls
         // AddCommonFieldAttributes, so the opt-in is inert here through the typed method exactly as
         // through the raw string. Pinned rather than fixed, mirroring the adornment inertness test
         // (#184): the claim is that configuring it is harmless, not that it works.
-        var config = FormBuilder<BasketModel>
-            .Create()
-            .AddCollectionField(x => x.Lines, collection => collection
-                .WithLabel("Lines")
-                .WithItemForm(item => item
-                    .AddField(x => x.IsGift, field => field
-                        .WithLabel("Gift")
-                        .WithNativeRequired())))
-            .Build();
-
-        // Act
-        var component = Render<FormCraftComponent<BasketModel>>(parameters => parameters
-            .Add(p => p.Model, new BasketModel { Lines = { new BasketLine() } })
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewBasket(), BooleanItemForm(field => field.WithNativeRequired()));
 
         // Assert
         component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
         component.FindAll(".mud-input-required").ShouldBeEmpty();
-    }
-
-    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
-        IFormConfiguration<OrderModel> config)
-    {
-        var model = new OrderModel { Items = { new OrderItem() } };
-
-        return Render<FormCraftComponent<OrderModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, config));
-    }
-
-    private static IFormConfiguration<OrderModel> BuildConfiguration(
-        Action<FieldBuilder<OrderItem, string>> configureItemField)
-    {
-        return FormBuilder<OrderModel>
-            .Create()
-            .AddCollectionField(x => x.Items, collection => collection
-                .WithLabel("Items")
-                .WithItemForm(item => item
-                    .AddField(x => x.ProductName, field =>
-                    {
-                        field.WithLabel("Product");
-                        configureItemField(field);
-                    })))
-            .Build();
-    }
-
-    private class OrderModel
-    {
-        public List<OrderItem> Items { get; set; } = new();
-    }
-
-    private class OrderItem
-    {
-        public string ProductName { get; set; } = string.Empty;
-    }
-
-    private class BasketModel
-    {
-        public List<BasketLine> Lines { get; set; } = new();
-    }
-
-    private class BasketLine
-    {
-        public int Quantity { get; set; }
-
-        public bool IsGift { get; set; }
-    }
-
-    private class AppointmentModel
-    {
-        public List<AppointmentSlot> Slots { get; set; } = new();
-    }
-
-    private class AppointmentSlot
-    {
-        public DateTime When { get; set; }
     }
 }


### PR DESCRIPTION
Implements #205.

Closes #205.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

Test-only refactor: no production file is modified. The `CollectionRequiredTests` / `CollectionAdornmentTests`
suites stop carrying private copies of the same four model pairs and two helpers, and share one fixture instead.

### Plan
- [x] Task 1: Add the shared fixture
- [x] Task 2: Migrate `CollectionRequiredTests`
- [x] Task 3: Migrate `CollectionAdornmentTests` and confirm nothing was lost




## Verification

- Baseline before any change: `FormCraft.ForMudBlazor.UnitTests` = **354** tests.
- After: **363** = 354 + 9 fixture self-tests. Per-suite counts unchanged —
  `CollectionRequiredTests` **15**, `CollectionAdornmentTests` **10** (enumerated with
  `--list-tests --filter-class`, not inferred from the total).
- **Both** migrated suites mutation-tested: reintroducing the original defect
  (`Required` driven from `field.IsRequired` for #190; `GetItemFieldAdornment` ignoring the
  configured value for #184) turns **exactly the same set of tests red as before the migration** —
  13 and 17 respectively, diffed and byte-identical. The tests still bite.
- CI gate `./build.sh Test`: Restore/Compile/Test all succeeded, **0 warnings, 0 errors**.
- No production file is touched — the branch diff is 4 files, all under
  `FormCraft.ForMudBlazor.UnitTests/`.

## Follow-ups

- **11 more test files still declare their own copies of these models** and can adopt the fixture:
  `CollectionAdornmentClickTests`, `CollectionCultureTests`, `CollectionShrinkLabelTests`,
  `NumericAdornmentClickTests`, `NumericFormatTests`, `ShrinkLabelDiagnosticsTests`,
  `ShrinkLabelKeyCollisionTests`, `CollectionFieldEditContextTests`, `NoValidateTests`,
  `RenderPipelineParityTests`, `SpecializedRendererDispatchTests`. #205's plan scoped only the two
  suites it named, so these are deliberately left alone rather than folded in here.
  (`CollectionCultureTests` needs a `decimal` line, which the fixture does not yet model.)
