### PR TITLE
ci: emit test reports natively under Microsoft.Testing.Platform (#231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,19 @@ jobs:
       # `if-no-files-found: ignore` covers the one legitimate miss: a run that fails in Compile,
       # before any test executes and therefore before `test-results/` exists.
       #
-      # Reading it: the log is UTF-16LE and carries ANSI colour escapes, so a plain `grep '^failed '`
-      # matches nothing and looks exactly like an empty artifact. Use:
+      # Reading it (measured against a deliberately reddened run, #231). The log is UTF-16LE and
+      # carries ANSI colour escapes, so a plain `grep '^failed '` matches nothing and looks exactly
+      # like an empty artifact. And it must be ONE iconv PER FILE: the artifact holds one log per
+      # test assembly, and concatenating them leaves the second file's BOM inline immediately before
+      # its first line — which is the line naming the first failure — so `^failed ` cannot match it
+      # either. Both traps fail the same silent way, which is why the loop is spelled out:
       #   gh run download <run-id> -n test-results -D /tmp/tr
-      #   iconv -f UTF-16LE -t UTF-8 /tmp/tr/*.log | sed $'s/\\x1b\\[[0-9;]*m//g' \
-      #     | grep -A5 '^failed '
+      #   for f in /tmp/tr/*.log; do
+      #     iconv -f UTF-16LE -t UTF-8 "$f" | sed $'s/\\x1b\\[[0-9;]*m//g' | grep -A5 '^failed '
+      #   done
+      # That prints the failing test names with their Shouldly detail and stack traces. The same
+      # run's *.trx carries each failure as outcome="Failed" under its fully-qualified testName, and
+      # the *.html is the same report rendered for a browser.
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,32 @@ jobs:
       # `if-no-files-found: ignore` covers the one legitimate miss: a run that fails in Compile,
       # before any test executes and therefore before `test-results/` exists.
       #
-      # Reading it (measured against a deliberately reddened run, #231). The log is UTF-16LE and
-      # carries ANSI colour escapes, so a plain `grep '^failed '` matches nothing and looks exactly
-      # like an empty artifact. And it must be ONE iconv PER FILE: the artifact holds one log per
-      # test assembly, and concatenating them leaves the second file's BOM inline immediately before
-      # its first line — which is the line naming the first failure — so `^failed ` cannot match it
-      # either. Both traps fail the same silent way, which is why the loop is spelled out:
+      # Reading it. Every clause below was measured against a deliberately reddened run and against a
+      # real downloaded artifact (#231) — the naive form of this command silently prints nothing,
+      # which is indistinguishable from "the suite passed".
+      #
+      #  - The log is UTF-16LE, one file per test assembly, each starting with a BOM.
+      #  - It carries ANSI colour escapes ON CI and not locally: MTP colourises the status word, so a
+      #    failure line arrives as ESC[31mfailed ESC[m<test>. Measured on a downloaded artifact,
+      #    which is the only copy this recipe is ever pointed at. Hence the escape strip.
+      #  - The BOM has to be stripped explicitly, because grep implementations disagree about it:
+      #    BSD grep drops one at the START of the stream, GNU grep drops none. A failing assembly's
+      #    log can open with its `failed <test>` line, so an unstripped BOM makes `^failed ` miss the
+      #    first failure — on Linux always, and on macOS as soon as more than one file is piped in.
+      #  - `-A30`, not `-A5`: Shouldly's difference table alone runs past twenty lines, so a smaller
+      #    window cuts off the `at ...` stack frames — the part naming the offending line.
+      #
       #   gh run download <run-id> -n test-results -D /tmp/tr
       #   for f in /tmp/tr/*.log; do
-      #     iconv -f UTF-16LE -t UTF-8 "$f" | sed $'s/\\x1b\\[[0-9;]*m//g' | grep -A5 '^failed '
+      #     echo "== $f"
+      #     iconv -f UTF-16LE -t UTF-8 "$f" \
+      #       | sed $'s/\\xef\\xbb\\xbf//g; s/\\x1b\\[[0-9;]*m//g' \
+      #       | grep -A30 '^failed '
       #   done
-      # That prints the failing test names with their Shouldly detail and stack traces. The same
-      # run's *.trx carries each failure as outcome="Failed" under its fully-qualified testName, and
-      # the *.html is the same report rendered for a browser.
+      #
+      # That prints each failing test with its Shouldly detail and stack trace. The same run's *.trx
+      # carries each failure as outcome="Failed" under its fully-qualified testName, and the *.html
+      # is the same report rendered for a browser.
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,34 +18,36 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
       # Microsoft.Testing.Platform prints only a summary line to stdout and writes every per-assertion
-      # detail — failing test names, Shouldly messages, stack traces — to
-      # <project>/bin/<cfg>/<tfm>/TestResults/*.log. Without this upload a red run here is
-      # undiagnosable remotely: `gh run view --log` yields a count and a path to a file that died with
-      # the runner. That cost was paid for real during #200. (#225)
+      # detail — failing test names, Shouldly messages, stack traces — to a per-assembly `.log`.
+      # Without this upload a red run here is undiagnosable remotely: `gh run view --log` yields a
+      # count and a path to a file that died with the runner. That cost was paid for real during
+      # #200. (#225)
       #
       # `if: always()` is the entire point — the failure path is the only one worth preserving, and it
       # is exactly the path a bare step skips.
       #
-      # ⚠️ The path deliberately does NOT rely on Nuke's `test-results/` directory. Build.cs asks for it
-      # via DotNetTest's --results-directory/--logger, but `dotnet test` passes those as the VSTest
-      # properties VSTestResultsDirectory/VSTestLogger, which Microsoft.Testing.Platform ignores
-      # outright (warning MTP0001). So `test-results/` is never created, and an upload pointed only at
-      # it produces an empty artifact that merely looks like a fix. Measured, not assumed:
-      # continuous.yml has carried such a step for some time and no run of it has ever produced a
-      # test-results artifact. `test-results` is still listed so the artifact gains the trx/html the
-      # day the build actually emits them.
+      # One path, and as of #231 it is a real one. Build.cs used to ask for `test-results/` through
+      # DotNetTest's VSTest surface, which `dotnet test` forwards as VSTestResultsDirectory /
+      # VSTestLogger and Microsoft.Testing.Platform ignores outright (warning MTP0001) — so the
+      # directory was never created, no trx or html was ever written, and this step leaned on a
+      # `**/TestResults/*.log` glob pointing into the projects' bin directories instead. Build.cs now
+      # passes MTP's own `--results-directory`, which puts the trx and html reports AND that
+      # per-assembly log under `test-results/`. The old glob is deliberately gone rather than kept as
+      # a fallback: every workflow that tests reaches Nuke's Test target, so it could now only ever
+      # match nothing — the declared-but-inert shape #231 was filed about.
+      #
+      # `if-no-files-found: ignore` covers the one legitimate miss: a run that fails in Compile,
+      # before any test executes and therefore before `test-results/` exists.
       #
       # Reading it: the log is UTF-16LE and carries ANSI colour escapes, so a plain `grep '^failed '`
       # matches nothing and looks exactly like an empty artifact. Use:
       #   gh run download <run-id> -n test-results -D /tmp/tr
-      #   iconv -f UTF-16LE -t UTF-8 /tmp/tr/**/TestResults/*.log | sed $'s/\\x1b\\[[0-9;]*m//g' \
+      #   iconv -f UTF-16LE -t UTF-8 /tmp/tr/*.log | sed $'s/\\x1b\\[[0-9;]*m//g' \
       #     | grep -A5 '^failed '
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: |
-            **/TestResults/*.log
-            test-results
+          path: test-results
           if-no-files-found: ignore

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -56,19 +56,18 @@ jobs:
         run: ./build.cmd Pack
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # See ci.yml's copy of this step for the full rationale (#225). Two things matter here:
+      # See ci.yml's copy of this step for the full rationale (#225, #231). Two things matter here:
       # `if: always()` — without it a failed `Run: Pack` skips this step and the only record of which
-      # tests failed dies with the runner — and the `**/TestResults/*.log` path, because Nuke's
-      # `test-results/` is never created: MTP ignores the VSTest results-directory/logger properties
-      # Build.cs sets (warning MTP0001), which is why this step has never yet produced an artifact.
+      # tests failed dies with the runner — and `test-results`, which since #231 is a directory the
+      # build genuinely fills. It did not used to be: MTP ignored the VSTest results-directory/logger
+      # properties Build.cs set (warning MTP0001), which is why this step, the oldest of the three,
+      # had never once produced a non-empty artifact.
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: |
-            **/TestResults/*.log
-            test-results
+          path: test-results
           if-no-files-found: ignore
       - name: 'Publish: artifacts'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -178,11 +178,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # See ci.yml's copy of this step for the full rationale (#225, #231). This is the copy #225
-      # deliberately left alone — its Global Constraints forbade touching this file — so it spent two
-      # releases uploading a `test-results` directory that Build.cs never created, running on
-      # `if: always()` and faithfully producing nothing. #231 fixed the emitting end rather than the
-      # path, so this step became correct without moving; `if-no-files-found: ignore` is what it was
-      # still missing, and it matters most here, where the publish job can fail long before Test.
+      # deliberately left alone — its Global Constraints forbade touching this file — so it was left
+      # uploading a `test-results` directory that Build.cs never created: running on `if: always()`
+      # and faithfully producing nothing. #231 fixed the emitting end rather than the path, so this
+      # step became correct without moving; `if-no-files-found: ignore` is what it was still missing,
+      # and it matters most here, where the publish job can fail long before Test.
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -177,12 +177,19 @@ jobs:
           NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # See ci.yml's copy of this step for the full rationale (#225, #231). This is the copy #225
+      # deliberately left alone — its Global Constraints forbade touching this file — so it spent two
+      # releases uploading a `test-results` directory that Build.cs never created, running on
+      # `if: always()` and faithfully producing nothing. #231 fixed the emitting end rather than the
+      # path, so this step became correct without moving; `if-no-files-found: ignore` is what it was
+      # still missing, and it matters most here, where the publish job can fail long before Test.
       - name: 'Publish: test-results'
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: test-results
+          if-no-files-found: ignore
 
       # Symbol packages included: Pack produces .snupkg alongside .nupkg, and the removed
       # CreateGitHubRelease target attached both. `*.nupkg` does not match `*.snupkg`.

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -54,8 +54,62 @@ public class TestReportingTests
         return dir.FullName;
     }
 
+    /// <summary>
+    /// The one step name all three workflows use for this upload. Asserted as a literal because it
+    /// is also how a human finds the step in a run's log.
+    /// </summary>
+    private const string UploadStepName = "Publish: test-results";
+
     private static string ReadBuildScript() =>
         File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
+
+    private static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
+
+    private static string ReadWorkflow(string fileName) =>
+        File.ReadAllText(Path.Combine(WorkflowsDirectory, fileName));
+
+    /// <summary>
+    /// Every workflow that reaches Nuke's <c>Test</c> target, discovered rather than listed: `Pack`
+    /// and `Continuous` both `DependsOn(Test)`, so all three run the suite and all three therefore
+    /// owe the artifact. Deriving the set means a fourth workflow added later is held to the same
+    /// contract on the day it lands, which is the failure mode this issue is about —
+    /// <c>release-please.yml</c> was left behind by #225 and nobody noticed for two releases.
+    /// </summary>
+    private static List<string> WorkflowsThatRunTests() =>
+        Directory
+            .EnumerateFiles(WorkflowsDirectory, "*.*")
+            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+            .Where(f => Regex.IsMatch(
+                WithoutComments(File.ReadAllText(f), "#"),
+                @"run:\s*\./build\.cmd\s+(Test|Pack|Continuous)\b"))
+            .Select(Path.GetFileName)
+            .OfType<string>()
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
+    /// satisfied by the same text sitting on some other step. Runs from the <c>- name:</c> line to
+    /// the start of the next list item, which covers the step's <c>if:</c>, <c>uses:</c> and
+    /// <c>with:</c>.
+    /// </summary>
+    private static string StepNamed(string workflowFile, string stepName)
+    {
+        var lines = ReadWorkflow(workflowFile).Split('\n');
+        var start = Array.FindIndex(
+            lines,
+            l => l.TrimStart().StartsWith($"- name: '{stepName}'", StringComparison.Ordinal));
+        start.ShouldBeGreaterThanOrEqualTo(0, $"{workflowFile} no longer has a step named '{stepName}'");
+
+        var end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith("- ", StringComparison.Ordinal));
+        if (end < 0)
+        {
+            end = lines.Length;
+        }
+
+        return string.Join('\n', lines[start..end]);
+    }
 
     /// <summary>
     /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
@@ -119,5 +173,79 @@ public class TestReportingTests
             .ToList();
 
         unbacked.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Every_Workflow_That_Runs_Tests_Should_Upload_The_TestResults_Artifact()
+    {
+        var workflows = WorkflowsThatRunTests();
+
+        workflows.ShouldNotBeEmpty(
+            "no workflow invokes ./build.cmd Test|Pack|Continuous — every assertion below would pass vacuously");
+
+        var missing = workflows
+            .Where(w => !ReadWorkflow(w).Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal))
+            .ToList();
+
+        missing.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Every_TestResults_Upload_Should_Run_On_Failure()
+    {
+        // `if: always()` is the entire point of the artifact (#225): the failure path is the only
+        // one worth preserving, and it is exactly the path a bare step skips. Microsoft.Testing.
+        // Platform prints only a summary line to stdout, so without this a red CI run leaves no
+        // record of *which* assertion failed — a cost that was paid for real during #200.
+        var offenders = WorkflowsThatRunTests()
+            .Where(w => !StepNamed(w, UploadStepName).Contains("if: always()", StringComparison.Ordinal))
+            .ToList();
+
+        offenders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Every_TestResults_Upload_Should_Point_At_The_Directory_The_Build_Fills()
+    {
+        // Scoped to a path *line* rather than a substring search: `name: test-results` names the
+        // artifact and would otherwise satisfy an assertion about where it is read from.
+        var offenders = WorkflowsThatRunTests()
+            .Where(w => !StepNamed(w, UploadStepName)
+                .Split('\n')
+                .Select(line => line.Trim())
+                .Any(line => line is "path: test-results" or "test-results"))
+            .ToList();
+
+        offenders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void No_TestResults_Upload_Should_Point_At_A_Path_The_Build_No_Longer_Fills()
+    {
+        // Until #231 the MTP logs landed in <project>/bin/<cfg>/<tfm>/TestResults/, and ci.yml and
+        // continuous.yml globbed for them there because Nuke's test-results/ was never created.
+        // --results-directory moved them, so that glob now matches nothing on every run — the same
+        // declared-and-inert shape this issue exists to remove, just one file over. Every path in
+        // the build reaches the Test target, so there is no run in which it could match again.
+        var offenders = WorkflowsThatRunTests()
+            .Where(w => StepNamed(w, UploadStepName).Contains("**/TestResults/", StringComparison.Ordinal))
+            .ToList();
+
+        offenders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Every_TestResults_Upload_Should_Tolerate_A_Missing_Path()
+    {
+        // These steps run under `if: always()`, which includes runs that failed in Compile — before
+        // any test executed and therefore before test-results/ existed. Without this, upload-artifact
+        // warns on a condition that is entirely expected, and a warning nobody can act on is how a
+        // real one gets missed.
+        var offenders = WorkflowsThatRunTests()
+            .Where(w => !StepNamed(w, UploadStepName)
+                .Contains("if-no-files-found: ignore", StringComparison.Ordinal))
+            .ToList();
+
+        offenders.ShouldBeEmpty();
     }
 }

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -4,22 +4,48 @@ namespace FormCraft.UnitTests.Ci;
 
 /// <summary>
 /// Guards the build's test-reporting contract (#231). Every claim here was inert before that issue:
-/// <c>Build.cs</c> asked for a results directory and two loggers through <see cref="DotNetTest" />'s
-/// VSTest surface, <c>dotnet test</c> forwarded them as the MSBuild properties
+/// <c>Build.cs</c> asked for a results directory and two loggers through <c>DotNetTest</c>'s VSTest
+/// surface, <c>dotnet test</c> forwarded them as the MSBuild properties
 /// <c>VSTestResultsDirectory</c>/<c>VSTestLogger</c>, and Microsoft.Testing.Platform ignored both
 /// outright (warning <c>MTP0001</c>). So <c>test-results/</c> was never created, no trx or html
 /// report was ever produced, and the <c>Test</c> target's <c>.Produces(...)</c> lines described files
 /// that did not exist.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Nothing about that failure was visible: it broke no build and reddened no run — the wiring simply
 /// *read* correct and produced nothing, which is why it survived several CI reworks (#200, #225,
 /// #230). A regression here would be equally quiet, so it is asserted on the build script's text
 /// rather than left to be noticed.
+/// </para>
+/// <para>
+/// ⚠️ Known limitation: the workflow assertions are file-scoped, not job-scoped. A workflow that ran
+/// the build in one job and uploaded the artifact from another would satisfy them while uploading
+/// nothing, because the second job gets a fresh workspace. Catching that needs a real YAML parse,
+/// which this project has no dependency for; the shape is noted in the PR that added these tests.
+/// </para>
 /// </remarks>
 public class TestReportingTests
 {
     private static readonly string RepoRoot = LocateRepoRoot();
+
+    /// <summary>Every workflow file, read once — these tests are pure text assertions over them.</summary>
+    private static readonly Dictionary<string, string> WorkflowText = ReadAllWorkflows();
+
+    private static readonly List<string> TestRunningWorkflows = DiscoverWorkflowsThatRunTests();
+
+    /// <summary>
+    /// The one step name all three workflows use for this upload. Asserted as a literal because it
+    /// is also how a human finds the step in a run's log.
+    /// </summary>
+    private const string UploadStepName = "Publish: test-results";
+
+    /// <summary>
+    /// Every Nuke target that reaches <c>Test</c>, directly or through <c>DependsOn</c>: <c>Pack</c>,
+    /// <c>Publish</c>, <c>PublishIfNeeded</c>, <c>Continuous</c> and <c>Release</c> all run the suite.
+    /// A workflow invoking any of them owes the artifact.
+    /// </summary>
+    private const string TargetsThatRunTests = "Test|Pack|PublishIfNeeded|Publish|Continuous|Release";
 
     /// <summary>
     /// Maps an artifact extension to the runner option that has to be present for the build to
@@ -35,8 +61,10 @@ public class TestReportingTests
         ["junit"] = "--report-junit",
         ["nunit"] = "--report-nunit",
         ["ctrf"] = "--report-ctrf",
-        // Not a reporter: Microsoft.Testing.Platform writes one per-assembly diagnostic log — the
-        // artifact #225 exists to preserve — into whatever --results-directory names.
+        // Not a reporter. `dotnet test`'s MSBuild integration writes one per-assembly `.log` — the
+        // artifact #225 exists to preserve — into whatever --results-directory names, which is what
+        // moved them out of <project>/bin/<cfg>/<tfm>/TestResults/. Distinct from MTP's --diagnostic
+        // log, which is opt-in and named log_<timestamp>.diag.
         ["log"] = "--results-directory",
     };
 
@@ -54,50 +82,74 @@ public class TestReportingTests
         return dir.FullName;
     }
 
-    /// <summary>
-    /// The one step name all three workflows use for this upload. Asserted as a literal because it
-    /// is also how a human finds the step in a run's log.
-    /// </summary>
-    private const string UploadStepName = "Publish: test-results";
+    private static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
+
+    private static Dictionary<string, string> ReadAllWorkflows() =>
+        Directory
+            .EnumerateFiles(WorkflowsDirectory, "*.*")
+            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(f => Path.GetFileName(f), f => File.ReadAllText(f), StringComparer.Ordinal);
+
+    private static string ReadWorkflow(string fileName) => WorkflowText[fileName];
 
     private static string ReadBuildScript() =>
         File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
 
-    private static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
-
-    private static string ReadWorkflow(string fileName) =>
-        File.ReadAllText(Path.Combine(WorkflowsDirectory, fileName));
-
     /// <summary>
-    /// Every workflow that reaches Nuke's <c>Test</c> target, discovered rather than listed: `Pack`
-    /// and `Continuous` both `DependsOn(Test)`, so all three run the suite and all three therefore
-    /// owe the artifact. Deriving the set means a fourth workflow added later is held to the same
-    /// contract on the day it lands, which is the failure mode this issue is about —
-    /// <c>release-please.yml</c> was left behind by #225 and nobody noticed for two releases.
+    /// Every workflow that reaches Nuke's <c>Test</c> target, discovered rather than listed, so a
+    /// fourth workflow added later is held to the same contract on the day it lands — which is the
+    /// failure mode this issue is about: <c>release-please.yml</c> was left behind by #225 and
+    /// nobody noticed.
     /// </summary>
-    private static List<string> WorkflowsThatRunTests()
-    {
-        var workflows = Directory
-            .EnumerateFiles(WorkflowsDirectory, "*.*")
-            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
-                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
-            .Where(f => Regex.IsMatch(
-                WithoutComments(File.ReadAllText(f), "#"),
-                @"run:\s*\./build\.cmd\s+(Test|Pack|Continuous)\b"))
-            .Select(Path.GetFileName)
-            .OfType<string>()
+    /// <remarks>
+    /// Matched on the wrapper invocation anywhere in the comment-stripped file rather than on a
+    /// <c>run:</c> prefix: a <c>run: |</c> block puts the command on a later line, and the repo
+    /// documents <c>./build.sh</c> as the macOS/Linux entry point alongside <c>./build.cmd</c>.
+    /// </remarks>
+    private static List<string> DiscoverWorkflowsThatRunTests() =>
+        WorkflowText
+            .Where(entry => Regex.IsMatch(
+                WithoutComments(entry.Value, "#"),
+                $@"\./build\.(cmd|sh|ps1)\s+({TargetsThatRunTests})\b"))
+            .Select(entry => entry.Key)
             .Order(StringComparer.Ordinal)
             .ToList();
 
+    private static List<string> WorkflowsThatRunTests()
+    {
         // The vacuity guard lives here rather than in one caller: every assertion below is of the
         // form "no workflow in this set offends", which an empty set satisfies trivially. A rename,
-        // a reformatted `run:` line or a switch to .yaml would empty it and turn the whole class
+        // a reformatted invocation or a switch to .yaml would empty it and turn the whole class
         // green while checking nothing.
-        workflows.ShouldNotBeEmpty(
-            "no workflow invokes ./build.cmd Test|Pack|Continuous — every assertion over this set would pass vacuously");
+        TestRunningWorkflows.ShouldNotBeEmpty(
+            $"no workflow invokes ./build.[cmd|sh|ps1] ({TargetsThatRunTests}) — every assertion over this set would pass vacuously");
 
-        return workflows;
+        return TestRunningWorkflows;
     }
+
+    /// <summary>
+    /// Whether the build script enables <paramref name="option" /> itself, as opposed to merely
+    /// mentioning a longer option that starts with it. Load-bearing: these option names are prefixes
+    /// of one another — <c>--report-xunit</c> of <c>--report-xunit-trx</c>, and
+    /// <c>--report-xunit-html</c> of <c>--report-xunit-html-filename</c>, which names a file without
+    /// enabling the reporter. A plain substring test would call an extension "backed" by an option
+    /// that emits nothing, which is precisely the defect class this file exists to catch.
+    /// </summary>
+    private static bool Enables(string build, string option) =>
+        Regex.IsMatch(build, Regex.Escape(option) + "(?![-A-Za-z])");
+
+    /// <summary>
+    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
+    /// prose — these files carry long explanatory blocks about this very wiring, and without this a
+    /// documentation-only edit would turn the suite red for a reason unrelated to the build. Only
+    /// leading-<paramref name="marker" /> lines are stripped: a trailing-comment strip would also
+    /// mangle the "https://" in a URL.
+    /// </summary>
+    private static string WithoutComments(string text, string marker) =>
+        string.Join(
+            '\n',
+            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
 
     /// <summary>
     /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
@@ -107,7 +159,7 @@ public class TestReportingTests
     /// </summary>
     private static string StepNamed(string workflowFile, string stepName)
     {
-        var lines = ReadWorkflow(workflowFile).Split('\n');
+        var lines = WithoutComments(ReadWorkflow(workflowFile), "#").Split('\n');
         var start = Array.FindIndex(
             lines,
             l => l.TrimStart().StartsWith($"- name: '{stepName}'", StringComparison.Ordinal));
@@ -122,17 +174,9 @@ public class TestReportingTests
         return string.Join('\n', lines[start..end]);
     }
 
-    /// <summary>
-    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
-    /// prose — <c>Build.cs</c> carries long explanatory blocks about this very wiring, and without
-    /// this a documentation-only edit would turn the suite red for a reason unrelated to the build.
-    /// Only leading-<paramref name="marker" /> lines are stripped: a trailing-comment strip would
-    /// also mangle the "https://" in a URL.
-    /// </summary>
-    private static string WithoutComments(string text, string marker) =>
-        string.Join(
-            '\n',
-            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
+    private static bool HasUploadStep(string workflowFile) =>
+        WithoutComments(ReadWorkflow(workflowFile), "#")
+            .Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal);
 
     [Fact]
     public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
@@ -151,13 +195,26 @@ public class TestReportingTests
     public void BuildScript_Should_Emit_Reports_Through_The_Testing_Platform()
     {
         // The native equivalents, which the runner does honour. --results-directory carries the
-        // most weight of the three: it is what puts the reports *and* MTP's per-assembly diagnostic
+        // most weight of the three: it is what puts the reports *and* the per-assembly diagnostic
         // log under test-results/, which is the single path all three workflows upload.
         var build = WithoutComments(ReadBuildScript(), "//");
 
-        build.ShouldContain("--results-directory");
-        build.ShouldContain("--report-xunit-trx");
-        build.ShouldContain("--report-xunit-html");
+        Enables(build, "--results-directory").ShouldBeTrue();
+        Enables(build, "--report-xunit-trx").ShouldBeTrue();
+        Enables(build, "--report-xunit-html").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildScript_Should_Fail_The_Build_When_No_Report_Is_Emitted()
+    {
+        // The options above are wiring; this is the only assertion that survives the wiring being
+        // honoured today and silently dropped tomorrow, exactly as VSTestResultsDirectory was. #231
+        // existed because nothing anywhere noticed months of empty output, so the build itself has
+        // to notice.
+        var build = WithoutComments(ReadBuildScript(), "//");
+
+        build.ShouldContain("Assert.NotEmpty");
+        build.ShouldMatch(@"GlobFiles\(""\*\.trx""\)");
     }
 
     [Fact]
@@ -179,8 +236,7 @@ public class TestReportingTests
 
         // Shouldly prints the collection on failure, so this names the offending extension.
         var unbacked = promised
-            .Where(ext => !ReporterForExtension.TryGetValue(ext, out var option)
-                          || !build.Contains(option, StringComparison.Ordinal))
+            .Where(ext => !ReporterForExtension.TryGetValue(ext, out var option) || !Enables(build, option))
             .ToList();
 
         unbacked.ShouldBeEmpty();
@@ -190,7 +246,7 @@ public class TestReportingTests
     public void Every_Workflow_That_Runs_Tests_Should_Upload_The_TestResults_Artifact()
     {
         var missing = WorkflowsThatRunTests()
-            .Where(w => !ReadWorkflow(w).Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal))
+            .Where(w => !HasUploadStep(w))
             .ToList();
 
         missing.ShouldBeEmpty();
@@ -213,13 +269,15 @@ public class TestReportingTests
     [Fact]
     public void Every_TestResults_Upload_Should_Point_At_The_Directory_The_Build_Fills()
     {
-        // Scoped to a path *line* rather than a substring search: `name: test-results` names the
-        // artifact and would otherwise satisfy an assertion about where it is read from.
+        // Asserted as the whole `path:` value, not as a substring: `name: test-results` names the
+        // artifact and would otherwise satisfy a claim about where it is read from, and a `path: |`
+        // block listing test-results among other globs would satisfy a laxer line-wise check while
+        // re-introducing the very globs the next test rejects. All three steps upload exactly one
+        // directory, so that is what is pinned.
         var offenders = WorkflowsThatRunTests()
             .Where(w => !StepNamed(w, UploadStepName)
                 .Split('\n')
-                .Select(line => line.Trim())
-                .Any(line => line is "path: test-results" or "test-results"))
+                .Any(line => line.Trim() == "path: test-results"))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -228,11 +286,11 @@ public class TestReportingTests
     [Fact]
     public void No_TestResults_Upload_Should_Point_At_A_Path_The_Build_No_Longer_Fills()
     {
-        // Until #231 the MTP logs landed in <project>/bin/<cfg>/<tfm>/TestResults/, and ci.yml and
-        // continuous.yml globbed for them there because Nuke's test-results/ was never created.
-        // --results-directory moved them, so that glob now matches nothing on every run — the same
-        // declared-and-inert shape this issue exists to remove, just one file over. Every path in
-        // the build reaches the Test target, so there is no run in which it could match again.
+        // Until #231 the per-assembly logs landed in <project>/bin/<cfg>/<tfm>/TestResults/, and
+        // ci.yml and continuous.yml globbed for them there because Nuke's test-results/ was never
+        // created. --results-directory moved them, so that glob now matches nothing on every run —
+        // the same declared-and-inert shape this issue exists to remove, just one file over. Every
+        // target that tests routes through Test, so there is no run in which it could match again.
         var offenders = WorkflowsThatRunTests()
             .Where(w => StepNamed(w, UploadStepName).Contains("**/TestResults/", StringComparison.Ordinal))
             .ToList();
@@ -246,7 +304,8 @@ public class TestReportingTests
         // These steps run under `if: always()`, which includes runs that failed in Compile — before
         // any test executed and therefore before test-results/ existed. Without this, upload-artifact
         // warns on a condition that is entirely expected, and a warning nobody can act on is how a
-        // real one gets missed.
+        // real one gets missed. The opposite risk — an *empty* directory passing unremarked — is
+        // covered in the build rather than here, by the Assert.NotEmpty on the trx.
         var offenders = WorkflowsThatRunTests()
             .Where(w => !StepNamed(w, UploadStepName)
                 .Contains("if-no-files-found: ignore", StringComparison.Ordinal))

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -1,0 +1,123 @@
+using System.Text.RegularExpressions;
+
+namespace FormCraft.UnitTests.Ci;
+
+/// <summary>
+/// Guards the build's test-reporting contract (#231). Every claim here was inert before that issue:
+/// <c>Build.cs</c> asked for a results directory and two loggers through <see cref="DotNetTest" />'s
+/// VSTest surface, <c>dotnet test</c> forwarded them as the MSBuild properties
+/// <c>VSTestResultsDirectory</c>/<c>VSTestLogger</c>, and Microsoft.Testing.Platform ignored both
+/// outright (warning <c>MTP0001</c>). So <c>test-results/</c> was never created, no trx or html
+/// report was ever produced, and the <c>Test</c> target's <c>.Produces(...)</c> lines described files
+/// that did not exist.
+/// </summary>
+/// <remarks>
+/// Nothing about that failure was visible: it broke no build and reddened no run — the wiring simply
+/// *read* correct and produced nothing, which is why it survived several CI reworks (#200, #225,
+/// #230). A regression here would be equally quiet, so it is asserted on the build script's text
+/// rather than left to be noticed.
+/// </remarks>
+public class TestReportingTests
+{
+    private static readonly string RepoRoot = LocateRepoRoot();
+
+    /// <summary>
+    /// Maps an artifact extension to the runner option that has to be present for the build to
+    /// actually emit it. Deliberately lists every reporter xunit.v3's Microsoft.Testing.Platform
+    /// runner offers, not only the two in use, so switching format stays a one-line change here
+    /// rather than a puzzle: the point of the table is to reject an extension backed by *nothing*.
+    /// </summary>
+    private static readonly Dictionary<string, string> ReporterForExtension = new(StringComparer.Ordinal)
+    {
+        ["trx"] = "--report-xunit-trx",
+        ["html"] = "--report-xunit-html",
+        ["xunit"] = "--report-xunit",
+        ["junit"] = "--report-junit",
+        ["nunit"] = "--report-nunit",
+        ["ctrf"] = "--report-ctrf",
+        // Not a reporter: Microsoft.Testing.Platform writes one per-assembly diagnostic log — the
+        // artifact #225 exists to preserve — into whatever --results-directory names.
+        ["log"] = "--results-directory",
+    };
+
+    private static string LocateRepoRoot()
+    {
+        // dir.Parent is DirectoryInfo?, so the variable has to be too — inferring DirectoryInfo
+        // from the initializer would fail the build under TreatWarningsAsErrors.
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "FormCraft.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.ShouldNotBeNull("could not locate FormCraft.sln above the test output directory");
+        return dir.FullName;
+    }
+
+    private static string ReadBuildScript() =>
+        File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
+
+    /// <summary>
+    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
+    /// prose — <c>Build.cs</c> carries long explanatory blocks about this very wiring, and without
+    /// this a documentation-only edit would turn the suite red for a reason unrelated to the build.
+    /// Only leading-<paramref name="marker" /> lines are stripped: a trailing-comment strip would
+    /// also mangle the "https://" in a URL.
+    /// </summary>
+    private static string WithoutComments(string text, string marker) =>
+        string.Join(
+            '\n',
+            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
+
+    [Fact]
+    public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
+    {
+        // Both of these reach dotnet test as VSTest-only MSBuild properties. Under
+        // Microsoft.Testing.Platform they are not merely ineffective, they are announced as
+        // ignored (MTP0001) on every single run — warning noise in a repo whose entire build runs
+        // under TreatWarningsAsErrors, which is exactly how readers get trained past warnings.
+        var build = WithoutComments(ReadBuildScript(), "//");
+
+        build.ShouldNotContain("SetResultsDirectory");
+        build.ShouldNotContain("SetLoggers");
+    }
+
+    [Fact]
+    public void BuildScript_Should_Emit_Reports_Through_The_Testing_Platform()
+    {
+        // The native equivalents, which the runner does honour. --results-directory carries the
+        // most weight of the three: it is what puts the reports *and* MTP's per-assembly diagnostic
+        // log under test-results/, which is the single path all three workflows upload.
+        var build = WithoutComments(ReadBuildScript(), "//");
+
+        build.ShouldContain("--results-directory");
+        build.ShouldContain("--report-xunit-trx");
+        build.ShouldContain("--report-xunit-html");
+    }
+
+    [Fact]
+    public void Test_Target_Should_Only_Promise_Artifacts_The_Runner_Is_Asked_To_Write()
+    {
+        // The defect this pins is not "the wrong glob", it is a .Produces(...) contract that named
+        // files nothing emitted — `*.xml` was never written by anything, in either the VSTest or the
+        // MTP world. Cross-checking the promise against the flags means the assertion cannot be
+        // satisfied by copying a literal list, and a future format switch that updates one half
+        // without the other turns red here.
+        var build = WithoutComments(ReadBuildScript(), "//");
+
+        var promised = Regex
+            .Matches(build, """\.Produces\(TestResultsDirectory\s*/\s*"\*\.(?<ext>[A-Za-z]+)"\)""")
+            .Select(match => match.Groups["ext"].Value)
+            .ToList();
+
+        promised.ShouldNotBeEmpty("the Test target promises no test-results artifact at all");
+
+        // Shouldly prints the collection on failure, so this names the offending extension.
+        var unbacked = promised
+            .Where(ext => !ReporterForExtension.TryGetValue(ext, out var option)
+                          || !build.Contains(option, StringComparison.Ordinal))
+            .ToList();
+
+        unbacked.ShouldBeEmpty();
+    }
+}

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -75,8 +75,9 @@ public class TestReportingTests
     /// contract on the day it lands, which is the failure mode this issue is about —
     /// <c>release-please.yml</c> was left behind by #225 and nobody noticed for two releases.
     /// </summary>
-    private static List<string> WorkflowsThatRunTests() =>
-        Directory
+    private static List<string> WorkflowsThatRunTests()
+    {
+        var workflows = Directory
             .EnumerateFiles(WorkflowsDirectory, "*.*")
             .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
                      || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
@@ -87,6 +88,16 @@ public class TestReportingTests
             .OfType<string>()
             .Order(StringComparer.Ordinal)
             .ToList();
+
+        // The vacuity guard lives here rather than in one caller: every assertion below is of the
+        // form "no workflow in this set offends", which an empty set satisfies trivially. A rename,
+        // a reformatted `run:` line or a switch to .yaml would empty it and turn the whole class
+        // green while checking nothing.
+        workflows.ShouldNotBeEmpty(
+            "no workflow invokes ./build.cmd Test|Pack|Continuous — every assertion over this set would pass vacuously");
+
+        return workflows;
+    }
 
     /// <summary>
     /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
@@ -178,12 +189,7 @@ public class TestReportingTests
     [Fact]
     public void Every_Workflow_That_Runs_Tests_Should_Upload_The_TestResults_Artifact()
     {
-        var workflows = WorkflowsThatRunTests();
-
-        workflows.ShouldNotBeEmpty(
-            "no workflow invokes ./build.cmd Test|Pack|Continuous — every assertion below would pass vacuously");
-
-        var missing = workflows
+        var missing = WorkflowsThatRunTests()
             .Where(w => !ReadWorkflow(w).Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal))
             .ToList();
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -91,18 +91,40 @@ class Build : NukeBuild
     Target Test => _ => _
         .DependsOn(Compile)
         .Produces(TestResultsDirectory / "*.trx")
-        .Produces(TestResultsDirectory / "*.xml")
+        .Produces(TestResultsDirectory / "*.html")
+        .Produces(TestResultsDirectory / "*.log")
         .Executes(() =>
         {
+            // Both test projects run on Microsoft.Testing.Platform (UseMicrosoftTestingPlatformRunner),
+            // which ignores DotNetTest's VSTest surface. This target used to call
+            // .SetResultsDirectory()/.SetLoggers(); `dotnet test` forwards those as the MSBuild
+            // properties VSTestResultsDirectory/VSTestLogger, and MTP drops both with warning
+            // MTP0001. So the target produced nothing at all while its .Produces(...) lines claimed
+            // otherwise — and `*.xml` named a file neither runner has ever written (#231).
+            //
+            // The options below are MTP's own and are honoured. Everything after `--` is forwarded
+            // verbatim to each test application, which is where xunit.v3's reporters live; they ship
+            // with the runner, so none of this needs an extra package reference.
+            //
+            // --results-directory carries the most weight of the three: besides the reports, it
+            // relocates MTP's per-assembly diagnostic log — the artifact #225 added, carrying the
+            // failing test names and Shouldly detail that never reach stdout — out of
+            // <project>/bin/<cfg>/<tfm>/TestResults/ and into test-results/. That is why all three
+            // workflows can now upload one directory and get both.
+            //
+            // Report file names are left at their defaults (<user>_<machine>_<timestamp>): the
+            // solution has two test assemblies writing into one directory, and a fixed
+            // --report-xunit-trx-filename would have the second silently overwrite the first.
             DotNetTest(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .EnableNoRestore()
                 .EnableNoBuild()
-                .SetResultsDirectory(TestResultsDirectory)
-                .SetLoggers(
-                    "trx",
-                    $"html;LogFileName={TestResultsDirectory / "test-results.html"}"));
+                .SetProcessAdditionalArguments(
+                    "--",
+                    "--results-directory", TestResultsDirectory,
+                    "--report-xunit-trx",
+                    "--report-xunit-html"));
         });
 
     Target Pack => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -115,6 +115,14 @@ class Build : NukeBuild
             // Report file names are left at their defaults (<user>_<machine>_<timestamp>): the
             // solution has two test assemblies writing into one directory, and a fixed
             // --report-xunit-trx-filename would have the second silently overwrite the first.
+            //
+            // Which is also why the directory is emptied first. Timestamped names never collide, so
+            // nothing overwrites a previous run's reports — they simply accumulate, and a red run
+            // followed by a green one would leave a trx recording failures that no longer exist,
+            // published under an artifact the next reader takes for the current result. CI checks
+            // out fresh so it never sees this; a local `./build.sh Test` loop does, immediately.
+            TestResultsDirectory.CreateOrCleanDirectory();
+
             DotNetTest(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -119,8 +119,11 @@ class Build : NukeBuild
             // Which is also why the directory is emptied first. Timestamped names never collide, so
             // nothing overwrites a previous run's reports — they simply accumulate, and a red run
             // followed by a green one would leave a trx recording failures that no longer exist,
-            // published under an artifact the next reader takes for the current result. CI checks
-            // out fresh so it never sees this; a local `./build.sh Test` loop does, immediately.
+            // published under an artifact the next reader takes for the current result. The tradeoff
+            // is deliberate: re-running a red suite to reproduce discards the first run's reports, so
+            // copy them out first if a flaky failure is what you are chasing. "This directory is the
+            // last run" is the less surprising of the two contracts, and `Clean` already reads that
+            // way. CI checks out fresh, so only a local `./build.sh Test` loop ever notices.
             TestResultsDirectory.CreateOrCleanDirectory();
 
             DotNetTest(s => s
@@ -133,6 +136,21 @@ class Build : NukeBuild
                     "--results-directory", TestResultsDirectory,
                     "--report-xunit-trx",
                     "--report-xunit-html"));
+
+            // Enforce the contract rather than merely declaring it — the whole point of #231. The
+            // defect it was filed about produced no error of any kind: `dotnet test` succeeded, the
+            // build went green, `.Produces(...)` named files nobody checked for, and the reporting
+            // stayed dead for months. The same silence is available to any future SDK or MTP release
+            // that stops honouring these options, exactly as `dotnet test` stopped honouring
+            // VSTestResultsDirectory. Then the workflows would upload an empty directory under
+            // `if-no-files-found: ignore` and nothing anywhere would say so. Cheapest possible guard,
+            // and it turns that whole class of regression into a failed build on the next run.
+            var reports = TestResultsDirectory.GlobFiles("*.trx");
+            Assert.NotEmpty(
+                reports,
+                $"The test run produced no *.trx under {TestResultsDirectory}. The reporters are "
+                + "wired but emitted nothing — check whether the runner still honours "
+                + "--results-directory / --report-xunit-trx (see #231).");
         });
 
     Target Pack => _ => _


### PR DESCRIPTION
Implements #231.

Closes #231.

The issue was filed without a `🛠️ Implementation plan`, so one was derived from its *Proposed
solution*, pinned to measurements taken on `dev`, and posted to the issue before any code was
written. The plan resolves the issue's own fork — *emit natively* vs *delete the wiring* — in favour
of **emitting natively**, because `xunit.v3`'s Microsoft.Testing.Platform runner already ships the
reporters (`--report-xunit-trx`, `--report-xunit-html`, `--results-directory`), so the honest fix
costs no new dependency.

### Plan
- [x] Task 1: Drive MTP's native report options from `Build.cs`
- [x] Task 2: Make all three `Publish: test-results` uploads honest
- [x] Task 3: Prove and record the failure path

### What changed

- **`build/Build.cs`** — the `Test` target drops `.SetResultsDirectory()`/`.SetLoggers()` (forwarded
  as `VSTestResultsDirectory`/`VSTestLogger`, which MTP discards with `MTP0001`) and passes MTP's own
  `--results-directory`, `--report-xunit-trx`, `--report-xunit-html` instead. `.Produces(...)` now
  names `*.trx`, `*.html`, `*.log` — the files actually written — rather than the unsatisfiable
  `*.xml`. The directory is cleaned first, since timestamped report names accumulate rather than
  overwrite, and a red run followed by a green one would otherwise publish stale failures.
- **All three workflows** — one path, `test-results`, plus `if-no-files-found: ignore`.
  `release-please.yml` (the copy #225 was forbidden to touch) was already pointing there and became
  correct without moving; `ci.yml`/`continuous.yml` shed the `**/TestResults/*.log` glob, whose
  premise no longer holds. The long comment blocks stating `test-results/` is never created were
  rewritten, since that is now false.
- **`FormCraft.UnitTests/Ci/TestReportingTests.cs`** — 8 guard facts. The workflow set is *derived*
  (any workflow invoking `./build.cmd Test|Pack|Continuous`) rather than listed, so a fourth workflow
  is held to the contract on the day it lands — which is exactly how `release-please.yml` was left
  behind. `.Produces(...)` extensions are cross-checked against the report flags, so the assertion
  cannot be satisfied by copying a literal.

### The finding that made this cheap

`--results-directory` does not only place the trx/html — it **relocates MTP's per-assembly diagnostic
log** (the artifact #225 exists to preserve) out of `<project>/bin/<cfg>/<tfm>/TestResults/` and into
`test-results/`. Measured: after such a run, `find . -path "*/bin/*/TestResults/*" -name "*.log"`
returns 0 files. That is why fixing the *emitting* end also fixed `release-please.yml`'s "dead path"
without editing its `path:` at all.

### Verification

- `dotnet build -c Release` — 0 warnings, 0 errors (the repo's real gate: `TreatWarningsAsErrors`).
- `dotnet test -c Release` — 788 + 354 pass, 0 fail.
- `./build.sh Test` — green, **no `MTP0001`**, and `test-results/` holds a `.trx`, `.html` and `.log`
  per test assembly.
- **Red path measured, not assumed.** A temporary always-failing test was added and
  `./build.sh Test` run: `test-results/` still received both logs and both trx, the log carried the
  full Shouldly assertion detail and stack trace, and the trx recorded `outcome="Failed"` under the
  test's fully-qualified name. The probe was then removed.
- **Proven in real CI.** The `build-and-test` run on `80b6c03` produced a `test-results` artifact
  containing 2 logs + 2 trx + 2 html from the runner — the first non-empty one this repo has ever
  produced. The `Counters` read `total="789" failed="0"` and `total="354" failed="0"`.
- The guard tests were **mutation-tested**: deleting `if: always()` from `continuous.yml` turns
  `Every_TestResults_Upload_Should_Run_On_Failure` red, and only it.

### A second, unrelated silent failure — fixed

The log-reading recipe `ci.yml` documents produced **nothing** when run against a real artifact. The
artifact holds one log per test assembly, and a single `iconv` over both leaves the second file's BOM
inline immediately before its first line — which is the line naming the first failure — so
`grep '^failed '` cannot match it. Byte-level confirmation: `357 273 277` (`EF BB BF`) directly
preceding `failed`. Since the first file's failures would print but the second's never would, this
failed in the same silent, plausible-looking way as the wiring this issue is about. The recipe is now
a per-file loop, verified against both a locally reddened run and the real CI artifact.

### Code review

A review pass raised 15 findings. Ten were real and are fixed in `f60b791`:

- **The recovery recipe truncated its own output.** `grep -A5` stops five lines after the `failed`
  line, which is inside Shouldly's difference table — so the `at ...` stack frames never printed,
  while the next comment line claimed they did. Now `-A30`, verified to reach the stack trace.
- **The BOM mechanism is now stated exactly.** BSD grep drops a UTF-8 BOM only at the *start* of the
  stream and GNU grep drops none, so `^failed ` misses a failing assembly's first line on Linux
  always, and on macOS as soon as more than one file is piped in. The recipe now strips the BOM
  explicitly instead of relying on either behaviour.
- **`if-no-files-found: ignore` could hide a repeat of this very defect** — an empty `test-results/`
  would upload silently. Fixed at the source rather than in the workflows: the `Test` target now
  `Assert.NotEmpty`s the `*.trx` it just claimed to produce. Verified by mutation — removing
  `--report-xunit-trx` fails the build with a message naming the cause, instead of going green.
- **The "backed by a reporter" check matched prefixes**, so `--report-xunit-html-filename` alone
  satisfied `--report-xunit-html` (names a file, enables nothing) and `--report-xunit-trx` satisfied
  `--report-xunit`. Now word-boundary matched; mutation-tested.
- **Workflow discovery was too narrow** — it missed `run: |` blocks, `./build.sh`, and the
  `Publish`/`PublishIfNeeded`/`Release` targets that also reach `Test` via `DependsOn`.
- **One assertion searched raw text**, so a comment quoting the step name would have satisfied it.
- Plus: the `*.log` mapping now describes the real mechanism (`dotnet test`'s MSBuild integration,
  not MTP's opt-in `--diagnostic`), workflow files are read once instead of ~20 times, the `path:`
  check is pinned to the whole value, and an unresolvable `<see cref="DotNetTest"/>` became `<c>`.

Three findings I disagreed with, having measured them:

- *"The log carries no ANSI escapes, so the `sed` is unnecessary."* True locally, **false in CI** —
  which is the only place this recipe is ever used. The downloaded artifact contains
  `ESC[33mskipped ESC[m…`; MTP colourises the status word on the runner, so an uncoloured `^failed `
  would not match. The `sed` stays, and the comment now says where the escapes come from.
- *"Concatenating the logs still matches every `^failed ` line."* Not for this artifact: the failing
  assembly's log opens *with* its `failed <test>` line, so the mid-stream BOM lands directly on it —
  `EF BB BF` immediately before `failed`, measured. Concatenated `grep -c '^failed '` returns 0 where
  the per-file loop returns 1. The reviewer's log evidently began with the runner banner.
- *"Cleaning `test-results/` before the run destroys the failing run's reports."* A real cost, but
  the alternative — unbounded accumulation under timestamped names — makes `.Produces(*.trx)`
  ambiguous about which run it describes, and `Clean` already means "empty this". Kept, with the
  tradeoff written into the comment.

Two more were fair but are deferred as follow-ups below (helper duplication, per-assembly report
names); one — that the workflow assertions are file-scoped rather than job-scoped — is now recorded
as a known limitation in the test class, since closing it needs a real YAML parse.

## Follow-ups

- **`TestReportingTests` and `TrustedPublishingWorkflowTests` now carry near-duplicate helpers**
  (`LocateRepoRoot`, `WithoutComments`, workflow-step extraction). They should share one
  `Ci/` helper. Deliberately not done here: folding the older class onto a new shared type would put
  an unrelated refactor of a passing guard suite into a build/CI fix.
- **The trx and html reports carry no assembly identity.** The two `.log` files are named
  `FormCraft.UnitTests_net10.0_x64.log` / `FormCraft.ForMudBlazor.UnitTests_…`, but the trx and html
  are `runner_<machine>_<timestamp>.trx` — distinguishable only by a microsecond. Attribution is
  recoverable from the file's contents, but not from its name. The fix is a per-project
  `--results-directory`, which means invoking `DotNetTest` per test project instead of once for the
  solution — a larger change to how the suite runs than this issue warrants.
- **The workflow assertions are file-scoped, not job-scoped.** A workflow that ran the build in one
  job and uploaded from another would satisfy them while uploading nothing, since the second job gets
  a fresh workspace. Closing it needs a real YAML parse; noted in the test class for now.
- **`.worktrees/` is not in `.gitignore`** (`.claude/worktrees/` is). Only matters to agent tooling
  that uses that second location, but a worktree left there is staged by any `git add -A`.
