### PR TITLE
test(ci): extract a shared workflow reader and scope guards to jobs (#255)

### DIFF
--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -27,12 +27,7 @@ namespace FormCraft.UnitTests.Ci;
 /// </remarks>
 public class TestReportingTests
 {
-    private static readonly string RepoRoot = LocateRepoRoot();
-
-    /// <summary>Every workflow file, read once — these tests are pure text assertions over them.</summary>
-    private static readonly Dictionary<string, string> WorkflowText = ReadAllWorkflows();
-
-    private static readonly List<string> TestRunningWorkflows = DiscoverWorkflowsThatRunTests();
+    private static readonly IReadOnlyList<string> TestRunningWorkflows = DiscoverWorkflowsThatRunTests();
 
     /// <summary>
     /// The one step name all three workflows use for this upload. Asserted as a literal because it
@@ -68,33 +63,13 @@ public class TestReportingTests
         ["log"] = "--results-directory",
     };
 
-    private static string LocateRepoRoot()
-    {
-        // dir.Parent is DirectoryInfo?, so the variable has to be too — inferring DirectoryInfo
-        // from the initializer would fail the build under TreatWarningsAsErrors.
-        DirectoryInfo? dir = new(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "FormCraft.sln")))
-        {
-            dir = dir.Parent;
-        }
+    /// <summary>The build script, comment-stripped — the text every <c>Build.cs</c> claim below reads.</summary>
+    private static string BuildScript() =>
+        WorkflowSource.WithoutComments(WorkflowSource.ReadBuildScript(), "//");
 
-        dir.ShouldNotBeNull("could not locate FormCraft.sln above the test output directory");
-        return dir.FullName;
-    }
-
-    private static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
-
-    private static Dictionary<string, string> ReadAllWorkflows() =>
-        Directory
-            .EnumerateFiles(WorkflowsDirectory, "*.*")
-            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
-                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
-            .ToDictionary(f => Path.GetFileName(f), f => File.ReadAllText(f), StringComparer.Ordinal);
-
-    private static string ReadWorkflow(string fileName) => WorkflowText[fileName];
-
-    private static string ReadBuildScript() =>
-        File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
+    /// <summary>One workflow, comment-stripped — the text every workflow claim below reads.</summary>
+    private static string Workflow(string fileName) =>
+        WorkflowSource.WithoutComments(WorkflowSource.Read(fileName), "#");
 
     /// <summary>
     /// Every workflow that reaches Nuke's <c>Test</c> target, discovered rather than listed, so a
@@ -107,16 +82,10 @@ public class TestReportingTests
     /// <c>run:</c> prefix: a <c>run: |</c> block puts the command on a later line, and the repo
     /// documents <c>./build.sh</c> as the macOS/Linux entry point alongside <c>./build.cmd</c>.
     /// </remarks>
-    private static List<string> DiscoverWorkflowsThatRunTests() =>
-        WorkflowText
-            .Where(entry => Regex.IsMatch(
-                WithoutComments(entry.Value, "#"),
-                $@"\./build\.(cmd|sh|ps1)\s+({TargetsThatRunTests})\b"))
-            .Select(entry => entry.Key)
-            .Order(StringComparer.Ordinal)
-            .ToList();
+    private static IReadOnlyList<string> DiscoverWorkflowsThatRunTests() =>
+        WorkflowSource.Matching($@"\./build\.(cmd|sh|ps1)\s+({TargetsThatRunTests})\b");
 
-    private static List<string> WorkflowsThatRunTests()
+    private static IReadOnlyList<string> WorkflowsThatRunTests()
     {
         // The vacuity guard lives here rather than in one caller: every assertion below is of the
         // form "no workflow in this set offends", which an empty set satisfies trivially. A rename,
@@ -139,44 +108,11 @@ public class TestReportingTests
     private static bool Enables(string build, string option) =>
         Regex.IsMatch(build, Regex.Escape(option) + "(?![-A-Za-z])");
 
-    /// <summary>
-    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
-    /// prose — these files carry long explanatory blocks about this very wiring, and without this a
-    /// documentation-only edit would turn the suite red for a reason unrelated to the build. Only
-    /// leading-<paramref name="marker" /> lines are stripped: a trailing-comment strip would also
-    /// mangle the "https://" in a URL.
-    /// </summary>
-    private static string WithoutComments(string text, string marker) =>
-        string.Join(
-            '\n',
-            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
-
-    /// <summary>
-    /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
-    /// satisfied by the same text sitting on some other step. Runs from the <c>- name:</c> line to
-    /// the start of the next list item, which covers the step's <c>if:</c>, <c>uses:</c> and
-    /// <c>with:</c>.
-    /// </summary>
-    private static string StepNamed(string workflowFile, string stepName)
-    {
-        var lines = WithoutComments(ReadWorkflow(workflowFile), "#").Split('\n');
-        var start = Array.FindIndex(
-            lines,
-            l => l.TrimStart().StartsWith($"- name: '{stepName}'", StringComparison.Ordinal));
-        start.ShouldBeGreaterThanOrEqualTo(0, $"{workflowFile} no longer has a step named '{stepName}'");
-
-        var end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith("- ", StringComparison.Ordinal));
-        if (end < 0)
-        {
-            end = lines.Length;
-        }
-
-        return string.Join('\n', lines[start..end]);
-    }
+    private static string StepNamed(string workflowFile, string stepName) =>
+        WorkflowSource.StepNamed(Workflow(workflowFile), stepName, workflowFile);
 
     private static bool HasUploadStep(string workflowFile) =>
-        WithoutComments(ReadWorkflow(workflowFile), "#")
-            .Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal);
+        Workflow(workflowFile).Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal);
 
     [Fact]
     public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
@@ -185,7 +121,7 @@ public class TestReportingTests
         // Microsoft.Testing.Platform they are not merely ineffective, they are announced as
         // ignored (MTP0001) on every single run — warning noise in a repo whose entire build runs
         // under TreatWarningsAsErrors, which is exactly how readers get trained past warnings.
-        var build = WithoutComments(ReadBuildScript(), "//");
+        var build = BuildScript();
 
         build.ShouldNotContain("SetResultsDirectory");
         build.ShouldNotContain("SetLoggers");
@@ -197,7 +133,7 @@ public class TestReportingTests
         // The native equivalents, which the runner does honour. --results-directory carries the
         // most weight of the three: it is what puts the reports *and* the per-assembly diagnostic
         // log under test-results/, which is the single path all three workflows upload.
-        var build = WithoutComments(ReadBuildScript(), "//");
+        var build = BuildScript();
 
         Enables(build, "--results-directory").ShouldBeTrue();
         Enables(build, "--report-xunit-trx").ShouldBeTrue();
@@ -211,7 +147,7 @@ public class TestReportingTests
         // honoured today and silently dropped tomorrow, exactly as VSTestResultsDirectory was. #231
         // existed because nothing anywhere noticed months of empty output, so the build itself has
         // to notice.
-        var build = WithoutComments(ReadBuildScript(), "//");
+        var build = BuildScript();
 
         build.ShouldContain("Assert.NotEmpty");
         build.ShouldMatch(@"GlobFiles\(""\*\.trx""\)");
@@ -225,7 +161,7 @@ public class TestReportingTests
         // MTP world. Cross-checking the promise against the flags means the assertion cannot be
         // satisfied by copying a literal list, and a future format switch that updates one half
         // without the other turns red here.
-        var build = WithoutComments(ReadBuildScript(), "//");
+        var build = BuildScript();
 
         var promised = Regex
             .Matches(build, """\.Produces\(TestResultsDirectory\s*/\s*"\*\.(?<ext>[A-Za-z]+)"\)""")

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -19,15 +19,16 @@ namespace FormCraft.UnitTests.Ci;
 /// rather than left to be noticed.
 /// </para>
 /// <para>
-/// ⚠️ Known limitation: the workflow assertions are file-scoped, not job-scoped. A workflow that ran
-/// the build in one job and uploaded the artifact from another would satisfy them while uploading
-/// nothing, because the second job gets a fresh workspace. Catching that needs a real YAML parse,
-/// which this project has no dependency for; the shape is noted in the PR that added these tests.
+/// The workflow assertions are scoped to the <b>job</b> that runs the build (#255), not to the file.
+/// Each job gets a fresh workspace, so a build in one job and an upload in another uploads nothing
+/// at all — silently, since <c>if-no-files-found: ignore</c> is pinned on every upload. Job splitting
+/// is done by indentation in <see cref="WorkflowSource.JobsOf" /> rather than with a YAML parser this
+/// project deliberately takes no dependency on.
 /// </para>
 /// </remarks>
 public class TestReportingTests
 {
-    private static readonly IReadOnlyList<string> TestRunningWorkflows = DiscoverWorkflowsThatRunTests();
+    private static readonly IReadOnlyList<TestRunningJob> TestRunningJobs = DiscoverJobsThatRunTests();
 
     /// <summary>
     /// The one step name all three workflows use for this upload. Asserted as a literal because it
@@ -67,34 +68,55 @@ public class TestReportingTests
     private static string BuildScript() =>
         WorkflowSource.WithoutComments(WorkflowSource.ReadBuildScript(), "//");
 
-    /// <summary>One workflow, comment-stripped — the text every workflow claim below reads.</summary>
-    private static string Workflow(string fileName) =>
-        WorkflowSource.WithoutComments(WorkflowSource.Read(fileName), "#");
+    /// <summary>
+    /// The wrapper invocation that means a job runs the suite. Matched anywhere in the job's
+    /// comment-stripped text rather than on a <c>run:</c> prefix: a <c>run: |</c> block puts the
+    /// command on a later line, and the repo documents <c>./build.sh</c> as the macOS/Linux entry
+    /// point alongside <c>./build.cmd</c>.
+    /// </summary>
+    private static string InvocationPattern => $@"\./build\.(cmd|sh|ps1)\s+({TargetsThatRunTests})\b";
+
+    /// <summary>One job of one workflow — the scope every workflow claim below is held against.</summary>
+    private sealed record TestRunningJob(string Workflow, string Job, string Text)
+    {
+        /// <summary>Names the offending pair when Shouldly prints the collection on failure.</summary>
+        public override string ToString() => $"{Workflow} / {Job}";
+    }
 
     /// <summary>
-    /// Every workflow that reaches Nuke's <c>Test</c> target, discovered rather than listed, so a
-    /// fourth workflow added later is held to the same contract on the day it lands — which is the
-    /// failure mode this issue is about: <c>release-please.yml</c> was left behind by #225 and
-    /// nobody noticed.
+    /// Every (workflow, job) pair that reaches Nuke's <c>Test</c> target, discovered rather than
+    /// listed, so a workflow — or a job — added later is held to the same contract on the day it
+    /// lands, which is the failure mode this guard is about: <c>release-please.yml</c> was left
+    /// behind by #225 and nobody noticed.
     /// </summary>
     /// <remarks>
-    /// Matched on the wrapper invocation anywhere in the comment-stripped file rather than on a
-    /// <c>run:</c> prefix: a <c>run: |</c> block puts the command on a later line, and the repo
-    /// documents <c>./build.sh</c> as the macOS/Linux entry point alongside <c>./build.cmd</c>.
+    /// Scoped to the <b>job</b> rather than the file (#255). Every job gets a fresh workspace, so a
+    /// build in job A leaves nothing for an upload in job B to find — and with
+    /// <c>if-no-files-found: ignore</c> pinned on every upload (#252), that combination uploads
+    /// nothing while satisfying a file-scoped assertion completely silently. Files are narrowed
+    /// first only as a cheap pre-filter: a job that matches implies a file that matches, so it
+    /// cannot drop a pair.
     /// </remarks>
-    private static IReadOnlyList<string> DiscoverWorkflowsThatRunTests() =>
-        WorkflowSource.Matching($@"\./build\.(cmd|sh|ps1)\s+({TargetsThatRunTests})\b");
+    private static IReadOnlyList<TestRunningJob> DiscoverJobsThatRunTests() =>
+        WorkflowSource
+            .Matching(InvocationPattern)
+            .SelectMany(workflow => WorkflowSource
+                .JobsOf(workflow)
+                .OrderBy(job => job.Key, StringComparer.Ordinal)
+                .Where(job => Regex.IsMatch(job.Value, InvocationPattern))
+                .Select(job => new TestRunningJob(workflow, job.Key, job.Value)))
+            .ToList();
 
-    private static IReadOnlyList<string> WorkflowsThatRunTests()
+    private static IReadOnlyList<TestRunningJob> JobsThatRunTests()
     {
         // The vacuity guard lives here rather than in one caller: every assertion below is of the
-        // form "no workflow in this set offends", which an empty set satisfies trivially. A rename,
-        // a reformatted invocation or a switch to .yaml would empty it and turn the whole class
-        // green while checking nothing.
-        TestRunningWorkflows.ShouldNotBeEmpty(
-            $"no workflow invokes ./build.[cmd|sh|ps1] ({TargetsThatRunTests}) — every assertion over this set would pass vacuously");
+        // form "no job in this set offends", which an empty set satisfies trivially. A rename, a
+        // reformatted invocation, a switch to .yaml — or a job layout this reader failed to split —
+        // would empty it and turn the whole class green while checking nothing.
+        TestRunningJobs.ShouldNotBeEmpty(
+            $"no job invokes ./build.[cmd|sh|ps1] ({TargetsThatRunTests}) — every assertion over this set would pass vacuously");
 
-        return TestRunningWorkflows;
+        return TestRunningJobs;
     }
 
     /// <summary>
@@ -108,11 +130,12 @@ public class TestReportingTests
     private static bool Enables(string build, string option) =>
         Regex.IsMatch(build, Regex.Escape(option) + "(?![-A-Za-z])");
 
-    private static string StepNamed(string workflowFile, string stepName) =>
-        WorkflowSource.StepNamed(Workflow(workflowFile), stepName, workflowFile);
-
-    private static bool HasUploadStep(string workflowFile) =>
-        Workflow(workflowFile).Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal);
+    /// <summary>
+    /// The upload step as it appears <em>within that job</em> — so an assertion about it cannot be
+    /// answered by an identically-named step sitting in a sibling job.
+    /// </summary>
+    private static string UploadStep(TestRunningJob job) =>
+        WorkflowSource.StepNamed(job.Text, UploadStepName, job.ToString());
 
     [Fact]
     public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
@@ -179,10 +202,12 @@ public class TestReportingTests
     }
 
     [Fact]
-    public void Every_Workflow_That_Runs_Tests_Should_Upload_The_TestResults_Artifact()
+    public void Every_Job_That_Runs_Tests_Should_Upload_The_TestResults_Artifact()
     {
-        var missing = WorkflowsThatRunTests()
-            .Where(w => !HasUploadStep(w))
+        // In that same job, not merely somewhere in the file: the artifact is uploaded from the
+        // workspace the build filled, and a sibling job's workspace is a different one.
+        var missing = JobsThatRunTests()
+            .Where(j => !j.Text.Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal))
             .ToList();
 
         missing.ShouldBeEmpty();
@@ -195,8 +220,8 @@ public class TestReportingTests
         // one worth preserving, and it is exactly the path a bare step skips. Microsoft.Testing.
         // Platform prints only a summary line to stdout, so without this a red CI run leaves no
         // record of *which* assertion failed — a cost that was paid for real during #200.
-        var offenders = WorkflowsThatRunTests()
-            .Where(w => !StepNamed(w, UploadStepName).Contains("if: always()", StringComparison.Ordinal))
+        var offenders = JobsThatRunTests()
+            .Where(j => !UploadStep(j).Contains("if: always()", StringComparison.Ordinal))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -210,8 +235,8 @@ public class TestReportingTests
         // block listing test-results among other globs would satisfy a laxer line-wise check while
         // re-introducing the very globs the next test rejects. All three steps upload exactly one
         // directory, so that is what is pinned.
-        var offenders = WorkflowsThatRunTests()
-            .Where(w => !StepNamed(w, UploadStepName)
+        var offenders = JobsThatRunTests()
+            .Where(j => !UploadStep(j)
                 .Split('\n')
                 .Any(line => line.Trim() == "path: test-results"))
             .ToList();
@@ -227,8 +252,8 @@ public class TestReportingTests
         // created. --results-directory moved them, so that glob now matches nothing on every run —
         // the same declared-and-inert shape this issue exists to remove, just one file over. Every
         // target that tests routes through Test, so there is no run in which it could match again.
-        var offenders = WorkflowsThatRunTests()
-            .Where(w => StepNamed(w, UploadStepName).Contains("**/TestResults/", StringComparison.Ordinal))
+        var offenders = JobsThatRunTests()
+            .Where(j => UploadStep(j).Contains("**/TestResults/", StringComparison.Ordinal))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -242,8 +267,8 @@ public class TestReportingTests
         // warns on a condition that is entirely expected, and a warning nobody can act on is how a
         // real one gets missed. The opposite risk — an *empty* directory passing unremarked — is
         // covered in the build rather than here, by the Assert.NotEmpty on the trx.
-        var offenders = WorkflowsThatRunTests()
-            .Where(w => !StepNamed(w, UploadStepName)
+        var offenders = JobsThatRunTests()
+            .Where(j => !UploadStep(j)
                 .Contains("if-no-files-found: ignore", StringComparison.Ordinal))
             .ToList();
 

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -64,10 +64,6 @@ public class TestReportingTests
         ["log"] = "--results-directory",
     };
 
-    /// <summary>The build script, comment-stripped — the text every <c>Build.cs</c> claim below reads.</summary>
-    private static string BuildScript() =>
-        WorkflowSource.WithoutComments(WorkflowSource.ReadBuildScript(), "//");
-
     /// <summary>
     /// The wrapper invocation that means a job runs the suite. Matched anywhere in the job's
     /// comment-stripped text rather than on a <c>run:</c> prefix: a <c>run: |</c> block puts the
@@ -111,12 +107,36 @@ public class TestReportingTests
     {
         // The vacuity guard lives here rather than in one caller: every assertion below is of the
         // form "no job in this set offends", which an empty set satisfies trivially. A rename, a
-        // reformatted invocation, a switch to .yaml — or a job layout this reader failed to split —
-        // would empty it and turn the whole class green while checking nothing.
+        // reformatted invocation or a switch to .yaml would empty it and turn the whole class green
+        // while checking nothing.
+        //
+        // It is deliberately only half the protection — it fires when the set is *entirely* empty,
+        // and cannot see one workflow dropping out. That case is covered by the test below.
         TestRunningJobs.ShouldNotBeEmpty(
             $"no job invokes ./build.[cmd|sh|ps1] ({TargetsThatRunTests}) — every assertion over this set would pass vacuously");
 
         return TestRunningJobs;
+    }
+
+    [Fact]
+    public void Every_Workflow_That_Runs_Tests_Should_Contribute_A_Job()
+    {
+        // Job scoping is strictly stronger than the file scoping it replaced — except in one way,
+        // which this closes. File scoping could not lose a workflow: the file either matched or it
+        // did not. Job scoping can, because a file that matches still contributes nothing when
+        // JobsOf fails to split it (an unrecognised `jobs:` layout, a quoted or differently indented
+        // job key). The whole-set vacuity guard cannot see that — the set is still non-empty from
+        // the other workflows — so the assertions would simply stop covering that file, green.
+        //
+        // Asserted as an equality against the file-level discovery, which is the one thing known to
+        // be complete: every workflow whose text invokes the build must appear in the pair set.
+        var covered = JobsThatRunTests()
+            .Select(j => j.Workflow)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        covered.ShouldBe(WorkflowSource.Matching(InvocationPattern));
     }
 
     /// <summary>
@@ -144,7 +164,7 @@ public class TestReportingTests
         // Microsoft.Testing.Platform they are not merely ineffective, they are announced as
         // ignored (MTP0001) on every single run — warning noise in a repo whose entire build runs
         // under TreatWarningsAsErrors, which is exactly how readers get trained past warnings.
-        var build = BuildScript();
+        var build = WorkflowSource.BuildScript;
 
         build.ShouldNotContain("SetResultsDirectory");
         build.ShouldNotContain("SetLoggers");
@@ -156,7 +176,7 @@ public class TestReportingTests
         // The native equivalents, which the runner does honour. --results-directory carries the
         // most weight of the three: it is what puts the reports *and* the per-assembly diagnostic
         // log under test-results/, which is the single path all three workflows upload.
-        var build = BuildScript();
+        var build = WorkflowSource.BuildScript;
 
         Enables(build, "--results-directory").ShouldBeTrue();
         Enables(build, "--report-xunit-trx").ShouldBeTrue();
@@ -170,7 +190,7 @@ public class TestReportingTests
         // honoured today and silently dropped tomorrow, exactly as VSTestResultsDirectory was. #231
         // existed because nothing anywhere noticed months of empty output, so the build itself has
         // to notice.
-        var build = BuildScript();
+        var build = WorkflowSource.BuildScript;
 
         build.ShouldContain("Assert.NotEmpty");
         build.ShouldMatch(@"GlobFiles\(""\*\.trx""\)");
@@ -184,7 +204,7 @@ public class TestReportingTests
         // MTP world. Cross-checking the promise against the flags means the assertion cannot be
         // satisfied by copying a literal list, and a future format switch that updates one half
         // without the other turns red here.
-        var build = BuildScript();
+        var build = WorkflowSource.BuildScript;
 
         var promised = Regex
             .Matches(build, """\.Produces\(TestResultsDirectory\s*/\s*"\*\.(?<ext>[A-Za-z]+)"\)""")

--- a/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
+++ b/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
@@ -14,61 +14,26 @@ namespace FormCraft.UnitTests.Ci;
 /// </remarks>
 public class TrustedPublishingWorkflowTests
 {
-    private static readonly string RepoRoot = LocateRepoRoot();
+    /// <summary>The build script, comment-stripped — the text every <c>Build.cs</c> claim below reads.</summary>
+    private static string BuildScript() =>
+        WorkflowSource.WithoutComments(WorkflowSource.ReadBuildScript(), "//");
 
-    private static string LocateRepoRoot()
-    {
-        // dir.Parent is DirectoryInfo?, so the variable has to be too — inferring DirectoryInfo
-        // from the initializer would fail the build under TreatWarningsAsErrors.
-        DirectoryInfo? dir = new(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "FormCraft.sln")))
-        {
-            dir = dir.Parent;
-        }
-
-        dir.ShouldNotBeNull("could not locate FormCraft.sln above the test output directory");
-        return dir.FullName;
-    }
-
-    private static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
-
-    private static string ReadWorkflow(string fileName) =>
-        File.ReadAllText(Path.Combine(WorkflowsDirectory, fileName));
-
-    private static string ReadBuildScript() =>
-        File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
-
-    /// <summary>
-    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
-    /// prose. These files carry long explanatory comment blocks about this very key, so without
-    /// this a documentation-only edit would turn the suite red — and the natural repair under
-    /// time pressure is to delete the assertion. Only leading-<paramref name="marker"/> lines are
-    /// stripped: a trailing-comment strip would also mangle the "https://" in a URL.
-    /// </summary>
-    private static string WithoutComments(string text, string marker) =>
-        string.Join(
-            '\n',
-            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
+    /// <summary>One workflow, comment-stripped — the text every whole-file claim below reads.</summary>
+    private static string Workflow(string fileName) =>
+        WorkflowSource.WithoutComments(WorkflowSource.Read(fileName), "#");
 
     /// <summary>
     /// A single step of a workflow, so an assertion about its <c>if:</c> cannot be satisfied by the
-    /// same expression sitting on some other step. Runs from the <c>id:</c> line to the start of the
-    /// next list item, which covers the step's <c>if:</c>, <c>uses:</c> and <c>with:</c>.
+    /// same expression sitting on some other step.
     /// </summary>
-    private static string StepWithId(string workflowFile, string stepId)
-    {
-        var lines = ReadWorkflow(workflowFile).Split('\n');
-        var start = Array.FindIndex(lines, l => l.Contains($"id: {stepId}", StringComparison.Ordinal));
-        start.ShouldBeGreaterThanOrEqualTo(0, $"{workflowFile} no longer has a step with `id: {stepId}`");
-
-        var end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith("- ", StringComparison.Ordinal));
-        if (end < 0)
-        {
-            end = lines.Length;
-        }
-
-        return string.Join('\n', lines[start..end]);
-    }
+    /// <remarks>
+    /// Deliberately reads the workflow *unstripped*. The scan runs from the <c>id:</c> line to the
+    /// next list item, so the slice carries whatever explanatory comments sit between the step and
+    /// its successor — harmless here, because every claim below is about a line these files spell
+    /// as wiring (<c>if:</c>, <c>uses:</c>) rather than as prose.
+    /// </remarks>
+    private static string StepWithId(string workflowFile, string stepId) =>
+        WorkflowSource.StepWithId(WorkflowSource.Read(workflowFile), stepId, workflowFile);
 
     /// <summary>
     /// The <c>if:</c> expression of a single step, so a claim about what a step is *gated on* cannot
@@ -89,7 +54,7 @@ public class TrustedPublishingWorkflowTests
     [Fact]
     public void ReleaseWorkflow_Should_Request_The_OidcToken()
     {
-        WithoutComments(ReadWorkflow("release-please.yml"), "#").ShouldContain("id-token: write");
+        Workflow("release-please.yml").ShouldContain("id-token: write");
     }
 
     [Fact]
@@ -104,8 +69,7 @@ public class TrustedPublishingWorkflowTests
         step.ShouldContain("NUGET_USER");
 
         // The minted key has to actually reach the build; this lives on the later `Run` step.
-        WithoutComments(ReadWorkflow("release-please.yml"), "#")
-            .ShouldContain("steps.login.outputs.NUGET_API_KEY");
+        Workflow("release-please.yml").ShouldContain("steps.login.outputs.NUGET_API_KEY");
     }
 
     [Fact]
@@ -141,7 +105,7 @@ public class TrustedPublishingWorkflowTests
         // in #197: release-please creates the tag with GITHUB_TOKEN, which never fires
         // `on: push: tags`, so a publish path here could not run — but it could still mint a key.
         // Two workflows able to push the same version is the failure this prevents.
-        var continuous = WithoutComments(ReadWorkflow("continuous.yml"), "#");
+        var continuous = Workflow("continuous.yml");
 
         continuous.ShouldNotContain("NuGet/login@");
         continuous.ShouldNotContain("id-token");
@@ -154,18 +118,14 @@ public class TrustedPublishingWorkflowTests
         // Every workflow, not just the publishing one: any workflow that added
         // ${{ secrets.NUGET_API_KEY }} would re-arm exactly the credential #198 exists to retire,
         // with release-please.yml still perfectly clean.
-        var workflows = Directory
-            .EnumerateFiles(WorkflowsDirectory, "*.*")
-            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
-                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var workflows = WorkflowSource.All;
 
         workflows.ShouldNotBeEmpty("no workflow files found — the scan would pass vacuously");
 
         var offenders = workflows
-            .Where(f => WithoutComments(File.ReadAllText(f), "#")
+            .Where(entry => WorkflowSource.WithoutComments(entry.Value, "#")
                 .Contains("secrets.NUGET_API_KEY", StringComparison.Ordinal))
-            .Select(Path.GetFileName)
+            .Select(entry => entry.Key)
             .ToList();
 
         // Shouldly prints the collection on failure, so this names the workflow that re-armed it.
@@ -176,7 +136,7 @@ public class TrustedPublishingWorkflowTests
     public void BuildScript_Should_Not_Import_The_LongLived_NuGetApiKey_Secret()
     {
         // The key arrives as a step output now, not as an imported secret.
-        WithoutComments(ReadBuildScript(), "//").ShouldNotContain("ImportSecrets");
+        BuildScript().ShouldNotContain("ImportSecrets");
     }
 
     [Fact]
@@ -187,7 +147,7 @@ public class TrustedPublishingWorkflowTests
         // tag-triggered publish path that #197 deliberately removed. The wipe lands on the next
         // ./build.cmd, long after the edit, so assert the flag itself rather than trusting the
         // tests to run after a regeneration.
-        WithoutComments(ReadBuildScript(), "//").ShouldContain("AutoGenerate = false");
+        BuildScript().ShouldContain("AutoGenerate = false");
     }
 
     [Fact]
@@ -196,7 +156,7 @@ public class TrustedPublishingWorkflowTests
         // release-please.yml leaves NUGET_API_KEY empty on a dry run, but a skipped step yields an
         // empty string rather than an unset variable — so this static gate, not the emptiness of
         // the key, is what keeps a non-release run from reaching DotNetNuGetPush.
-        var build = WithoutComments(ReadBuildScript(), "//");
+        var build = BuildScript();
         build.ShouldMatch(@"OnlyWhenStatic\(\(\) => IsOnVersionTag\(\)\)");
         build.ShouldMatch(@"OnlyWhenStatic\(\(\) => IsServerBuild\)");
     }

--- a/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
+++ b/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
@@ -14,14 +14,6 @@ namespace FormCraft.UnitTests.Ci;
 /// </remarks>
 public class TrustedPublishingWorkflowTests
 {
-    /// <summary>The build script, comment-stripped — the text every <c>Build.cs</c> claim below reads.</summary>
-    private static string BuildScript() =>
-        WorkflowSource.WithoutComments(WorkflowSource.ReadBuildScript(), "//");
-
-    /// <summary>One workflow, comment-stripped — the text every whole-file claim below reads.</summary>
-    private static string Workflow(string fileName) =>
-        WorkflowSource.WithoutComments(WorkflowSource.Read(fileName), "#");
-
     /// <summary>
     /// A single step of a workflow, so an assertion about its <c>if:</c> cannot be satisfied by the
     /// same expression sitting on some other step.
@@ -54,7 +46,7 @@ public class TrustedPublishingWorkflowTests
     [Fact]
     public void ReleaseWorkflow_Should_Request_The_OidcToken()
     {
-        Workflow("release-please.yml").ShouldContain("id-token: write");
+        WorkflowSource.Stripped("release-please.yml").ShouldContain("id-token: write");
     }
 
     [Fact]
@@ -69,7 +61,7 @@ public class TrustedPublishingWorkflowTests
         step.ShouldContain("NUGET_USER");
 
         // The minted key has to actually reach the build; this lives on the later `Run` step.
-        Workflow("release-please.yml").ShouldContain("steps.login.outputs.NUGET_API_KEY");
+        WorkflowSource.Stripped("release-please.yml").ShouldContain("steps.login.outputs.NUGET_API_KEY");
     }
 
     [Fact]
@@ -105,7 +97,7 @@ public class TrustedPublishingWorkflowTests
         // in #197: release-please creates the tag with GITHUB_TOKEN, which never fires
         // `on: push: tags`, so a publish path here could not run — but it could still mint a key.
         // Two workflows able to push the same version is the failure this prevents.
-        var continuous = Workflow("continuous.yml");
+        var continuous = WorkflowSource.Stripped("continuous.yml");
 
         continuous.ShouldNotContain("NuGet/login@");
         continuous.ShouldNotContain("id-token");
@@ -118,14 +110,14 @@ public class TrustedPublishingWorkflowTests
         // Every workflow, not just the publishing one: any workflow that added
         // ${{ secrets.NUGET_API_KEY }} would re-arm exactly the credential #198 exists to retire,
         // with release-please.yml still perfectly clean.
-        var workflows = WorkflowSource.All;
+        var workflows = WorkflowSource.All.Keys;
 
         workflows.ShouldNotBeEmpty("no workflow files found — the scan would pass vacuously");
 
         var offenders = workflows
-            .Where(entry => WorkflowSource.WithoutComments(entry.Value, "#")
+            .Where(fileName => WorkflowSource.Stripped(fileName)
                 .Contains("secrets.NUGET_API_KEY", StringComparison.Ordinal))
-            .Select(entry => entry.Key)
+            .Order(StringComparer.Ordinal)
             .ToList();
 
         // Shouldly prints the collection on failure, so this names the workflow that re-armed it.
@@ -136,7 +128,7 @@ public class TrustedPublishingWorkflowTests
     public void BuildScript_Should_Not_Import_The_LongLived_NuGetApiKey_Secret()
     {
         // The key arrives as a step output now, not as an imported secret.
-        BuildScript().ShouldNotContain("ImportSecrets");
+        WorkflowSource.BuildScript.ShouldNotContain("ImportSecrets");
     }
 
     [Fact]
@@ -147,7 +139,7 @@ public class TrustedPublishingWorkflowTests
         // tag-triggered publish path that #197 deliberately removed. The wipe lands on the next
         // ./build.cmd, long after the edit, so assert the flag itself rather than trusting the
         // tests to run after a regeneration.
-        BuildScript().ShouldContain("AutoGenerate = false");
+        WorkflowSource.BuildScript.ShouldContain("AutoGenerate = false");
     }
 
     [Fact]
@@ -156,7 +148,7 @@ public class TrustedPublishingWorkflowTests
         // release-please.yml leaves NUGET_API_KEY empty on a dry run, but a skipped step yields an
         // empty string rather than an unset variable — so this static gate, not the emptiness of
         // the key, is what keeps a non-release run from reaching DotNetNuGetPush.
-        var build = BuildScript();
+        var build = WorkflowSource.BuildScript;
         build.ShouldMatch(@"OnlyWhenStatic\(\(\) => IsOnVersionTag\(\)\)");
         build.ShouldMatch(@"OnlyWhenStatic\(\(\) => IsServerBuild\)");
     }

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -69,6 +69,87 @@ internal static class WorkflowSource
             .ToList();
 
     /// <summary>
+    /// A workflow's jobs by name, each mapped to that job's own slice of the file — so a claim
+    /// about a step can be held against the job that owns it rather than against the whole file.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Why it matters: every job gets a fresh workspace. A workflow that ran the build in job A and
+    /// uploaded <c>test-results/</c> from job B would satisfy a file-scoped assertion while
+    /// uploading nothing at all, and with <c>if-no-files-found: ignore</c> pinned on every upload
+    /// (#252) that failure is completely silent — the same "declared but inert" shape #231 was filed
+    /// about, moved to the job boundary. <c>release-please.yml</c> is already a two-job workflow; it
+    /// is correct today only because its build and its upload happen to share the <c>nupkg</c> job.
+    /// </para>
+    /// <para>
+    /// Split by indentation rather than by a YAML parser: <c>jobs:</c> is a top-level key and each
+    /// job is its own two-space-indented key beneath it. That is a smaller approximation than the
+    /// step scan already relied on, and it buys the scoping without a parser dependency the project
+    /// deliberately does not take (see the class remarks).
+    /// </para>
+    /// <para>
+    /// ⚠️ Comments are stripped <em>before</em> the split, not after. These files discuss their own
+    /// wiring at length — <c>release-please.yml</c>'s non-publishing job carries a comment block
+    /// mentioning <c>./build.cmd Pack</c> — so splitting raw text would let a commented-out
+    /// invocation mark a job as one that runs the build.
+    /// </para>
+    /// </remarks>
+    internal static IReadOnlyDictionary<string, string> JobsOf(string fileName)
+    {
+        var jobs = new Dictionary<string, string>(StringComparer.Ordinal);
+        var lines = WithoutComments(Read(fileName), "#").Split('\n');
+
+        var index = Array.FindIndex(lines, l => l.TrimEnd() == "jobs:");
+        if (index < 0)
+        {
+            // No `jobs:` key at all (no workflow here has one today). An empty map contributes no
+            // pairs; the caller's vacuity guard is what stops that from silently emptying the set.
+            return jobs;
+        }
+
+        string? current = null;
+        var body = new List<string>();
+
+        for (index++; index < lines.Length; index++)
+        {
+            var line = lines[index];
+
+            if (JobHeader.Match(line) is { Success: true } header)
+            {
+                if (current is not null)
+                {
+                    jobs[current] = string.Join('\n', body);
+                }
+
+                current = header.Groups["name"].Value;
+                body = [];
+                continue;
+            }
+
+            // A non-blank line back at column 0 is a sibling of `jobs:`, so the block has ended.
+            if (line.Length > 0 && !char.IsWhiteSpace(line[0]))
+            {
+                break;
+            }
+
+            body.Add(line);
+        }
+
+        if (current is not null)
+        {
+            jobs[current] = string.Join('\n', body);
+        }
+
+        return jobs;
+    }
+
+    /// <summary>
+    /// A job's key: exactly two spaces, then a name. Anchored at two so it cannot match the deeper
+    /// keys that make up a job's body — <c>runs-on:</c>, <c>steps:</c>, every <c>with:</c> entry.
+    /// </summary>
+    private static readonly Regex JobHeader = new(@"^  (?<name>[A-Za-z0-9_-]+):", RegexOptions.Compiled);
+
+    /// <summary>
     /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
     /// satisfied by the same text sitting on some other step. Runs from the <c>- name:</c> line to
     /// the start of the next list item, which covers the step's <c>if:</c>, <c>uses:</c> and

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+
+namespace FormCraft.UnitTests.Ci;
+
+/// <summary>
+/// The one reader the <c>Ci/</c> guard suites use to reach the repository's own files (#255): repo
+/// root, workflow enumeration and text, comment stripping, and the scan that isolates a single
+/// workflow step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These suites assert on repository *files* rather than on library behaviour, because the things
+/// they guard run a handful of times a year (a release, a publish) or fail silently (#231's inert
+/// reporting) — so a regression is invisible until it is expensive.
+/// </para>
+/// <para>
+/// The step scan is an approximation of YAML, and a deliberate one: no parser dependency is added
+/// for five files the repo controls, and several assertions work on raw *text* on purpose — see
+/// <see cref="WithoutComments" />, which exists so a documentation edit cannot redden the suite, a
+/// distinction a parsed model discards. What is not deliberate is an approximation living in two
+/// places at once. It did until #255: both suites carried byte-identical copies of everything here,
+/// explanatory comments included, so a fix to one had no way of reaching the other. #205 is the
+/// same pattern with a measured cost — a copied comment carried a factual error into a second file
+/// and hid a render path from coverage.
+/// </para>
+/// </remarks>
+internal static class WorkflowSource
+{
+    /// <summary>The repository root, located once from the test output directory.</summary>
+    internal static string RepoRoot { get; } = LocateRepoRoot();
+
+    internal static string WorkflowsDirectory => Path.Combine(RepoRoot, ".github", "workflows");
+
+    /// <summary>
+    /// Every workflow file by name, read once. These are pure text assertions over files that
+    /// cannot change during a run, so the read is cached rather than repeated per assertion.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> All { get; } = ReadAllWorkflows();
+
+    internal static string Read(string fileName) => All[fileName];
+
+    internal static string ReadBuildScript() =>
+        File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
+
+    /// <summary>
+    /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
+    /// prose — these files carry long explanatory blocks about this very wiring, and without this a
+    /// documentation-only edit would turn the suite red for a reason unrelated to the build, whose
+    /// natural repair under time pressure is to delete the assertion. Only leading-<paramref
+    /// name="marker" /> lines are stripped: a trailing-comment strip would also mangle the
+    /// "https://" in a URL.
+    /// </summary>
+    internal static string WithoutComments(string text, string marker) =>
+        string.Join(
+            '\n',
+            text.Split('\n').Where(line => !line.TrimStart().StartsWith(marker, StringComparison.Ordinal)));
+
+    /// <summary>
+    /// The workflow files whose comment-stripped text matches <paramref name="pattern" />, in a
+    /// stable order. Discovery rather than a hardcoded list, so a workflow added later is held to
+    /// the same contract on the day it lands — the failure mode #231 was about, where
+    /// <c>release-please.yml</c> was left behind by #225 and nobody noticed.
+    /// </summary>
+    internal static IReadOnlyList<string> Matching(string pattern) =>
+        All
+            .Where(entry => Regex.IsMatch(WithoutComments(entry.Value, "#"), pattern))
+            .Select(entry => entry.Key)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// A single step of a workflow, so an assertion about its <c>if:</c> or <c>path:</c> cannot be
+    /// satisfied by the same text sitting on some other step. Runs from the <c>- name:</c> line to
+    /// the start of the next list item, which covers the step's <c>if:</c>, <c>uses:</c> and
+    /// <c>with:</c>.
+    /// </summary>
+    /// <param name="scope">
+    /// The text to search — a whole workflow, or one job's slice of it from
+    /// <see cref="JobsOf" />. Taking text rather than a filename is what lets the same primitive
+    /// serve a whole-file assertion and a job-scoped one.
+    /// </param>
+    /// <param name="stepName">The step's <c>name:</c>, as quoted in the workflow.</param>
+    /// <param name="scopeDescription">
+    /// What <paramref name="scope" /> is, for the failure message only — a filename, or a
+    /// "workflow/job" pair. The scan cannot infer it from text.
+    /// </param>
+    internal static string StepNamed(string scope, string stepName, string? scopeDescription = null)
+    {
+        var lines = scope.Split('\n');
+        var start = Array.FindIndex(
+            lines,
+            l => l.TrimStart().StartsWith($"- name: '{stepName}'", StringComparison.Ordinal));
+        start.ShouldBeGreaterThanOrEqualTo(
+            0,
+            $"{scopeDescription ?? "the searched text"} no longer has a step named '{stepName}'");
+
+        return StepFrom(lines, start);
+    }
+
+    /// <summary>
+    /// The same boundary as <see cref="StepNamed" />, matched on a step's <c>id:</c> instead of its
+    /// name — so an assertion about what a step is gated on cannot be satisfied by another step's
+    /// <c>if:</c>.
+    /// </summary>
+    internal static string StepWithId(string scope, string stepId, string? scopeDescription = null)
+    {
+        var lines = scope.Split('\n');
+        var start = Array.FindIndex(lines, l => l.Contains($"id: {stepId}", StringComparison.Ordinal));
+        start.ShouldBeGreaterThanOrEqualTo(
+            0,
+            $"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
+
+        return StepFrom(lines, start);
+    }
+
+    /// <summary>
+    /// From a step's header line to the start of the next list item, or to the end of
+    /// <paramref name="lines" /> when it is the last step.
+    /// </summary>
+    private static string StepFrom(string[] lines, int start)
+    {
+        var end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith("- ", StringComparison.Ordinal));
+        if (end < 0)
+        {
+            end = lines.Length;
+        }
+
+        return string.Join('\n', lines[start..end]);
+    }
+
+    private static string LocateRepoRoot()
+    {
+        // dir.Parent is DirectoryInfo?, so the variable has to be too — inferring DirectoryInfo
+        // from the initializer would fail the build under TreatWarningsAsErrors.
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "FormCraft.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        dir.ShouldNotBeNull("could not locate FormCraft.sln above the test output directory");
+        return dir.FullName;
+    }
+
+    private static Dictionary<string, string> ReadAllWorkflows() =>
+        Directory
+            .EnumerateFiles(WorkflowsDirectory, "*.*")
+            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(f => Path.GetFileName(f), f => File.ReadAllText(f), StringComparer.Ordinal);
+}

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace FormCraft.UnitTests.Ci;
@@ -37,10 +38,37 @@ internal static class WorkflowSource
     /// </summary>
     internal static IReadOnlyDictionary<string, string> All { get; } = ReadAllWorkflows();
 
-    internal static string Read(string fileName) => All[fileName];
+    /// <summary>
+    /// One workflow's raw text. Asserts rather than throwing a bare <c>KeyNotFoundException</c>:
+    /// these suites exist to tell a reader *which* CI file broke, and a dictionary miss that names
+    /// neither the file nor the directory is the one failure message that cannot do that.
+    /// </summary>
+    internal static string Read(string fileName)
+    {
+        All.TryGetValue(fileName, out var text).ShouldBeTrue(
+            $"{fileName} is not in {WorkflowsDirectory} — found: {string.Join(", ", All.Keys.Order(StringComparer.Ordinal))}");
 
-    internal static string ReadBuildScript() =>
-        File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs"));
+        return text!;
+    }
+
+    /// <summary>
+    /// One workflow, comment-stripped and cached — the text nearly every assertion actually reads.
+    /// Stripping is not free (a <c>Split</c>/<c>Where</c>/<c>Join</c> over the whole file) and was
+    /// being repeated per call site, per assertion, over text that cannot change during a run.
+    /// Going through here also keeps the <c>"#"</c> marker in one place instead of at every caller.
+    /// </summary>
+    internal static string Stripped(string fileName) =>
+        StrippedCache.GetOrAdd(fileName, name => WithoutComments(Read(name), "#"));
+
+    private static readonly ConcurrentDictionary<string, string> StrippedCache = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// <c>build/Build.cs</c>, comment-stripped and cached — the text every <c>Build.cs</c> claim in
+    /// either suite reads. Shared rather than copied: both suites had a byte-identical private
+    /// helper for this, which is the duplication class #255 exists to remove.
+    /// </summary>
+    internal static string BuildScript { get; } =
+        WithoutComments(File.ReadAllText(Path.Combine(RepoRoot, "build", "Build.cs")), "//");
 
     /// <summary>
     /// Drops whole-line comments so a "not referenced" assertion fires on wiring rather than on
@@ -62,9 +90,8 @@ internal static class WorkflowSource
     /// <c>release-please.yml</c> was left behind by #225 and nobody noticed.
     /// </summary>
     internal static IReadOnlyList<string> Matching(string pattern) =>
-        All
-            .Where(entry => Regex.IsMatch(WithoutComments(entry.Value, "#"), pattern))
-            .Select(entry => entry.Key)
+        All.Keys
+            .Where(fileName => Regex.IsMatch(Stripped(fileName), pattern))
             .Order(StringComparer.Ordinal)
             .ToList();
 
@@ -97,13 +124,21 @@ internal static class WorkflowSource
     internal static IReadOnlyDictionary<string, string> JobsOf(string fileName)
     {
         var jobs = new Dictionary<string, string>(StringComparer.Ordinal);
-        var lines = WithoutComments(Read(fileName), "#").Split('\n');
+        var lines = Stripped(fileName).Split('\n');
 
-        var index = Array.FindIndex(lines, l => l.TrimEnd() == "jobs:");
+        // Tolerates a trailing comment (`jobs: # …`), which WithoutComments deliberately leaves
+        // alone — it only drops whole-line comments, so that a URL's "//" survives.
+        var index = Array.FindIndex(lines, l => JobsKey.IsMatch(l));
         if (index < 0)
         {
-            // No `jobs:` key at all (no workflow here has one today). An empty map contributes no
-            // pairs; the caller's vacuity guard is what stops that from silently emptying the set.
+            // This workflow declares no `jobs:` key, so it contributes no pairs.
+            //
+            // ⚠️ An empty map is NOT caught by a caller's whole-set vacuity guard: that only fires
+            // when *every* workflow yields nothing. A single file dropping out is exactly what such
+            // a guard cannot see, so a caller that needs each matched workflow represented has to
+            // assert that per workflow — TestReportingTests.Every_Workflow_That_Runs_Tests_Should_
+            // Contribute_A_Job does, and is what turns a split this reader botched into a red run
+            // rather than a quietly smaller guard set.
             return jobs;
         }
 
@@ -143,10 +178,19 @@ internal static class WorkflowSource
         return jobs;
     }
 
+    /// <summary>The top-level <c>jobs:</c> key, with or without a trailing comment.</summary>
+    private static readonly Regex JobsKey = new(@"^jobs:\s*(#.*)?$", RegexOptions.Compiled);
+
     /// <summary>
     /// A job's key: exactly two spaces, then a name. Anchored at two so it cannot match the deeper
     /// keys that make up a job's body — <c>runs-on:</c>, <c>steps:</c>, every <c>with:</c> entry.
     /// </summary>
+    /// <remarks>
+    /// Recognises the convention every workflow in this repo (and GitHub's own documentation) uses:
+    /// two-space indentation and an unquoted name. A four-space or quoted layout is legal YAML and
+    /// would not split — which is why the caller asserts that each matched workflow contributes a
+    /// job, so an unrecognised layout fails loudly instead of shrinking the guard set.
+    /// </remarks>
     private static readonly Regex JobHeader = new(@"^  (?<name>[A-Za-z0-9_-]+):", RegexOptions.Compiled);
 
     /// <summary>

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -106,4 +106,33 @@ public class WorkflowSourceTests
         step.ShouldContain("uses: NuGet/login@");
         step.ShouldNotContain("- name: 'Run: Pack");
     }
+
+    [Fact]
+    public void JobsOf_Should_Split_A_Multi_Job_Workflow_At_Its_Job_Keys()
+    {
+        // release-please.yml is the fixture because it is a real two-job workflow already in the
+        // repo — the shape that makes a file-scoped assertion a lie. `jobs:` is a top-level key and
+        // each job is a two-space-indented key beneath it, which is the whole rule.
+        var jobs = WorkflowSource.JobsOf("release-please.yml");
+
+        jobs.Keys.Order(StringComparer.Ordinal).ShouldBe(["nupkg", "release-please"]);
+
+        // The point of the split: the build invocation belongs to `nupkg` alone, so an assertion
+        // about the upload can be held against that same job rather than against the whole file.
+        jobs["nupkg"].ShouldContain("./build.cmd Pack");
+
+        // And `release-please` reads as test-running only if comments survive the split — this file
+        // *discusses* `./build.cmd Pack` in a comment block inside that job. Stripping before
+        // splitting is what keeps a commented-out invocation from marking a job as running the build.
+        jobs["release-please"].ShouldNotContain("./build.cmd");
+    }
+
+    [Fact]
+    public void JobsOf_Should_Return_One_Job_For_A_SingleJob_Workflow()
+    {
+        // The other half of the rule: the split must not invent jobs out of the deeper keys that
+        // make up a job's body (`runs-on:`, `steps:`, every `with:` entry), all of which are keys
+        // too — just not at a job's indentation.
+        WorkflowSource.JobsOf("ci.yml").Keys.ShouldBe(["build-and-test"]);
+    }
 }

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -1,0 +1,109 @@
+namespace FormCraft.UnitTests.Ci;
+
+/// <summary>
+/// Covers <see cref="WorkflowSource" />, the reader the <c>Ci/</c> guard suites share (#255).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this type, <c>TrustedPublishingWorkflowTests</c> and <c>TestReportingTests</c> each carried
+/// their own byte-identical copy of repo-root location, workflow enumeration, comment stripping and
+/// the step scan — comments included. Nothing tested those copies directly; they were only ever
+/// exercised through the assertions built on top of them, so a change to one had no way of
+/// announcing that the other had drifted. #205 records what that costs: a copied test comment
+/// propagated a factual error and hid a whole render path from coverage.
+/// </para>
+/// <para>
+/// The step scan and the job split are deliberate approximations of YAML — the project has no parser
+/// dependency and the assertions above them work on raw text on purpose (see
+/// <see cref="WorkflowSource.WithoutComments" />). An approximation owned by nobody is the actual
+/// hazard, so this file is where its edges are pinned.
+/// </para>
+/// </remarks>
+public class WorkflowSourceTests
+{
+    [Fact]
+    public void All_Should_Contain_Every_Workflow_File_On_Disk()
+    {
+        // The enumeration is the foundation every "no workflow offends" assertion rests on, and each
+        // of those is satisfied trivially by a set that is missing the offender. A workflow added as
+        // .yaml, or one this reader silently failed to pick up, would leave the whole family green.
+        var onDisk = Directory
+            .EnumerateFiles(WorkflowSource.WorkflowsDirectory, "*.*")
+            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+            .Select(f => Path.GetFileName(f))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        onDisk.ShouldNotBeEmpty("no workflow files found — the comparison would pass vacuously");
+        WorkflowSource.All.Keys.Order(StringComparer.Ordinal).ShouldBe(onDisk);
+    }
+
+    [Fact]
+    public void WithoutComments_Should_Drop_Whole_Line_Comments_But_Keep_A_Url()
+    {
+        // The two halves are one decision. Whole-line stripping is what stops a documentation-only
+        // edit from reddening a "not referenced" assertion — these workflows carry comment blocks
+        // longer than the wiring they describe. Stopping there, rather than also stripping trailing
+        // comments, is what keeps the `//` in a URL intact.
+        const string Text = """
+                            # a leading comment
+                              # an indented comment
+                            uses: actions/checkout@v7 # see https://github.com/actions/checkout
+                            """;
+
+        var stripped = WorkflowSource.WithoutComments(Text, "#");
+
+        stripped.ShouldNotContain("a leading comment");
+        stripped.ShouldNotContain("an indented comment");
+        stripped.ShouldContain("https://github.com/actions/checkout");
+    }
+
+    [Fact]
+    public void WithoutComments_Should_Take_The_Marker_It_Is_Given()
+    {
+        // Both markers are in use: `#` over the workflows, `//` over Build.cs. The C# case is the
+        // one where the URL clause above earns its keep twice, since there the marker and the thing
+        // that must survive are the same two characters.
+        const string Text = """
+                            // a leading comment
+                            var url = "https://nuget.org";
+                            """;
+
+        var stripped = WorkflowSource.WithoutComments(Text, "//");
+
+        stripped.ShouldNotContain("a leading comment");
+        stripped.ShouldContain("https://nuget.org");
+    }
+
+    [Fact]
+    public void StepNamed_Should_Return_Only_That_Steps_Own_Lines()
+    {
+        // The whole reason the scan exists: an assertion about one step's `if:` or `path:` must not
+        // be satisfiable by the same text on a neighbouring step. release-please.yml is the fixture
+        // because its upload step is directly followed by another `- name:` step.
+        var workflow = WorkflowSource.WithoutComments(WorkflowSource.Read("release-please.yml"), "#");
+
+        var step = WorkflowSource.StepNamed(workflow, "Publish: test-results");
+
+        step.ShouldContain("if-no-files-found: ignore");
+        step.ShouldNotContain("Attach packages to the GitHub Release");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Return_Only_That_Steps_Own_Lines()
+    {
+        // Same boundary, matched on `id:` instead of `- name:` — the variant #226 depends on, where
+        // a claim about the login step's gating must not be answerable by a later step's text.
+        //
+        // Read raw, not comment-stripped: the scope is the caller's to choose, and this path is
+        // deliberately given the unstripped file (as #226's assertions always have). So the slice
+        // does carry the explanatory block that follows the step — which is why the boundary is
+        // asserted against the *next step's header*, the thing the scan actually has to exclude,
+        // rather than against prose that legitimately sits inside the slice.
+        var step = WorkflowSource.StepWithId(WorkflowSource.Read("release-please.yml"), "login");
+
+        step.ShouldContain("uses: NuGet/login@");
+        step.ShouldNotContain("- name: 'Run: Pack");
+    }
+}

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -27,15 +27,22 @@ public class WorkflowSourceTests
         // The enumeration is the foundation every "no workflow offends" assertion rests on, and each
         // of those is satisfied trivially by a set that is missing the offender. A workflow added as
         // .yaml, or one this reader silently failed to pick up, would leave the whole family green.
+        //
+        // Compared against an UNFILTERED listing on purpose. Re-stating the reader's own `.yml`/
+        // `.yaml` predicate here would make the two sides move together — drop `.yaml` from the
+        // reader and the copy drops it too, so the assertion stays green while the guard family
+        // quietly stops seeing those files. That is the one regression this test exists to catch,
+        // so the expectation has to come from somewhere the reader does not decide: the directory.
         var onDisk = Directory
-            .EnumerateFiles(WorkflowSource.WorkflowsDirectory, "*.*")
-            .Where(f => f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
-                     || f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+            .EnumerateFiles(WorkflowSource.WorkflowsDirectory)
             .Select(f => Path.GetFileName(f))
             .Order(StringComparer.Ordinal)
             .ToList();
 
         onDisk.ShouldNotBeEmpty("no workflow files found — the comparison would pass vacuously");
+
+        // Every file in .github/workflows is a workflow; if a non-YAML file is ever added there,
+        // this is meant to go red so a human decides whether the reader should skip it.
         WorkflowSource.All.Keys.Order(StringComparer.Ordinal).ShouldBe(onDisk);
     }
 
@@ -105,6 +112,26 @@ public class WorkflowSourceTests
 
         step.ShouldContain("uses: NuGet/login@");
         step.ShouldNotContain("- name: 'Run: Pack");
+    }
+
+    [Fact]
+    public void Matching_Should_Find_The_Workflows_That_Invoke_The_Build()
+    {
+        // The discovery primitive the whole TestReportingTests family rests on: it decides which
+        // workflows are held to the artifact contract, so a regression here does not redden
+        // anything — it just quietly shrinks the set being checked.
+        var matched = WorkflowSource.Matching(@"\./build\.(cmd|sh|ps1)\s+(Test|Pack|Continuous)\b");
+
+        matched.ShouldBe(["ci.yml", "continuous.yml", "release-please.yml"]);
+    }
+
+    [Fact]
+    public void Matching_Should_Not_Be_Satisfied_By_A_Commented_Out_Invocation()
+    {
+        // The other half of the same decision, and the reason Matching strips before it matches.
+        // release-please.yml discusses `./build.cmd Continuous` in prose; ci.yml's comment block
+        // names `**/TestResults/`, a glob its wiring deliberately no longer uses. Neither may count.
+        WorkflowSource.Matching(@"\*\*/TestResults/").ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Implements #255.

Closes #255.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

### Plan
- [x] Task 1: Extract `WorkflowSource` and move `TestReportingTests` onto it
- [x] Task 2: Move `TrustedPublishingWorkflowTests` onto the shared reader
- [x] Task 3: Split workflows into jobs and scope the test-results assertions to one

### Code review

A review over `dev...HEAD` raised 12 findings; 9 are fixed in `test(ci): address code-review findings…`:

- **Job scoping could silently drop a whole workflow.** `Matching` finds a file, `JobsOf` fails to
  split it, and it contributes no pairs — invisible to the whole-set vacuity guard, which only fires
  when *every* workflow yields nothing. That was a strict regression against the file-scoped code,
  which could not lose a workflow. Closed by `Every_Workflow_That_Runs_Tests_Should_Contribute_A_Job`,
  asserting the covered set equals `Matching(InvocationPattern)`. Verified non-vacuous: making
  `ci.yml` unsplittable (`"jobs":`) turns it red while all five upload assertions stay green — which
  is exactly the hole.
- **`BuildScript()` was copy-pasted verbatim into both suites**, doc comment included — the very
  duplication class this PR exists to remove, introduced by it. Now a cached `WorkflowSource.BuildScript`.
- **Comment stripping ran two-to-three times per file** and the `"#"` marker was repeated at five call
  sites. Now one cached `WorkflowSource.Stripped(fileName)`.
- **`All_Should_Contain_Every_Workflow_File_On_Disk` re-implemented the predicate it tested**, so both
  sides moved together and it could never catch the `.yaml`-dropped regression its comment promised.
  Now compared against an unfiltered directory listing.
- **`Matching` had no test at all** despite deciding whether the whole suite is vacuous. Two added,
  including one pinning that a commented-out invocation must not match.
- **`Read` threw a bare `KeyNotFoundException`** naming neither file nor directory, in a suite whose
  value is saying which CI file broke. Now asserts with the filename and the available keys.
- **`JobsOf` rejected `jobs:` with a trailing comment** (`WithoutComments` only strips whole lines).
- **The `jobs:`-not-found comment was factually wrong** about the guard protecting it — corrected, in
  a file whose premise (#205) is that a wrong copied comment costs coverage.

## Follow-ups

Deferred deliberately — real, but outside this issue's plan (which is scoped to `TestReportingTests`
and explicitly says "no change to *what* either suite asserts, beyond adding the job scoping"):

- **Job-scope `TrustedPublishingWorkflowTests` too.** `id-token: write` is a *job-level* permission on
  `nupkg` (`release-please.yml:100-102`), but is asserted file-wide — move it to the wrong job and the
  test still passes while OIDC is unavailable where `NuGet/login` runs. Same for
  `steps.login.outputs.NUGET_API_KEY`, which only resolves inside the job owning the `login` step.
  Higher consequence than the suite this PR rescoped, and now a one-line change per assertion.
- **`StepWithId` matches `id: <x>` as an unanchored substring**, so `id: login` also matches
  `id: login-legacy`/`id: login2`, and the first matching line wins. Pre-existing (moved unchanged per
  the plan); tightening it risks changing what #226's assertions bind to, so it wants its own change.
- **Uniform offender reporting.** A job missing the upload step yields one clean failure plus four
  noisier ones thrown from inside `StepNamed`. A `TryStepNamed` returning `string?` would let all five
  report offenders the same way.




