### PR TITLE
test(ci): make the shared step scan bind to exactly one step (#267)

### DIFF
--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -190,13 +190,33 @@ public class TestReportingTests
     /// <remarks>
     /// Non-asserting since #267. The asserting form threw from in here, so deleting one upload step
     /// reddened five tests: the one whose actual subject is "every such job uploads" named the
-    /// offending job cleanly, and the other four died inside this helper — four extra failures
-    /// describing one root cause, presented as a fault in the shared reader rather than in the
-    /// workflow. Each caller below now treats absence as an offender of its own, so all five report
-    /// the same `<c>workflow / job</c>` pair and the count of red tests matches the count of causes.
+    /// offending job cleanly, and the other four died inside this helper, presented as a fault in the
+    /// shared reader rather than in the workflow.
+    /// <para>
+    /// What changed is the <em>message</em>, not the count. Measured on <c>ci.yml</c>: five tests were
+    /// red before and five are red after — but where four used to read
+    /// <c>Array.FindIndex(…) should be greater than or equal to 0 but was -1</c>, all five now name
+    /// <c>ci.yml / build-and-test</c> as an offender. The count cannot fall; every one of these claims
+    /// is genuinely unsatisfied by a job with no upload step.
+    /// </para>
     /// </remarks>
     private static string? UploadStep(TestRunningJob job) =>
         WorkflowSource.TryStepNamed(job.Text, UploadStepName);
+
+    /// <summary>
+    /// Whether <paramref name="job" />'s upload step fails <paramref name="claim" /> — including by
+    /// not existing at all.
+    /// </summary>
+    /// <remarks>
+    /// The absence rule lives here, once, rather than inline at each assertion below. Restating
+    /// <c>is not { } step ||</c> per call site puts a vacuity hole one forgotten clause away: written
+    /// as <c>is { } step &amp;&amp;</c>, a missing step reads as *satisfying* the claim, which is the
+    /// silence this file guards against everywhere else (see <see cref="JobsThatRunTests" />). Absence
+    /// offends every claim here — a step that is not there has no <c>if: always()</c>, and equally
+    /// does not "avoid the stale glob" in any sense worth being green about.
+    /// </remarks>
+    private static bool UploadStepFails(TestRunningJob job, Func<string, bool> claim) =>
+        UploadStep(job) is not { } step || !claim(step);
 
     [Fact]
     public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
@@ -347,10 +367,8 @@ public class TestReportingTests
         // one worth preserving, and it is exactly the path a bare step skips. Microsoft.Testing.
         // Platform prints only a summary line to stdout, so without this a red CI run leaves no
         // record of *which* assertion failed — a cost that was paid for real during #200.
-        // A job with no upload step at all offends this too — there is no `if: always()` on a step
-        // that is not there. Reported rather than thrown, so this test names the job like the others.
         var offenders = JobsThatRunTests()
-            .Where(j => UploadStep(j) is not { } step || !step.Contains("if: always()", StringComparison.Ordinal))
+            .Where(j => UploadStepFails(j, s => s.Contains("if: always()", StringComparison.Ordinal)))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -365,8 +383,7 @@ public class TestReportingTests
         // re-introducing the very globs the next test rejects. All three steps upload exactly one
         // directory, so that is what is pinned.
         var offenders = JobsThatRunTests()
-            .Where(j => UploadStep(j) is not { } step
-                     || !step.Split('\n').Any(line => line.Trim() == "path: test-results"))
+            .Where(j => UploadStepFails(j, s => s.Split('\n').Any(line => line.Trim() == "path: test-results")))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -380,12 +397,12 @@ public class TestReportingTests
         // created. --results-directory moved them, so that glob now matches nothing on every run —
         // the same declared-and-inert shape this issue exists to remove, just one file over. Every
         // target that tests routes through Test, so there is no run in which it could match again.
-        // Absence offends here too, even though a step that is not there points at nothing. Today a
-        // missing step makes this test red by throwing, so letting it read as vacuously satisfied
-        // would trade a loud failure for a quieter suite — the opposite of the point. The claim being
-        // kept is "every such job has an upload step, and it does not glob the stale path".
+        // The claim is inverted, so it reads "the step exists AND avoids the stale glob". Absence
+        // offends it, even though a step that is not there points at nothing: a missing step makes
+        // this test red today by throwing, so letting it read as vacuously satisfied would trade a
+        // loud failure for a quieter suite — the opposite of the point.
         var offenders = JobsThatRunTests()
-            .Where(j => UploadStep(j) is not { } step || step.Contains("**/TestResults/", StringComparison.Ordinal))
+            .Where(j => UploadStepFails(j, s => !s.Contains("**/TestResults/", StringComparison.Ordinal)))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -400,8 +417,7 @@ public class TestReportingTests
         // real one gets missed. The opposite risk — an *empty* directory passing unremarked — is
         // covered in the build rather than here, by the Assert.NotEmpty on the trx.
         var offenders = JobsThatRunTests()
-            .Where(j => UploadStep(j) is not { } step
-                     || !step.Contains("if-no-files-found: ignore", StringComparison.Ordinal))
+            .Where(j => UploadStepFails(j, s => s.Contains("if-no-files-found: ignore", StringComparison.Ordinal)))
             .ToList();
 
         offenders.ShouldBeEmpty();

--- a/FormCraft.UnitTests/Ci/TestReportingTests.cs
+++ b/FormCraft.UnitTests/Ci/TestReportingTests.cs
@@ -184,10 +184,19 @@ public class TestReportingTests
 
     /// <summary>
     /// The upload step as it appears <em>within that job</em> — so an assertion about it cannot be
-    /// answered by an identically-named step sitting in a sibling job.
+    /// answered by an identically-named step sitting in a sibling job — or <c>null</c> when that job
+    /// has no such step.
     /// </summary>
-    private static string UploadStep(TestRunningJob job) =>
-        WorkflowSource.StepNamed(job.Text, UploadStepName, job.ToString());
+    /// <remarks>
+    /// Non-asserting since #267. The asserting form threw from in here, so deleting one upload step
+    /// reddened five tests: the one whose actual subject is "every such job uploads" named the
+    /// offending job cleanly, and the other four died inside this helper — four extra failures
+    /// describing one root cause, presented as a fault in the shared reader rather than in the
+    /// workflow. Each caller below now treats absence as an offender of its own, so all five report
+    /// the same `<c>workflow / job</c>` pair and the count of red tests matches the count of causes.
+    /// </remarks>
+    private static string? UploadStep(TestRunningJob job) =>
+        WorkflowSource.TryStepNamed(job.Text, UploadStepName);
 
     [Fact]
     public void BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores()
@@ -320,8 +329,12 @@ public class TestReportingTests
     {
         // In that same job, not merely somewhere in the file: the artifact is uploaded from the
         // workspace the build filled, and a sibling job's workspace is a different one.
+        //
+        // Asked through the same primitive as the four tests below rather than by a raw substring
+        // search, so "present" means the one thing here and there — a step the scan can actually
+        // isolate, not merely the text of a `- name:` line appearing somewhere in the job.
         var missing = JobsThatRunTests()
-            .Where(j => !j.Text.Contains($"- name: '{UploadStepName}'", StringComparison.Ordinal))
+            .Where(j => UploadStep(j) is null)
             .ToList();
 
         missing.ShouldBeEmpty();
@@ -334,8 +347,10 @@ public class TestReportingTests
         // one worth preserving, and it is exactly the path a bare step skips. Microsoft.Testing.
         // Platform prints only a summary line to stdout, so without this a red CI run leaves no
         // record of *which* assertion failed — a cost that was paid for real during #200.
+        // A job with no upload step at all offends this too — there is no `if: always()` on a step
+        // that is not there. Reported rather than thrown, so this test names the job like the others.
         var offenders = JobsThatRunTests()
-            .Where(j => !UploadStep(j).Contains("if: always()", StringComparison.Ordinal))
+            .Where(j => UploadStep(j) is not { } step || !step.Contains("if: always()", StringComparison.Ordinal))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -350,9 +365,8 @@ public class TestReportingTests
         // re-introducing the very globs the next test rejects. All three steps upload exactly one
         // directory, so that is what is pinned.
         var offenders = JobsThatRunTests()
-            .Where(j => !UploadStep(j)
-                .Split('\n')
-                .Any(line => line.Trim() == "path: test-results"))
+            .Where(j => UploadStep(j) is not { } step
+                     || !step.Split('\n').Any(line => line.Trim() == "path: test-results"))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -366,8 +380,12 @@ public class TestReportingTests
         // created. --results-directory moved them, so that glob now matches nothing on every run —
         // the same declared-and-inert shape this issue exists to remove, just one file over. Every
         // target that tests routes through Test, so there is no run in which it could match again.
+        // Absence offends here too, even though a step that is not there points at nothing. Today a
+        // missing step makes this test red by throwing, so letting it read as vacuously satisfied
+        // would trade a loud failure for a quieter suite — the opposite of the point. The claim being
+        // kept is "every such job has an upload step, and it does not glob the stale path".
         var offenders = JobsThatRunTests()
-            .Where(j => UploadStep(j).Contains("**/TestResults/", StringComparison.Ordinal))
+            .Where(j => UploadStep(j) is not { } step || step.Contains("**/TestResults/", StringComparison.Ordinal))
             .ToList();
 
         offenders.ShouldBeEmpty();
@@ -382,8 +400,8 @@ public class TestReportingTests
         // real one gets missed. The opposite risk — an *empty* directory passing unremarked — is
         // covered in the build rather than here, by the Assert.NotEmpty on the trx.
         var offenders = JobsThatRunTests()
-            .Where(j => !UploadStep(j)
-                .Contains("if-no-files-found: ignore", StringComparison.Ordinal))
+            .Where(j => UploadStep(j) is not { } step
+                     || !step.Contains("if-no-files-found: ignore", StringComparison.Ordinal))
             .ToList();
 
         offenders.ShouldBeEmpty();

--- a/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
+++ b/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
@@ -19,9 +19,9 @@ public class TrustedPublishingWorkflowTests
     /// same expression sitting on some other step.
     /// </summary>
     /// <remarks>
-    /// Deliberately reads the workflow *unstripped*. The scan runs from the <c>id:</c> line to the
-    /// next list item, so the slice carries whatever explanatory comments sit between the step and
-    /// its successor — harmless here, because every claim below is about a line these files spell
+    /// Deliberately reads the workflow *unstripped*. The scan runs from the step's own <c>- </c> list
+    /// item to the next one, so the slice carries whatever explanatory comments sit between the step
+    /// and its successor — harmless here, because every claim below is about a line these files spell
     /// as wiring (<c>if:</c>, <c>uses:</c>) rather than as prose.
     /// </remarks>
     private static string StepWithId(string workflowFile, string stepId) =>

--- a/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
+++ b/FormCraft.UnitTests/Ci/TrustedPublishingWorkflowTests.cs
@@ -19,10 +19,19 @@ public class TrustedPublishingWorkflowTests
     /// same expression sitting on some other step.
     /// </summary>
     /// <remarks>
-    /// Deliberately reads the workflow *unstripped*. The scan runs from the step's own <c>- </c> list
-    /// item to the next one, so the slice carries whatever explanatory comments sit between the step
-    /// and its successor — harmless here, because every claim below is about a line these files spell
-    /// as wiring (<c>if:</c>, <c>uses:</c>) rather than as prose.
+    /// Deliberately reads the workflow *unstripped*. The scan runs from the step's own list item to
+    /// the next one, so the slice carries whatever explanatory comments sit between the step and its
+    /// successor.
+    /// <para>
+    /// ⚠️ That is <b>not</b> harmless, and this remark used to claim it was. The login step's slice
+    /// carries a comment block that mentions <c>release_created</c> in prose, so
+    /// <see cref="ReleaseWorkflow_Should_Gate_The_Login_On_A_Created_Release" /> — a whole-slice
+    /// <c>ShouldContain</c> — is satisfied by that comment alone and would stay green if the step's
+    /// <c>if:</c> were deleted outright, which is the #226 regression it exists to catch. Pre-existing
+    /// (the prose sat inside the slice before #267 moved its start), not introduced here, and left
+    /// standing only because narrowing it changes *what* this suite asserts. The tests that go through
+    /// <see cref="StepCondition" /> read the <c>if:</c> line alone and are unaffected.
+    /// </para>
     /// </remarks>
     private static string StepWithId(string workflowFile, string stepId) =>
         WorkflowSource.StepWithId(WorkflowSource.Read(workflowFile), stepId, workflowFile);

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -212,9 +212,9 @@ internal static class WorkflowSource
     internal static string StepNamed(string scope, string stepName, string? scopeDescription = null)
     {
         var step = TryStepNamed(scope, stepName);
-        step.ShouldNotBeNull($"{scopeDescription ?? "the searched text"} no longer has a step named '{stepName}'");
 
-        return step!;
+        return step.ShouldNotBeNull(
+            $"{scopeDescription ?? "the searched text"} no longer has a step named '{stepName}'");
     }
 
     /// <summary>
@@ -254,10 +254,18 @@ internal static class WorkflowSource
     /// on a version that never reached nuget.org.
     /// </para>
     /// <para>
-    /// Two steps claiming one id fails loudly instead of resolving to the first. That is invalid in
-    /// GitHub Actions, so it should never happen — but anchoring the match buys nothing if an
-    /// ambiguous one still quietly picks a winner, which is the same silent wrong answer wearing a
-    /// different hat.
+    /// Two steps claiming one id fails loudly instead of resolving to the first: anchoring the match
+    /// buys nothing if an ambiguous one still quietly picks a winner, which is the same silent wrong
+    /// answer wearing a different hat.
+    /// </para>
+    /// <para>
+    /// ⚠️ Step ids are unique per <b>job</b>, not per workflow, so this is <em>not</em> a claim that
+    /// the workflow is invalid. A caller that passes a whole file as the scope — as
+    /// <c>TrustedPublishingWorkflowTests</c> does — can therefore see two legitimate matches from two
+    /// different jobs, and would fail here on a perfectly valid config. That caller wants
+    /// <see cref="JobsOf" /> scoping, which <c>TestReportingTests</c> has had since #255 and which is
+    /// tracked for this suite on #198; until then the failure is loud and explains itself, which is
+    /// the safer half of the trade for a guard on the release path.
     /// </para>
     /// <para>
     /// The slice starts at the step's own <c>- </c> list item rather than at the <c>id:</c> line, so
@@ -270,9 +278,9 @@ internal static class WorkflowSource
     internal static string StepWithId(string scope, string stepId, string? scopeDescription = null)
     {
         var step = StepWithIdOrNull(scope, stepId, scopeDescription);
-        step.ShouldNotBeNull($"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
 
-        return step!;
+        return step.ShouldNotBeNull(
+            $"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
     }
 
     /// <summary>
@@ -313,15 +321,16 @@ internal static class WorkflowSource
     }
 
     /// <summary>
-    /// The indexes of every line in <paramref name="lines" /> whose trimmed text is exactly the key
-    /// <c>id: &lt;stepId&gt;</c>.
+    /// The indexes of every line in <paramref name="lines" /> that declares the key
+    /// <c>id: &lt;stepId&gt;</c> and nothing else — optionally opening a list item, and optionally
+    /// followed by a whitespace-separated <c># comment</c>.
     /// </summary>
     /// <remarks>
     /// Every index, not the first: the count is what tells <see cref="StepWithId" /> apart absent,
     /// found, and ambiguous — and only the last of those can pass itself off as the middle one.
-    /// Trailing whitespace and a trailing <c># comment</c> are tolerated because
-    /// <see cref="WithoutComments" /> drops only whole-line comments (so a URL's <c>//</c> survives),
-    /// and callers may hand over unstripped text anyway — <c>TrustedPublishingWorkflowTests</c> does.
+    /// A trailing <c># comment</c> is tolerated because <see cref="WithoutComments" /> drops only
+    /// whole-line comments (so a URL's <c>//</c> survives), and callers may hand over unstripped text
+    /// anyway — <c>TrustedPublishingWorkflowTests</c> does.
     /// </remarks>
     private static List<int> LinesDeclaring(string[] lines, string stepId)
     {
@@ -330,11 +339,18 @@ internal static class WorkflowSource
         // for the handful of scans a run performs. The shape mirrors JobsKey's, trailing-comment
         // tolerance included.
         //
-        // The optional `- ` covers `- id: login`, where the id is the list item's first key. That is
+        // The optional dash covers `- id: login`, where the id is the list item's first key. That is
         // legal and common, no workflow here currently writes it, and an anchored `^id:` would lose
         // it — reporting a step that is plainly present as absent. Loud, unlike the bug this replaces,
         // but still a wrong answer, and the walk-back stops on that same line as the step's header.
-        var key = new Regex($@"^(- )?id:\s*{Regex.Escape(stepId)}\s*(#.*)?$");
+        // `-\s+` rather than `- ` because `-  id:` and `-<tab>id:` are the same YAML.
+        //
+        // ⚠️ The comment clause requires WHITESPACE before the `#`, and that is the whole point of
+        // spelling it `\s+#` rather than `\s*#`: YAML only starts a comment after whitespace, so
+        // `id: login#1` is a single scalar naming a *different* step. With `\s*` the `#.*` swallowed
+        // the `#1` and a search for `login` bound to it — a longer id re-entering through the very
+        // clause added to keep longer ids out.
+        var key = new Regex($@"^(?:-\s+)?id:\s*{Regex.Escape(stepId)}(?:\s+#.*)?\s*$");
 
         var matches = new List<int>();
         for (var index = 0; index < lines.Length; index++)
@@ -349,23 +365,66 @@ internal static class WorkflowSource
     }
 
     /// <summary>
-    /// The nearest line at or above <paramref name="from" /> that opens a list item, or <c>-1</c> when
-    /// there is none — the step's own <c>- </c> header.
+    /// The header of the list item that <em>contains</em> the key at <paramref name="from" />, or
+    /// <c>-1</c> when that key belongs to no list item.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Starts <em>at</em> <paramref name="from" /> rather than above it, so an id written on the list
     /// item itself (<c>- id: login</c>) finds that line instead of running past it into the previous
     /// step. Returning <c>-1</c> rather than falling back to 0 is what makes a malformed scope read as
     /// absent: an <c>id:</c> under some <c>env:</c> block belongs to no step, and a slice from the top
     /// of the file would answer a question the scope cannot answer.
+    /// </para>
+    /// <para>
+    /// ⚠️ Indentation is what makes this <em>containment</em> rather than "the nearest dash above",
+    /// and the difference is not academic — the loose version reintroduced the defect this whole
+    /// change removes, by the other door. A list item indented at or deeper than the key is nested
+    /// <em>inside</em> the step (a sequence under <c>with:</c>, a bullet in a block scalar), and
+    /// stopping on it returns a fragment of a step as the step. A plain key indented shallower is a
+    /// container the key sits under, and reaching one means no header intervened — so the search ends
+    /// there rather than crossing a job boundary to adopt the previous job's last step.
+    /// </para>
     /// </remarks>
     private static int HeaderAtOrAbove(string[] lines, int from)
     {
-        for (var index = from; index >= 0; index--)
+        // The matched line may itself be the header, in which case there is nothing to walk back to.
+        if (OpensListItem(lines[from]))
         {
-            if (lines[index].TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            return from;
+        }
+
+        var depth = IndentOf(lines[from]);
+
+        for (var index = from - 1; index >= 0; index--)
+        {
+            var line = lines[index];
+            var trimmed = line.Trim();
+
+            // Blank lines and comments carry no structure and sit at whatever indentation a human
+            // felt like — release-please.yml's own step comments are indented to their step's dash.
+            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
             {
-                return index;
+                continue;
+            }
+
+            var indent = IndentOf(line);
+
+            if (OpensListItem(line))
+            {
+                if (indent < depth)
+                {
+                    return index;
+                }
+
+                // Nested deeper than the key: part of this step's own value, not its header.
+                continue;
+            }
+
+            if (indent < depth)
+            {
+                // A containing key, reached without passing a header — the key is not in a list item.
+                return -1;
             }
         }
 
@@ -373,12 +432,46 @@ internal static class WorkflowSource
     }
 
     /// <summary>
-    /// From a step's header line to the start of the next list item, or to the end of
+    /// Whether a line opens a YAML list item: a <c>-</c> that is alone on the line or followed by
+    /// whitespace.
+    /// </summary>
+    /// <remarks>
+    /// Not <c>StartsWith("- ")</c>. `-` alone (the item's keys starting on the next line) and
+    /// <c>-&lt;tab&gt;</c> are the same YAML, and missing them made the walk-back skip a real header
+    /// and return the <em>previous</em> step — silently, on the primitive #226 depends on. Excludes
+    /// <c>---</c>, a document separator rather than an item.
+    /// </remarks>
+    private static bool OpensListItem(string line)
+    {
+        var trimmed = line.TrimStart();
+
+        return trimmed.StartsWith('-')
+            && (trimmed.Length == 1 || char.IsWhiteSpace(trimmed[1]));
+    }
+
+    /// <summary>The line's leading-whitespace width — its YAML nesting depth.</summary>
+    private static int IndentOf(string line) => line.Length - line.TrimStart().Length;
+
+    /// <summary>
+    /// From a step's header line to the start of the next <em>sibling</em> list item, or to the end of
     /// <paramref name="lines" /> when it is the last step.
     /// </summary>
+    /// <remarks>
+    /// Sibling, not merely "next list item": a sequence nested inside the step — <c>args:</c> entries,
+    /// a bullet in a <c>path: |</c> block — is part of the step's own value, and ending there returns a
+    /// truncated fragment as the whole step. That direction of error is the dangerous one for the
+    /// negative assertions this reader serves: a <c>ShouldNotContain</c> over a slice cut short passes
+    /// because the text it rejects fell outside the fragment, not because the step is clean. Depth is
+    /// the same rule <see cref="HeaderAtOrAbove" /> walks back by, applied forwards.
+    /// </remarks>
     private static string StepFrom(string[] lines, int start)
     {
-        var end = Array.FindIndex(lines, start + 1, l => l.TrimStart().StartsWith("- ", StringComparison.Ordinal));
+        var depth = IndentOf(lines[start]);
+        var end = Array.FindIndex(
+            lines,
+            start + 1,
+            l => OpensListItem(l) && IndentOf(l) <= depth);
+
         if (end < 0)
         {
             end = lines.Length;

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -243,6 +243,13 @@ internal static class WorkflowSource
     /// ambiguous one still quietly picks a winner, which is the same silent wrong answer wearing a
     /// different hat.
     /// </para>
+    /// <para>
+    /// The slice starts at the step's own <c>- </c> list item rather than at the <c>id:</c> line, so
+    /// this returns the same shape <see cref="StepNamed" /> does for the same step — its <c>- name:</c>
+    /// where it has one, its <c>- uses:</c> where it does not. Starting at the <c>id:</c> excluded the
+    /// step's own name, which made the two primitives disagree about what "a step" is and left this
+    /// one unable to assert anything about the name at all.
+    /// </para>
     /// </remarks>
     internal static string StepWithId(string scope, string stepId, string? scopeDescription = null)
     {
@@ -252,10 +259,16 @@ internal static class WorkflowSource
         matches.Count.ShouldBeLessThan(
             2,
             $"{scopeDescription ?? "the searched text"} has {matches.Count} steps claiming `id: {stepId}` — an ambiguous id cannot be resolved to one step");
-        matches.ShouldNotBeEmpty(
+
+        // Both "no such id" and "an id belonging to no list item" are absence: the second is a
+        // malformed scope, and slicing it from line 0 would hand back the file's preamble dressed up
+        // as a step. One message covers both because the caller's remedy is the same either way.
+        var header = matches.Count == 1 ? HeaderAtOrAbove(lines, matches[0]) : -1;
+        header.ShouldBeGreaterThanOrEqualTo(
+            0,
             $"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
 
-        return StepFrom(lines, matches[0]);
+        return StepFrom(lines, header);
     }
 
     /// <summary>
@@ -275,7 +288,12 @@ internal static class WorkflowSource
         // the id being looked for, and RegexOptions.Compiled pays its cost up front — strictly a loss
         // for the handful of scans a run performs. The shape mirrors JobsKey's, trailing-comment
         // tolerance included.
-        var key = new Regex($@"^id:\s*{Regex.Escape(stepId)}\s*(#.*)?$");
+        //
+        // The optional `- ` covers `- id: login`, where the id is the list item's first key. That is
+        // legal and common, no workflow here currently writes it, and an anchored `^id:` would lose
+        // it — reporting a step that is plainly present as absent. Loud, unlike the bug this replaces,
+        // but still a wrong answer, and the walk-back stops on that same line as the step's header.
+        var key = new Regex($@"^(- )?id:\s*{Regex.Escape(stepId)}\s*(#.*)?$");
 
         var matches = new List<int>();
         for (var index = 0; index < lines.Length; index++)
@@ -287,6 +305,30 @@ internal static class WorkflowSource
         }
 
         return matches;
+    }
+
+    /// <summary>
+    /// The nearest line at or above <paramref name="from" /> that opens a list item, or <c>-1</c> when
+    /// there is none — the step's own <c>- </c> header.
+    /// </summary>
+    /// <remarks>
+    /// Starts <em>at</em> <paramref name="from" /> rather than above it, so an id written on the list
+    /// item itself (<c>- id: login</c>) finds that line instead of running past it into the previous
+    /// step. Returning <c>-1</c> rather than falling back to 0 is what makes a malformed scope read as
+    /// absent: an <c>id:</c> under some <c>env:</c> block belongs to no step, and a slice from the top
+    /// of the file would answer a question the scope cannot answer.
+    /// </remarks>
+    private static int HeaderAtOrAbove(string[] lines, int from)
+    {
+        for (var index = from; index >= 0; index--)
+        {
+            if (lines[index].TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     /// <summary>

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -227,15 +227,66 @@ internal static class WorkflowSource
     /// name — so an assertion about what a step is gated on cannot be satisfied by another step's
     /// <c>if:</c>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Matched as an exact <c>id:</c> key rather than as a substring (#267). A <c>Contains</c> search
+    /// for <c>login</c> also hits <c>id: login-legacy</c>, <c>id: login2</c>, and any <c>with:</c>
+    /// value or comment carrying the text — and taking the <em>first</em> hit means an unrelated
+    /// earlier line silently redefines the whole slice, so every claim about the intended step is
+    /// then answered by the wrong one. That is precisely the failure this primitive exists to
+    /// prevent, and it landed on the primitive #226 depends on, where a wrong answer is a green run
+    /// on a version that never reached nuget.org.
+    /// </para>
+    /// <para>
+    /// Two steps claiming one id fails loudly instead of resolving to the first. That is invalid in
+    /// GitHub Actions, so it should never happen — but anchoring the match buys nothing if an
+    /// ambiguous one still quietly picks a winner, which is the same silent wrong answer wearing a
+    /// different hat.
+    /// </para>
+    /// </remarks>
     internal static string StepWithId(string scope, string stepId, string? scopeDescription = null)
     {
         var lines = scope.Split('\n');
-        var start = Array.FindIndex(lines, l => l.Contains($"id: {stepId}", StringComparison.Ordinal));
-        start.ShouldBeGreaterThanOrEqualTo(
-            0,
+        var matches = LinesDeclaring(lines, stepId);
+
+        matches.Count.ShouldBeLessThan(
+            2,
+            $"{scopeDescription ?? "the searched text"} has {matches.Count} steps claiming `id: {stepId}` — an ambiguous id cannot be resolved to one step");
+        matches.ShouldNotBeEmpty(
             $"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
 
-        return StepFrom(lines, start);
+        return StepFrom(lines, matches[0]);
+    }
+
+    /// <summary>
+    /// The indexes of every line in <paramref name="lines" /> whose trimmed text is exactly the key
+    /// <c>id: &lt;stepId&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Every index, not the first: the count is what tells <see cref="StepWithId" /> apart absent,
+    /// found, and ambiguous — and only the last of those can pass itself off as the middle one.
+    /// Trailing whitespace and a trailing <c># comment</c> are tolerated because
+    /// <see cref="WithoutComments" /> drops only whole-line comments (so a URL's <c>//</c> survives),
+    /// and callers may hand over unstripped text anyway — <c>TrustedPublishingWorkflowTests</c> does.
+    /// </remarks>
+    private static List<int> LinesDeclaring(string[] lines, string stepId)
+    {
+        // Built per call rather than compiled once, unlike JobsKey/JobHeader: the pattern depends on
+        // the id being looked for, and RegexOptions.Compiled pays its cost up front — strictly a loss
+        // for the handful of scans a run performs. The shape mirrors JobsKey's, trailing-comment
+        // tolerance included.
+        var key = new Regex($@"^id:\s*{Regex.Escape(stepId)}\s*(#.*)?$");
+
+        var matches = new List<int>();
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (key.IsMatch(lines[index].Trim()))
+            {
+                matches.Add(index);
+            }
+        }
+
+        return matches;
     }
 
     /// <summary>

--- a/FormCraft.UnitTests/Ci/WorkflowSource.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSource.cs
@@ -211,15 +211,31 @@ internal static class WorkflowSource
     /// </param>
     internal static string StepNamed(string scope, string stepName, string? scopeDescription = null)
     {
+        var step = TryStepNamed(scope, stepName);
+        step.ShouldNotBeNull($"{scopeDescription ?? "the searched text"} no longer has a step named '{stepName}'");
+
+        return step!;
+    }
+
+    /// <summary>
+    /// <see cref="StepNamed" /> without the assertion: the step's own lines, or <c>null</c> when the
+    /// scope has no such step.
+    /// </summary>
+    /// <remarks>
+    /// For callers that have something better to say about absence than this helper does (#267).
+    /// Asserting from in here means one missing step reddens every test that reaches for it, each
+    /// reporting the same single root cause as an apparent *helper* failure — so the one test whose
+    /// actual subject is "the step is present" is drowned out by four whose subject is what the step
+    /// contains. A caller collecting offenders can name the job instead, once, per test that cares.
+    /// </remarks>
+    internal static string? TryStepNamed(string scope, string stepName)
+    {
         var lines = scope.Split('\n');
         var start = Array.FindIndex(
             lines,
             l => l.TrimStart().StartsWith($"- name: '{stepName}'", StringComparison.Ordinal));
-        start.ShouldBeGreaterThanOrEqualTo(
-            0,
-            $"{scopeDescription ?? "the searched text"} no longer has a step named '{stepName}'");
 
-        return StepFrom(lines, start);
+        return start < 0 ? null : StepFrom(lines, start);
     }
 
     /// <summary>
@@ -253,6 +269,34 @@ internal static class WorkflowSource
     /// </remarks>
     internal static string StepWithId(string scope, string stepId, string? scopeDescription = null)
     {
+        var step = StepWithIdOrNull(scope, stepId, scopeDescription);
+        step.ShouldNotBeNull($"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
+
+        return step!;
+    }
+
+    /// <summary>
+    /// <see cref="StepWithId" /> without the absence assertion: the step's own lines, or <c>null</c>
+    /// when the scope has no step carrying that id.
+    /// </summary>
+    /// <remarks>
+    /// An <em>ambiguous</em> id still fails loudly here rather than reading as absent. The two are
+    /// different answers with different remedies, and reporting a duplicated step as a missing one
+    /// would quietly undo the anchoring above, one call further out.
+    /// </remarks>
+    internal static string? TryStepWithId(string scope, string stepId) =>
+        StepWithIdOrNull(scope, stepId, null);
+
+    /// <summary>
+    /// The shared body of <see cref="StepWithId" /> and <see cref="TryStepWithId" />: <c>null</c> for
+    /// absent, the step's lines otherwise, and a loud failure for an ambiguous id either way.
+    /// </summary>
+    /// <remarks>
+    /// Private, and carrying the <paramref name="scopeDescription" /> the public <c>Try</c> form does
+    /// not take, so the ambiguity message can still name a scope when the caller knows one.
+    /// </remarks>
+    private static string? StepWithIdOrNull(string scope, string stepId, string? scopeDescription)
+    {
         var lines = scope.Split('\n');
         var matches = LinesDeclaring(lines, stepId);
 
@@ -262,13 +306,10 @@ internal static class WorkflowSource
 
         // Both "no such id" and "an id belonging to no list item" are absence: the second is a
         // malformed scope, and slicing it from line 0 would hand back the file's preamble dressed up
-        // as a step. One message covers both because the caller's remedy is the same either way.
+        // as a step. One answer covers both because the caller's remedy is the same either way.
         var header = matches.Count == 1 ? HeaderAtOrAbove(lines, matches[0]) : -1;
-        header.ShouldBeGreaterThanOrEqualTo(
-            0,
-            $"{scopeDescription ?? "the searched text"} no longer has a step with `id: {stepId}`");
 
-        return StepFrom(lines, header);
+        return header < 0 ? null : StepFrom(lines, header);
     }
 
     /// <summary>

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -187,6 +187,64 @@ public class WorkflowSourceTests
     }
 
     [Fact]
+    public void StepWithId_Should_Return_The_Step_From_Its_Own_Header()
+    {
+        // The second half of #267: the scan started at the `id:` line, so the "step" it returned
+        // excluded the step's own `- name:` — it could not be used to assert anything *about* the
+        // name, and it silently differed in shape from what StepNamed returns for the very same step.
+        // Two primitives on one reader answering the same question differently is how the looser of
+        // them drifts unnoticed.
+        var step = WorkflowSource.StepWithId(WorkflowSource.Read("release-please.yml"), "login");
+
+        step.ShouldContain("- name: NuGet login");
+
+        // Still bounded above by the next step, which is what the slice has always been for.
+        step.ShouldNotContain("- name: 'Run: Pack");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Treat_An_Id_Outside_Any_Step_As_Absent()
+    {
+        // Walking back has to be allowed to fail. An `id:` key that belongs to no list item is not a
+        // step, and slicing from line 0 would hand the caller the file's preamble dressed up as one —
+        // a wrong answer of exactly the kind the anchored match was added to stop, arriving by the
+        // other door.
+        const string Malformed = """
+                                 jobs:
+                                   publish:
+                                     env:
+                                       id: login
+                                 """;
+
+        var error = Should.Throw<ShouldAssertException>(
+            () => WorkflowSource.StepWithId(Malformed, "login", "the fixture"));
+
+        error.Message.ShouldContain("no longer has a step with `id: login`");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Find_An_Id_Written_On_The_List_Item_Line()
+    {
+        // `- id: login` is legal, common in the wild, and the one shape an anchored `^id:` match
+        // loses that the old substring scan handled. Losing it fails in the opposite direction to
+        // #267's bug — loudly, reporting a step that is plainly present as gone — which is a better
+        // failure but still a wrong answer, and one no workflow in this repo would currently catch.
+        const string Steps = """
+                             steps:
+                               - id: login
+                                 uses: NuGet/login@v1
+                             """;
+
+        var step = WorkflowSource.StepWithId(Steps, "login");
+
+        // The matched line *is* the header here, so the walk-back must stop on it rather than run
+        // past it to `steps:`.
+        step.ShouldContain("- id: login");
+        step.ShouldContain("uses: NuGet/login@v1");
+        step.ShouldNotContain("steps:");
+    }
+
+    [Fact]
     public void Matching_Should_Find_The_Workflows_That_Invoke_The_Build()
     {
         // The discovery primitive the whole TestReportingTests family rests on: it decides which

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -115,6 +115,78 @@ public class WorkflowSourceTests
     }
 
     [Fact]
+    public void StepWithId_Should_Not_Bind_To_A_Step_Whose_Id_Merely_Starts_With_The_One_Asked_For()
+    {
+        // The defect #267 exists to remove: the scan matched `id: <stepId>` as an unanchored
+        // substring, so a search for `login` also matched `id: login-legacy` — and it takes the
+        // *first* hit, so an unrelated earlier step silently redefined the whole slice and every
+        // claim about the login step's `if:` and `uses:` was answered by the wrong step. That is the
+        // exact failure StepWithId exists to prevent, reintroduced one level down, on the one
+        // primitive #226 depends on — where a wrong answer is a green run on a version that never
+        // reached nuget.org.
+        const string Steps = """
+                             steps:
+                               - name: legacy login
+                                 id: login-legacy
+                                 uses: NuGet/login-legacy@v0
+                               - name: current login
+                                 id: login
+                                 uses: NuGet/login@v1
+                             """;
+
+        var step = WorkflowSource.StepWithId(Steps, "login");
+
+        step.ShouldContain("uses: NuGet/login@v1");
+        step.ShouldNotContain("login-legacy");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Fail_Loudly_When_Two_Steps_Claim_One_Id()
+    {
+        // Two steps sharing an id is invalid in GitHub Actions, so the only open question is what the
+        // scan does when a workflow gets there anyway. Resolving to the first is how the old scan
+        // returned the wrong step without saying so, and anchoring the match buys nothing if an
+        // ambiguous one still quietly picks a winner: the caller would be told about *a* step, with
+        // no way to know it was not the one it asked about.
+        const string Steps = """
+                             steps:
+                               - name: first login
+                                 id: login
+                                 uses: NuGet/login@v1
+                               - name: second login
+                                 id: login
+                                 uses: NuGet/login@v2
+                             """;
+
+        var error = Should.Throw<ShouldAssertException>(
+            () => WorkflowSource.StepWithId(Steps, "login", "the fixture"));
+
+        error.Message.ShouldContain("ambiguous");
+
+        // The scan cannot infer what it was handed, so the scope description is the only thing that
+        // tells a reader *which* file or job to go and look at.
+        error.Message.ShouldContain("the fixture");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Match_An_Id_Carrying_Trailing_Space_Or_A_Comment()
+    {
+        // The tolerance an exact key match has to keep, and the reason it is spelled as a regex
+        // rather than as string equality. `WithoutComments` only drops *whole-line* comments (so a
+        // URL's "//" survives), which means a trailing `# …` reaches this scan intact — and callers
+        // may hand over unstripped text anyway, as TrustedPublishingWorkflowTests does. An anchored
+        // match that forgot either case would report a step that is plainly there as absent.
+        const string Steps = """
+                             steps:
+                               - name: current login
+                                 id: login   # minted per run
+                                 uses: NuGet/login@v1
+                             """;
+
+        WorkflowSource.StepWithId(Steps, "login").ShouldContain("uses: NuGet/login@v1");
+    }
+
+    [Fact]
     public void Matching_Should_Find_The_Workflows_That_Invoke_The_Build()
     {
         // The discovery primitive the whole TestReportingTests family rests on: it decides which

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -245,6 +245,78 @@ public class WorkflowSourceTests
     }
 
     [Fact]
+    public void TryStepNamed_Should_Return_Null_Where_StepNamed_Asserts()
+    {
+        // Why absence needs a non-asserting form at all: StepNamed asserts from inside the shared
+        // helper, so one missing step turns every test that reaches for it red — each of them
+        // reporting the same single root cause as an apparent *helper* failure. TestReportingTests
+        // had four tests doing that, next to one that reported the offender cleanly.
+        const string Steps = """
+                             steps:
+                               - name: 'Publish: test-results'
+                                 uses: actions/upload-artifact@v4
+                             """;
+
+        WorkflowSource.TryStepNamed(Steps, "nope").ShouldBeNull();
+
+        // A present step still comes back whole, from its own header.
+        WorkflowSource.TryStepNamed(Steps, "Publish: test-results")
+            .ShouldNotBeNull()
+            .ShouldContain("- name: 'Publish: test-results'");
+
+        // And the asserting form is untouched — it is still the right choice for a caller with
+        // nothing better to say about absence, because it names the scope the scan cannot infer.
+        var error = Should.Throw<ShouldAssertException>(
+            () => WorkflowSource.StepNamed(Steps, "nope", "the fixture"));
+
+        error.Message.ShouldContain("the fixture");
+        error.Message.ShouldContain("no longer has a step named 'nope'");
+    }
+
+    [Fact]
+    public void TryStepWithId_Should_Return_Null_Where_StepWithId_Asserts()
+    {
+        const string Steps = """
+                             steps:
+                               - name: current login
+                                 id: login
+                                 uses: NuGet/login@v1
+                             """;
+
+        WorkflowSource.TryStepWithId(Steps, "nope").ShouldBeNull();
+
+        WorkflowSource.TryStepWithId(Steps, "login")
+            .ShouldNotBeNull()
+            .ShouldContain("- name: current login");
+
+        var error = Should.Throw<ShouldAssertException>(
+            () => WorkflowSource.StepWithId(Steps, "nope", "the fixture"));
+
+        error.Message.ShouldContain("the fixture");
+        error.Message.ShouldContain("no longer has a step with `id: nope`");
+    }
+
+    [Fact]
+    public void TryStepWithId_Should_Still_Fail_Loudly_On_An_Ambiguous_Id()
+    {
+        // The one thing the Try form must NOT soften. Absence and ambiguity are different answers:
+        // returning null for two steps claiming one id would report a duplicated step as a missing
+        // one, quietly undoing Task 1's whole point one call further out.
+        const string Steps = """
+                             steps:
+                               - name: first login
+                                 id: login
+                                 uses: NuGet/login@v1
+                               - name: second login
+                                 id: login
+                                 uses: NuGet/login@v2
+                             """;
+
+        Should.Throw<ShouldAssertException>(() => WorkflowSource.TryStepWithId(Steps, "login"))
+            .Message.ShouldContain("ambiguous");
+    }
+
+    [Fact]
     public void Matching_Should_Find_The_Workflows_That_Invoke_The_Build()
     {
         // The discovery primitive the whole TestReportingTests family rests on: it decides which

--- a/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
+++ b/FormCraft.UnitTests/Ci/WorkflowSourceTests.cs
@@ -184,6 +184,12 @@ public class WorkflowSourceTests
                              """;
 
         WorkflowSource.StepWithId(Steps, "login").ShouldContain("uses: NuGet/login@v1");
+
+        // `-  id:` and `-<tab>id:` are the same YAML as `- id:`; requiring exactly one space reported
+        // a step that is plainly present as absent.
+        WorkflowSource.TryStepWithId("steps:\n  -  id: login\n     uses: NuGet/login@v1", "login")
+            .ShouldNotBeNull()
+            .ShouldContain("uses: NuGet/login@v1");
     }
 
     [Fact]
@@ -194,12 +200,74 @@ public class WorkflowSourceTests
         // name, and it silently differed in shape from what StepNamed returns for the very same step.
         // Two primitives on one reader answering the same question differently is how the looser of
         // them drifts unnoticed.
-        var step = WorkflowSource.StepWithId(WorkflowSource.Read("release-please.yml"), "login");
+        // Only the header claim lives here. The upper bound on the same step is already owned by
+        // StepWithId_Should_Return_Only_That_Steps_Own_Lines above; re-asserting it would leave two
+        // near-identical bodies to be kept in step when release-please.yml's login step moves.
+        WorkflowSource.StepWithId(WorkflowSource.Read("release-please.yml"), "login")
+            .ShouldContain("- name: NuGet login");
+    }
 
-        step.ShouldContain("- name: NuGet login");
+    [Fact]
+    public void StepWithId_Should_Not_Stop_The_Walk_Back_On_A_Nested_List_Item()
+    {
+        // "The nearest dash above" is not the rule — containment is. A sequence nested inside the
+        // step (here under `with:`, but a bullet in a `path: |` block behaves identically) sits
+        // between the `id:` and its real header, and stopping on it returns a fragment of the step as
+        // the step: every later claim about this step's `uses:` would then be answered by nothing.
+        const string Steps = """
+                             steps:
+                               - name: current login
+                                 with:
+                                   args:
+                                     - --verbose
+                                 id: login
+                                 uses: NuGet/login@v1
+                             """;
 
-        // Still bounded above by the next step, which is what the slice has always been for.
-        step.ShouldNotContain("- name: 'Run: Pack");
+        var step = WorkflowSource.StepWithId(Steps, "login");
+
+        step.ShouldContain("- name: current login");
+        step.ShouldContain("uses: NuGet/login@v1");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Recognise_A_Bare_Dash_Step_Header()
+    {
+        // `-` alone, with the item's keys starting on the next line, is legal YAML and the failure it
+        // caused was the silent kind: `StartsWith("- ")` skipped this header and the walk-back carried
+        // on into the PREVIOUS step, so a claim about `login` was answered by the checkout step.
+        const string Steps = """
+                             steps:
+                               - name: previous step
+                                 uses: actions/checkout@v4
+                               -
+                                 name: current login
+                                 id: login
+                                 uses: NuGet/login@v1
+                             """;
+
+        var step = WorkflowSource.StepWithId(Steps, "login");
+
+        step.ShouldContain("name: current login");
+        step.ShouldNotContain("previous step");
+    }
+
+    [Fact]
+    public void StepWithId_Should_Not_Bind_To_An_Id_Whose_Hash_Is_Part_Of_The_Value()
+    {
+        // The trailing-comment tolerance has to require whitespace before the `#`. YAML only starts a
+        // comment after whitespace, so `login#1` is one scalar naming a different step — and a
+        // tolerance spelled `\s*#` swallowed the `#1`, letting a LONGER id back in through the very
+        // clause added to keep longer ids out.
+        const string Steps = """
+                             steps:
+                               - name: hash login
+                                 id: login#1
+                                 uses: NuGet/login@v1
+                             """;
+
+        WorkflowSource.TryStepWithId(Steps, "login").ShouldBeNull();
+        WorkflowSource.TryStepWithId(Steps, "login#1").ShouldNotBeNull();
     }
 
     [Fact]
@@ -209,8 +277,18 @@ public class WorkflowSourceTests
         // step, and slicing from line 0 would hand the caller the file's preamble dressed up as one —
         // a wrong answer of exactly the kind the anchored match was added to stop, arriving by the
         // other door.
+        //
+        // The fixture carries a real step in an EARLIER job on purpose. Without one it proves nothing:
+        // a scope containing no list item at all reaches the top of the file whatever the walk-back
+        // does, so the test passed while the loose "nearest dash above" version happily crossed the
+        // job boundary and returned `- name: real step` as the login step. What makes this absent is
+        // that `env:` is indented shallower than the id — a container, reached without a header.
         const string Malformed = """
                                  jobs:
+                                   build:
+                                     steps:
+                                       - name: real step
+                                         uses: actions/checkout@v4
                                    publish:
                                      env:
                                        id: login


### PR DESCRIPTION
Implements #267.

Closes #267.

Makes the two step-extraction primitives on the shared `Ci/` reader (`WorkflowSource`, #255) agree
about how precise a step match has to be, and closes the parked YAML-parser question in writing.

All three tasks landed; every checkbox on the issue's plan is ticked.

### Plan
- [x] Task 1: Anchor `StepWithId` on an exact `id:` match, and make ambiguity loud
- [x] Task 2: Start the slice at the step's own list-item header
- [x] Task 3: Add `Try*` variants and report a missing step uniformly

### What changed

Test infrastructure only — `FormCraft.UnitTests/Ci/`. No library code, no workflow, no `build/Build.cs`
behaviour change, and no new package (the parser stays rejected; see the issue's *Alternatives*).

- **`StepWithId` can no longer bind to the wrong step.** `id: <x>` was matched as an unanchored
  substring and `Array.FindIndex` took the first hit, so a search for `login` resolved to
  `id: login-legacy` — silently, on the primitive #226 depends on. It is now an exact trimmed-key
  match (trailing whitespace and a trailing `# comment` tolerated), and **two steps claiming one id
  fails loudly** instead of resolving to the first.
- **Both primitives return the same shape.** The slice starts at the step's own `- ` list item rather
  than at the `id:` line, so `StepWithId` now carries the step's `- name:` just as `StepNamed` does.
  An `id:` belonging to no list item reads as *absent* rather than slicing from line 0.
- **A missing step is reported once, by each test that cares.** New `TryStepNamed`/`TryStepWithId`
  return `string?`; the asserting forms are reimplemented over them with byte-identical messages, and
  `TestReportingTests`' five upload assertions route through the `Try*` form.

### Code review

A review over `origin/dev...HEAD` raised 14 findings; 9 were implemented in `fix: address
code-review findings`, and each fix was confirmed to correct a genuine wrong answer by running the old
and new algorithms side by side against the same fixtures:

| Finding | Old answer | Now |
|---|---|---|
| Walk-back had no containment check — a nested list item (`args:` entry, `path: \|` bullet) between the `id:` and its header stopped the search | returned a **fragment** of the step | walks past nested items to the step's own header |
| …and it could cross a **job boundary**, adopting the previous job's last step | returned `- name: real step` from another job | reads as absent (a shallower plain key ends the search) |
| `- ` matched literally — a bare `-` header, or `-  id:` | silently returned the **previous** step / reported a present step absent | `-` alone, `-<tab>` and `-  ` all recognised |
| `\s*(#.*)?$` let a longer id back in through the comment clause | `id: login#1` matched a search for `login` | comment requires preceding whitespace (`\s+#`) |
| `StepFrom`'s **end** boundary was not depth-aware either | truncated a step at its own nested sequence — and a truncated slice makes `ShouldNotContain` pass for the wrong reason | ends at the next *sibling* item |
| `StepWithId_Should_Treat_An_Id_Outside_Any_Step_As_Absent` passed **vacuously** — its fixture had no list item at all | false confidence on the one guard for the `-1` path | fixture now carries a real step in an earlier job |
| The `UploadStep` remark claimed "the count of red tests matches the count of causes" | **false** — 5 red before, 5 red after | states what actually changed: the messages, not the count |
| The absence rule was restated inline at 4 assertions | a 5th written `is { } step &&` would read a missing step as satisfied | centralised in one `UploadStepFails` helper |
| Two needless `!` null-forgiving operators | — | `return step.ShouldNotBeNull(…)` |

Also corrected two comments of mine that asserted things which are not true: step ids are unique per
**job**, not per workflow (so the new ambiguity failure is *not* evidence of an invalid workflow — the
real fix is `JobsOf` scoping, tracked on #198), and the unstripped-slice remark in
`TrustedPublishingWorkflowTests` claimed a harmlessness it does not have (see Follow-ups).

Five findings were **declined**, with reasons — three as explicit plan non-goals (job-scoping this
suite is #198; adding ambiguity detection to `StepNamed` and restructuring the guard set both change
*what* the suite asserts), one as plan-mandated surface (`TryStepWithId`'s throw-on-ambiguity is
deliberate and pinned by a test — returning `null` there would report a duplicated step as a missing
one), and one perf suggestion not worth trading precision for in a helper that runs seven times a run.

### Verification

- `./build.sh Test` (the exact CI target, invoked exactly as `ci.yml` does) — Restore/Compile/Test all
  succeeded, before and after the review fixes.
- `dotnet test -c Release` — **1351 passed, 1 skipped, 0 failed** (`FormCraft.UnitTests` 819, up from
  807 on `dev`; `ForMudBlazor` 464; `ForFluentUI` 68).
- **The reporting improvement was measured, not assumed.** With the `Publish: test-results` step
  temporarily deleted from `ci.yml`, on the pre-change code four of the five tests failed as
  `Shouldly.ShouldAssertException : Array.FindIndex(…) should be greater than or equal to 0 but was -1`
  — an apparent fault in the shared reader — while one named the offender. After the change all five
  report `[ci.yml / build-and-test]` as an offender collection, and the failure count is still exactly
  five, so no coverage was traded away. `ci.yml` was reverted; the workflow is untouched in this PR.

## Follow-ups

- **`ReleaseWorkflow_Should_Gate_The_Login_On_A_Created_Release` is inert, and pre-dates this PR.**
  It asserts `ShouldContain("release_created")` over the login step's *unstripped* slice, and that
  slice carries a comment block mentioning `release_created` in prose (`release-please.yml:153`). So
  deleting the step's `if:` outright — the exact #226 regression it exists to catch, whose cost is a
  green run on a version that never reached nuget.org — leaves it green. The prose sat inside the slice
  before this PR moved the slice's start, so this is not a regression here; it is left standing because
  narrowing it changes *what* the suite asserts, which #267 rules out. Fix is small: read
  `WorkflowSource.Stripped(...)` in that helper (the `# v1.2.0` digest annotation survives whole-line
  stripping, so the `uses: NuGet/login@<sha>` match is unaffected), or assert via `StepCondition` as
  the sibling #226 test already does. **Worth filing on its own.**
- **`StepNamed` still takes the first match, with no ambiguity check.** Step *names* need not be unique
  in GitHub Actions — unlike ids — so if a job ever splits its upload in two (a natural consequence of
  #256's per-project results directories), the four content assertions would read only the first and
  stay green while the second misbehaves. Declined here as a change to what the suite asserts.
- **The five absence branches have no automated coverage.** They were verified by hand (deleting the
  step from `ci.yml`, per the plan's own Step 6) but cannot execute in a normal run, because the guard
  set is discovered from the real workflows, which always contain the step. An inverted condition would
  ship green. Making the job set injectable — or a fixture overload of `UploadStep` — would close it.
- **`dotnet format` reports 57 pre-existing violations in `FormCraft.UnitTests`** — missing final
  newlines (~14 files), `IMPORTS` ordering in `GlobalUsings.cs`, and `IDE0011` missing braces in the
  validator/builder suites. **None are in the files this PR touches**, and CI does not gate on
  `dotnet format` (the enforcing gate is the Release build under `TreatWarningsAsErrors`, which is
  clean). Fixing them here would have meant a 50+ file diff unrelated to #267, so they are left for a
  deliberate formatting pass.
