### PR TITLE
docs(profile): document the working per-class test filter (#277)

### DIFF
--- a/.claude/skills/repo-profile.md
+++ b/.claude/skills/repo-profile.md
@@ -18,33 +18,45 @@
 - **Single-suite filter (per-task, fast):** **available — but never via `dotnet test --filter`.**
   The test projects are Microsoft.Testing.Platform hosts (`OutputType=Exe` +
   `UseMicrosoftTestingPlatformRunner=true`), so xunit.v3's runner exposes real filter options on
-  them. Both forms below run a strict subset and print a genuine summary line. Measured on SDK
-  `10.0.302` / xunit.v3 runner `3.2.2` (#277) — re-measure if either moves.
-  - **Preferred** (builds first; the SDK forwards everything after `--` to the host):
+  them. Both forms below run a strict subset. ⚠️ **They report *failure* differently — read the
+  path-specific rules below before writing a verification loop.** Recorded on macOS arm64,
+  `dotnet --version` = `10.0.302`, xunit.v3 runner `3.2.2` (#277). Re-stamp from `dotnet --version`,
+  **not** from `global.json`: `rollForward: latestFeature` lets the real SDK drift above the pin, so
+  the pinned string can never tell you the measurement went stale.
+  - **Preferred** (builds first; the SDK forwards everything after `--` to the host).
+    ⚠️ **Always name the `.csproj`** — see the solution-level trap below:
     ```bash
     dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj -c Release \
       -- --filter-class FormCraft.UnitTests.Ci.GitignoreTests
-    # Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6 — ~10s including the build
     ```
+    → `Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6 … - FormCraft.UnitTests.dll`, exit `0`,
+    ~10s including the build.
   - **Fastest** (runs the built host directly — **it does not build**, so `dotnet build -c Release`
-    must precede it or you are silently testing stale code):
+    must precede it or you are silently testing stale code). Path is relative to the repo root, and
+    is `…\FormCraft.UnitTests.exe` on Windows (not measured here — recorded on macOS):
     ```bash
     FormCraft.UnitTests/bin/Release/net10.0/FormCraft.UnitTests \
       --filter-class FormCraft.UnitTests.Ci.GitignoreTests
-    # total: 6 (of 808), 191ms
     ```
+    → `Test run summary: Passed! - …/FormCraft.UnitTests.dll (net10.0|arm64)` on one line, then
+    `  total: 6` / `  failed: 0` / `  succeeded: 6` / `  skipped: 0` / `  duration: 191ms` on the
+    next five. **The verdict and the count are on different lines** — one `grep` gets you one of
+    them, never both.
     Not project-specific — every test project has its own host:
     ```bash
     FormCraft.ForMudBlazor.UnitTests/bin/Release/net10.0/FormCraft.ForMudBlazor.UnitTests \
       --filter-class FormCraft.ForMudBlazor.UnitTests.Fields.AriaRequiredTests
-    # total: 34 (of 464)
     ```
+    → `Passed!` with `total: 34` (of 464).
   - **Flags** (`--help` on the host lists them all): `--filter-class`, `--filter-method`,
     `--filter-namespace`, `--filter-trait`, `--filter-uid`, `--filter-query`, plus a
     `--filter-not-*` counterpart for class/method/namespace/trait. `*` wildcards work at either end
     (`--filter-class '*GitignoreTests'` → 6).
-    - ⚠️ **`--filter-method` wants the fully-qualified name** (`<namespace>.<class>.<method>`) —
-      a bare method name matches **nothing** and does not say so; a wildcard
+    Simple filters (`--filter-class/-method/-namespace/-trait` and their `-not-` forms) **cannot be
+    combined with `--filter-query`** — the runner's own help says so.
+    - ⚠️ **`--filter-method` wants the fully-qualified name** (`<namespace>.<class>.<method>`, as
+      its `--help` states) — a bare method name matches nothing and reports that as
+      `Zero tests ran` (exit `8`), which is easy to skim past as success. A wildcard
       (`--filter-method '*Clearing_A_Standalone*'`) is the ergonomic escape.
     - ⚠️ **`--filter-trait` is dead weight here:** no test in this repo carries a `[Trait]`, so
       `--filter-trait 'Category=Builder'` returns `Zero tests ran`. Note `CLAUDE.md` still
@@ -54,19 +66,36 @@
     replaced. It is a VSTest option forwarded as an MSBuild property that MTP ignores, warning
     `MTP0001: VSTest-specific properties are set but will be ignored … VSTestTestCaseFilter` while
     **the whole suite runs anyway** (`Total: 808`). Never report such a run as filtered.
-  - ⚠️ **Assert on the summary line — never on the exit code, never on the absence of `Failed!`.**
-    A wrong flag is not a failure you will notice: `<binary> --filter "*Gitignore*"` prints
-    `Unknown option '--filter'` followed by the full `--help` text, runs nothing, and emits **no
-    summary line at all**, so `grep 'Failed!'` matches nothing and reads as green. Its *direct*
-    exit is `5`, but the usual `| tail`/`| grep` replaces `$?` with the pipe's `0` — the pipe, not
-    the binary, is what manufactures the false pass. A filter that matches nothing prints
-    `Zero tests ran` and exits `8`. Require a real `Passed!`/`Failed!` line **and** a plausible
-    test count.
+  - ⚠️ **How a filtered run lies — and it lies differently per path.** Require a real
+    `Passed!`/`Failed!` verdict **and** a plausible count **and** the assembly name; do not trust
+    `$?` through a pipe, and never conclude from the mere absence of `Failed!`.
+    - **Direct host, wrong flag** → `Unknown option '--filter'` plus the full `--help`, **no
+      summary line at all**, so `grep 'Failed!'` matches nothing and reads as green. Direct exit is
+      `5`, but the habitual `| tail` / `| grep` replaces `$?` with the pipe's `0` — the pipe, not
+      the binary, manufactures the false pass.
+    - **Direct host, filter matches nothing** → `Test run summary: Zero tests ran`, `total: 0`,
+      exit `8`. It *does* announce itself; treat `Zero tests ran` as a hard stop, not noise.
+    - **Preferred form, wrong flag** → the diagnostic never reaches stdout. You get only
+      `… : error run failed: Tests failed: '<path>/TestResults/<assembly>_net10.0_arm64.log'` and
+      exit `1` — wording that blames the tests for what is an argument error. The real message is
+      in that log file; go read it before debugging any source.
+    - **Preferred form, filter matches nothing** → `Failed! - Failed: 0, Passed: 0, Skipped: 0,
+      Total: 0` and exit `1`. **No `Zero tests ran` on this path** — an empty filter is
+      indistinguishable at a glance from a real regression, so check `Total: 0` before you go
+      hunting for a broken test.
+  - ⚠️ **Scope the passthrough to a `.csproj`.** Run solution-wide,
+    `dotnet test -c Release -- --filter-class FormCraft.UnitTests.Ci.GitignoreTests` applies the
+    filter to **all three** assemblies: `Passed! … Total: 6` for `FormCraft.UnitTests.dll` and
+    `Failed! … Total: 0` for the other two, **exit 1**. A loop that greps for `Passed!` finds one
+    and reports green on a command that failed — this single form defeats the rule directly above,
+    which is why the example names its project.
   - **Scope:** this is *within-task* iteration only. It does **not** replace the *CI gates* below —
-    `./build.cmd Test` stays the pre-merge gate and still runs everything: 1340 tests across the
-    three test projects (808 + 464 + 68), ~30s including `Compile`. Bare `dotnet test -c Release`
-    runs the same 1340 in ~11s on a warm build. Filter to iterate; run one of these before you
-    claim done.
+    `./build.cmd Test` stays the pre-merge gate and still runs everything: 808 + 464 + 68 = 1340
+    tests, ~30s including `Compile`. Bare `dotnet test -c Release` runs the same three suites in
+    ~11s warm. ⚠️ **Neither prints a `1340` aggregate** — you get one `Passed!` line *per assembly*,
+    in nondeterministic order, so a check that reads the first one accepts `Total: 68` as the whole
+    suite. Confirm all three assemblies reported, or trust the process exit code for the full run
+    (unpiped). Filter to iterate; run one of these before you claim done.
 - **Format/lint apply:** `dotnet format FormCraft.sln`
 - **Format/lint verify (the gate):** *CI runs no `dotnet format` check.* The enforcing gate is the
   **build itself**: `Directory.Build.props` sets `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
@@ -181,19 +210,21 @@
 - `TreatWarningsAsErrors=true` **is** deliberate here — do not relax it to make a build pass.
 
 ## Worktree home
-- `.claude/worktrees/` — **⚠️ not actually git-ignored.** `.gitignore:13` reads
-  `/test-results/.claude/worktrees/` (two entries collapsed onto one line), so neither
-  `/test-results/` nor `.claude/worktrees/` is ignored. Keep worktrees out of `git add`, or fix the
-  `.gitignore` line first.
+- `.claude/worktrees/` — **ignored, and safe to use.** `.gitignore:13` is `/test-results/` and
+  `:16` is `.claude/worktrees/`, on their own lines. (This entry previously warned they had been
+  collapsed onto one line and that neither was ignored; #223 — `6e8a10c` — restored the newline, and
+  `FormCraft.UnitTests/Ci/GitignoreTests` now pins it. Corrected under #277 after re-measuring.)
+- ⚠️ `.worktrees/` — the kit's *other* default worktree home — is **not** ignored. Nothing here
+  plants worktrees there, but a tool that does would leave a full checkout stageable by `git add -A`.
+  One line in `.gitignore` would settle it if that ever becomes real.
 
 ## Environment gotchas
 - **Default branch is `dev`.** The lifecycle skills' examples say `main`; substitute `dev` everywhere
   (`--base dev`, `git merge origin/dev`).
-- **`dotnet test --filter` is inert here (`MTP0001`) — but per-suite filtering is not.** Reach for
-  `dotnet test <csproj> -c Release -- --filter-class <FQN>`, or run the built MTP host directly; see
-  *Build & test* for the flag list and, more importantly, for the two ways a filtered run lies about
-  itself — a **wrong flag** prints `--help`, runs nothing and emits no summary line (`grep 'Failed!'`
-  reads that as green), and a filter matching **nothing** reports `Zero tests ran`. Verify a real
-  `Passed!`/`Failed!` line and a plausible count; do not trust `$?` through a pipe.
+- **`dotnet test --filter` is inert here (`MTP0001`) — but per-suite filtering is not:** use
+  `dotnet test <csproj> -c Release -- --filter-class <FQN>`. A filtered run has several ways of
+  looking green while having run nothing, and they differ between the two invocation paths — read
+  *Build & test* before writing any check against one. (Kept as a pointer on purpose: the details
+  live in exactly one place so a re-measure cannot update one copy and leave the other lying.)
 - Use `git -C <path>` rather than `cd <path> && …` — a `cd` in a compound command gets reset between
   tool calls.

--- a/.claude/skills/repo-profile.md
+++ b/.claude/skills/repo-profile.md
@@ -39,11 +39,17 @@
       --filter-class FormCraft.ForMudBlazor.UnitTests.Fields.AriaRequiredTests
     # total: 34 (of 464)
     ```
-  - **Flags:** `--filter-class`, `--filter-method`, `--filter-namespace`, their `--filter-not-*`
-    counterparts, and `--filter-uid`. `*` wildcards work at either end
-    (`--filter-class '*GitignoreTests'` → 6). ⚠️ **`--filter-method` wants the fully-qualified
-    name** (`<namespace>.<class>.<method>`) — a bare method name matches **nothing** and does not
-    say so; a wildcard (`--filter-method '*Clearing_A_Standalone*'`) is the ergonomic escape.
+  - **Flags** (`--help` on the host lists them all): `--filter-class`, `--filter-method`,
+    `--filter-namespace`, `--filter-trait`, `--filter-uid`, `--filter-query`, plus a
+    `--filter-not-*` counterpart for class/method/namespace/trait. `*` wildcards work at either end
+    (`--filter-class '*GitignoreTests'` → 6).
+    - ⚠️ **`--filter-method` wants the fully-qualified name** (`<namespace>.<class>.<method>`) —
+      a bare method name matches **nothing** and does not say so; a wildcard
+      (`--filter-method '*Clearing_A_Standalone*'`) is the ergonomic escape.
+    - ⚠️ **`--filter-trait` is dead weight here:** no test in this repo carries a `[Trait]`, so
+      `--filter-trait 'Category=Builder'` returns `Zero tests ran`. Note `CLAUDE.md` still
+      advertises `dotnet test --filter "Category=Builder"`, which is wrong twice over — the option
+      is inert *and* the trait does not exist. Filter by class or namespace instead.
   - ⛔ **`dotnet test --filter …` really is inert** — the true half of the advice this bullet
     replaced. It is a VSTest option forwarded as an MSBuild property that MTP ignores, warning
     `MTP0001: VSTest-specific properties are set but will be ignored … VSTestTestCaseFilter` while

--- a/.claude/skills/repo-profile.md
+++ b/.claude/skills/repo-profile.md
@@ -15,9 +15,52 @@
 ## Build & test
 - **Build:** `dotnet build -c Release`
 - **Full test:** `dotnet test -c Release`
-- **Single-suite filter (per-task, fast):** *not available* — this repo's test projects run on
-  **Microsoft.Testing.Platform**, which prints `MTP0001` and **silently ignores `--filter`**, running
-  the whole suite anyway. Use the full run; it completes in seconds. Never report a filtered result.
+- **Single-suite filter (per-task, fast):** **available — but never via `dotnet test --filter`.**
+  The test projects are Microsoft.Testing.Platform hosts (`OutputType=Exe` +
+  `UseMicrosoftTestingPlatformRunner=true`), so xunit.v3's runner exposes real filter options on
+  them. Both forms below run a strict subset and print a genuine summary line. Measured on SDK
+  `10.0.302` / xunit.v3 runner `3.2.2` (#277) — re-measure if either moves.
+  - **Preferred** (builds first; the SDK forwards everything after `--` to the host):
+    ```bash
+    dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj -c Release \
+      -- --filter-class FormCraft.UnitTests.Ci.GitignoreTests
+    # Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6 — ~10s including the build
+    ```
+  - **Fastest** (runs the built host directly — **it does not build**, so `dotnet build -c Release`
+    must precede it or you are silently testing stale code):
+    ```bash
+    FormCraft.UnitTests/bin/Release/net10.0/FormCraft.UnitTests \
+      --filter-class FormCraft.UnitTests.Ci.GitignoreTests
+    # total: 6 (of 808), 191ms
+    ```
+    Not project-specific — every test project has its own host:
+    ```bash
+    FormCraft.ForMudBlazor.UnitTests/bin/Release/net10.0/FormCraft.ForMudBlazor.UnitTests \
+      --filter-class FormCraft.ForMudBlazor.UnitTests.Fields.AriaRequiredTests
+    # total: 34 (of 464)
+    ```
+  - **Flags:** `--filter-class`, `--filter-method`, `--filter-namespace`, their `--filter-not-*`
+    counterparts, and `--filter-uid`. `*` wildcards work at either end
+    (`--filter-class '*GitignoreTests'` → 6). ⚠️ **`--filter-method` wants the fully-qualified
+    name** (`<namespace>.<class>.<method>`) — a bare method name matches **nothing** and does not
+    say so; a wildcard (`--filter-method '*Clearing_A_Standalone*'`) is the ergonomic escape.
+  - ⛔ **`dotnet test --filter …` really is inert** — the true half of the advice this bullet
+    replaced. It is a VSTest option forwarded as an MSBuild property that MTP ignores, warning
+    `MTP0001: VSTest-specific properties are set but will be ignored … VSTestTestCaseFilter` while
+    **the whole suite runs anyway** (`Total: 808`). Never report such a run as filtered.
+  - ⚠️ **Assert on the summary line — never on the exit code, never on the absence of `Failed!`.**
+    A wrong flag is not a failure you will notice: `<binary> --filter "*Gitignore*"` prints
+    `Unknown option '--filter'` followed by the full `--help` text, runs nothing, and emits **no
+    summary line at all**, so `grep 'Failed!'` matches nothing and reads as green. Its *direct*
+    exit is `5`, but the usual `| tail`/`| grep` replaces `$?` with the pipe's `0` — the pipe, not
+    the binary, is what manufactures the false pass. A filter that matches nothing prints
+    `Zero tests ran` and exits `8`. Require a real `Passed!`/`Failed!` line **and** a plausible
+    test count.
+  - **Scope:** this is *within-task* iteration only. It does **not** replace the *CI gates* below —
+    `./build.cmd Test` stays the pre-merge gate and still runs everything: 1340 tests across the
+    three test projects (808 + 464 + 68), ~30s including `Compile`. Bare `dotnet test -c Release`
+    runs the same 1340 in ~11s on a warm build. Filter to iterate; run one of these before you
+    claim done.
 - **Format/lint apply:** `dotnet format FormCraft.sln`
 - **Format/lint verify (the gate):** *CI runs no `dotnet format` check.* The enforcing gate is the
   **build itself**: `Directory.Build.props` sets `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
@@ -26,6 +69,8 @@
 - **Prerequisites / caveats:**
   - `global.json` pins SDK `10.0.302` with `rollForward: latestFeature`.
   - Multi-target `net8.0;net10.0` — a build error can be TFM-specific; read which TFM the error names.
+    The **test** projects are single-target `net10.0`, so each has exactly one host binary under
+    `bin/<cfg>/net10.0/` — no per-TFM ambiguity when picking the path above.
   - Nuke wrapper: `./build.sh` / `./build.cmd <Target>` (`Clean`, `Restore`, `Compile`, `Test`, `Pack`,
     `Continuous`). `Test` is `DependsOn(Compile)` with `--no-build --no-restore`.
 
@@ -138,6 +183,11 @@
 ## Environment gotchas
 - **Default branch is `dev`.** The lifecycle skills' examples say `main`; substitute `dev` everywhere
   (`--base dev`, `git merge origin/dev`).
-- `dotnet test --filter` is inert (MTP0001) — see *Build & test*.
+- **`dotnet test --filter` is inert here (`MTP0001`) — but per-suite filtering is not.** Reach for
+  `dotnet test <csproj> -c Release -- --filter-class <FQN>`, or run the built MTP host directly; see
+  *Build & test* for the flag list and, more importantly, for the two ways a filtered run lies about
+  itself — a **wrong flag** prints `--help`, runs nothing and emits no summary line (`grep 'Failed!'`
+  reads that as green), and a filter matching **nothing** reports `Zero tests ran`. Verify a real
+  `Passed!`/`Failed!` line and a plausible count; do not trust `$?` through a pipe.
 - Use `git -C <path>` rather than `cd <path> && …` — a `cd` in a compound command gets reset between
   tool calls.


### PR DESCRIPTION
Implements #277.

Closes #277.

The repo profile records per-suite test filtering as impossible. The premise is right — `dotnet test --filter` really is inert under Microsoft.Testing.Platform (`MTP0001`) — but the conclusion isn't: the built test assemblies are MTP hosts with their own command line, and xunit.v3's runner exposes real `--filter-class` / `--filter-method` / `--filter-namespace` options on them.

Correcting both bullets, and naming the trap the correction itself would otherwise introduce: passing the *wrong* flag to the host prints `--help`, runs nothing, and exits **0** — a false green for any loop that greps for `Failed!`.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

### Plan
- [x] Task 1: Measure the real invocation surface
- [x] Task 2: Correct the profile

### What was measured

Every command in the new text was run before it was written down, and re-run verbatim afterwards
(SDK `10.0.302`, xunit.v3 runner `3.2.2`, Release):

| Invocation | Result |
|---|---|
| `dotnet test <csproj> -c Release -- --filter-class <FQN>` | **works** — `Total: 6`, exit 0, ~10s incl. build → the form the profile leads with |
| `<binary> --filter-class <FQN>` | **works** — `total: 6` of 808, 191 ms |
| `<binary> --filter-namespace FormCraft.UnitTests.Ci` | `total: 59` of 808 |
| `<binary> --filter-class '*GitignoreTests'` | `total: 6` — wildcards work |
| MudBlazor host, `--filter-class …AriaRequiredTests` | `total: 34` of 464 — not project-specific |
| `dotnet test --filter FullyQualifiedName~…` | **still inert** — `MTP0001`, `Total: 808`, whole suite ran |
| `<binary> --filter "*Gitignore*"` | `Unknown option`, full `--help`, **no summary line**, direct exit **5** |
| `<binary> --filter-method '<bare name>'` | **`Zero tests ran`, exit 8** — needs the fully-qualified name |
| `./build.sh Test` | 1340 tests (808 + 464 + 68), green, ~30s |

Two corrections to the issue's own premises, both measured rather than assumed:

1. **The bad flag exits `5`, not `0`.** The false green is real but the mechanism is different — piping
   (`| tail`, `| grep`, as agents habitually do) replaces `$?` with the pipe's `0`, and the run emits
   *no summary line at all*, so `grep 'Failed!'` matches nothing. The profile now says to assert on the
   summary line and warns that the pipe, not the binary, manufactures the pass.
2. **A second trap, not in the issue:** `--filter-method` silently matches nothing when given a bare
   method name — it wants `<namespace>.<class>.<method>`, or a wildcard. That prints `Zero tests ran`
   and exits `8`.

### Code review

A review over `dev...HEAD` returned 12 findings, all independently re-measured before acting. Nine
were real and are fixed in `fix: address code-review findings`; the substantive ones:

- **The two paths report failure differently** — the biggest gap. Via the *Preferred* passthrough a
  zero-match prints `Failed! … Total: 0` + exit 1 and **never says `Zero tests ran`**, and a wrong
  flag's `Unknown option` diagnostic never reaches stdout at all (it goes to a `TestResults` log,
  while stdout says `error run failed: Tests failed`). The original text described only the
  direct-binary behaviour, so its verification rule did not apply to the form it recommended.
- **Solution-level passthrough is a live trap.** `dotnet test -c Release -- --filter-class X`
  applies the filter to all three assemblies → one `Passed! … Total: 6` plus two
  `Failed! … Total: 0`, exit 1. Grepping `Passed!` reports green on a failed command. The example
  now names its `.csproj` and the trap is documented.
- **Self-contradiction removed:** the text claimed a bare `--filter-method` name "matches nothing
  and does not say so" while elsewhere documenting `Zero tests ran` — it does say so.
- **Fabricated output line** `# total: 6 (of 808), 191ms` replaced with the real two-line shape, so
  the "grep the summary line" rule is actually executable.
- **No `1340` aggregate is ever printed** — three per-assembly summaries in nondeterministic order;
  a check reading the first accepts `Total: 68` as the whole suite.
- **Duplicate guidance collapsed:** the *Environment gotchas* entry is a pointer again, not a second
  copy that would drift.
- Also added: simple filters cannot be combined with `--filter-query`; the SDK stamp now comes from
  `dotnet --version` rather than the `global.json` pin (`rollForward: latestFeature` means the pin
  cannot signal drift); Windows `.exe` caveat, marked as not measured here.

**Scope call:** the review also flagged the **Worktree home** section as flatly false — it claimed
`.claude/worktrees/` was unignored due to a collapsed `.gitignore:13`. Verified: line 13 is
`/test-results/`, line 16 is `.claude/worktrees/`, split apart by #223 (`6e8a10c`) and pinned by the
very `GitignoreTests` class this PR uses as its example. Although "auditing the rest of the profile"
is a stated non-goal, leaving a **proven-false** claim in the one file this PR exists to make
truthful would be self-defeating, so it is corrected here. Flagged rather than smuggled.

## Follow-ups

Deliberately **not** fixed here — genuinely out of scope (different file / different audience):

- **`CLAUDE.md` still teaches five inert `dotnet test --filter …` invocations** (lines 37-43),
  including `--filter "Category=Builder|Renderer|Security"`. Measured: `--filter` is ignored
  (`MTP0001`, `Total: 808` — the whole suite), *and* the repo contains zero `[Trait]` attributes, so
  the `Category` examples never matched anything. This matters more than the profile: `CLAUDE.md` is
  auto-loaded every session, while `repo-profile.md` is read only by the lifecycle skills.
- `CLAUDE.md` also still says "600+ unit tests across 2 test projects" — it is now **1340** across
  **three** (`FormCraft.ForFluentUI.UnitTests`, added in #261).
- The alternate worktree home `.worktrees/` is not ignored (`worktrees-ignored.sh` exits `1`).
  Now noted in the profile; the one-line `.gitignore` addition was not taken unasked.
- Minor: the issue's own spec cites `global.json` as SDK `10.0.301`; it pins `10.0.302`.
