### PR TITLE
fix(mudblazor): report post-init and partially-discarded masked values (#283)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
@@ -77,4 +77,118 @@ public class MaskedValueDiagnosticTests
         // Assert
         applies.ShouldBeFalse();
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // #283 Task 2 — characterisation. Ground truth before the rule, because the rule in Task 3 hangs
+    // entirely on whether MudBlazor gives us something that can tell a DISCARD apart from a
+    // REFORMAT. These tests record what PatternMask 9.8.0 actually does rather than what the issue
+    // assumed it does; if a MudBlazor upgrade changes any of it, these fail first and name the
+    // reason, instead of the rule quietly going wrong.
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// What <c>PatternMask("(000) 000-0000")</c> produces for the four values in the issue's table.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Text</c> is what renders. <c>GetCleanText()</c> is what the mask considers the significant
+    /// characters — the value with the pattern's literals stripped — and is what <c>CleanDelimiters</c>
+    /// makes the mask report back to the model (#265).
+    /// </para>
+    /// <para>
+    /// First finding: the mask CONSUMES characters positionally and silently drops whatever does not
+    /// fit. <c>"+1 555 123 4567"</c> keeps only the first ten digits — <i>a different phone
+    /// number</i> — and <c>"N/A5551234567"</c> drops the letters and keeps the digits. Neither
+    /// blanks, so #266's total-collapse rule cannot see either.
+    /// </para>
+    /// <para>
+    /// Second finding, and the one that changed the design: <b><c>GetCleanText()</c> is not "what
+    /// survived".</b> The issue assumed it returns the mask-significant characters; measured against
+    /// 9.8.0 it returns <c>Text</c> verbatim whenever <c>CleanDelimiters</c> is <c>false</c> — which
+    /// is FormCraft's default and therefore the normal case. Pinned by
+    /// <see cref="PatternMask_CleanText_Should_Follow_CleanDelimiters"/>. A rule written on
+    /// <c>GetCleanText()</c> would have compared <c>"(555) 123-4567"</c> against the raw stored value
+    /// and fired on every correctly-masked field — the exact happy-path false positive #266 was
+    /// designed to avoid.
+    /// </para>
+    /// <para>
+    /// So Task 3 takes the fallback the spec named: compare the two sides with the MASK'S OWN
+    /// LITERALS removed from each. <c>"555 123 4567"</c> and <c>"(555) 123-4567"</c> both reduce to
+    /// <c>5551234567</c> and stay silent, while <c>"+1 555 123 4567"</c> reduces to
+    /// <c>+15551234567</c> against the rendered <c>1555123456</c> and warns. The literal set is
+    /// derivable because the mask exposes its placeholder alphabet — see
+    /// <see cref="PatternMask_Should_Expose_Its_Placeholder_Alphabet"/>.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("N/A", "", "")]
+    [InlineData("+1 555 123 4567", "(155) 512-3456", "(155) 512-3456")]
+    [InlineData("N/A5551234567", "(555) 123-4567", "(555) 123-4567")]
+    [InlineData("5551234567", "(555) 123-4567", "(555) 123-4567")]
+    public void PatternMask_Should_Produce_The_Recorded_Text_And_CleanText(
+        string stored,
+        string expectedText,
+        string expectedCleanText)
+    {
+        // Arrange
+        var mask = new PatternMask("(000) 000-0000");
+
+        // Act
+        mask.SetText(stored);
+
+        // Assert
+        mask.Text.ShouldBe(expectedText);
+        mask.GetCleanText().ShouldBe(expectedCleanText);
+    }
+
+    /// <summary>
+    /// <c>GetCleanText()</c> reports the significant characters regardless of <c>CleanDelimiters</c>.
+    /// </summary>
+    /// <remarks>
+    /// The edge case the spec flagged (#265): a mask that strips its own literals must not read as
+    /// having discarded them. This records that <c>CleanDelimiters</c> changes only what the mask
+    /// reports to the MODEL, not what <c>GetCleanText()</c> returns — so a rule written on
+    /// <c>GetCleanText()</c> is unaffected by the setting, and the same stored value yields the same
+    /// verdict either way. Without this, Task 3's rule would need a special case it does not need.
+    /// </remarks>
+    [Theory]
+    [InlineData(false, "(555) 123-4567")]
+    [InlineData(true, "5551234567")]
+    public void PatternMask_CleanText_Should_Follow_CleanDelimiters(
+        bool cleanDelimiters,
+        string expectedCleanText)
+    {
+        // Arrange
+        var mask = new PatternMask("(000) 000-0000") { CleanDelimiters = cleanDelimiters };
+
+        // Act
+        mask.SetText("5551234567");
+
+        // Assert - Text is the same either way; only GetCleanText() moves.
+        mask.Text.ShouldBe("(555) 123-4567");
+        mask.GetCleanText().ShouldBe(expectedCleanText);
+    }
+
+    /// <summary>
+    /// The pattern's placeholder alphabet is readable off the mask, so its literals are derivable.
+    /// </summary>
+    /// <remarks>
+    /// This is the fallback the spec named, and measuring it is what makes the fallback usable rather
+    /// than hypothetical. <c>MaskChars</c> carries the placeholder characters — <c>0</c>, <c>a</c>,
+    /// <c>*</c> by default — so "a literal" is precisely "a pattern character that is not one of
+    /// these", computed from the mask in hand rather than from a hardcoded list that a caller
+    /// supplying custom <c>MaskChars</c> would silently invalidate.
+    /// </remarks>
+    [Fact]
+    public void PatternMask_Should_Expose_Its_Placeholder_Alphabet()
+    {
+        // Arrange
+        var mask = new PatternMask("(000) 000-0000");
+
+        // Act
+        var placeholders = mask.MaskChars.Select(m => m.Char).ToArray();
+
+        // Assert
+        placeholders.ShouldBe(['0', 'a', '*'], ignoreOrder: true);
+    }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
@@ -1,22 +1,30 @@
 namespace FormCraft.ForMudBlazor.UnitTests.Diagnostics;
 
 /// <summary>
-/// Tests the rule behind the diagnostic that reports a mask blanking a stored value (#266).
+/// Tests the rule behind the diagnostic that reports a mask blanking (#266) or partly discarding
+/// (#283) a stored value.
 /// <para>
-/// The rule is deliberately narrow, and the narrowness is the whole design: a mask that reformats
-/// <c>5551234567</c> into <c>(555) 123-4567</c> is doing its job, and warning about it would fire on
-/// every correctly-masked field in every form until someone muted the category. Only total collapse
-/// — a value went in, nothing came out — means the mask rejected the value outright, which is the
-/// case where the user sees a blank field and the model quietly keeps the original.
+/// What the rule must never do is fire on the happy path: a mask that reformats <c>5551234567</c>
+/// into <c>(555) 123-4567</c> is doing its job, and warning about that would fire on every
+/// correctly-masked field in every form until someone muted the category — taking the real signal
+/// with it. So the signal is <b>loss</b>, not difference.
+/// </para>
+/// <para>
+/// ⛔ <b>Do not write a new mask case against <c>(000) 000-0000</c> alone.</b> That pattern's
+/// decoration — <c>"() -"</c> — happens to contain the space and hyphen that test values are
+/// naturally punctuated with, so it cannot distinguish a rule that strips the mask's decoration from
+/// one that strips punctuation generally. An earlier draft of #283 stripped only the mask's own
+/// literals and passed this entire suite while warning on `000-00-0000` + `"123 45 6789"`, a value
+/// nothing had been lost from. Pair every rule case with a pattern whose decoration does NOT match
+/// the value's — see <see cref="Applies_Should_Not_Report_A_Value_Punctuated_Unlike_The_Mask"/>.
 /// </para>
 /// </summary>
 public class MaskedValueDiagnosticTests
 {
     /// <summary>
-    /// The literal characters of <c>(000) 000-0000</c>, the pattern every case here is written
-    /// against — i.e. what <see cref="MaskedValueDiagnostic.LiteralsOf"/> returns for it.
+    /// What <see cref="MaskedValueDiagnostic.DecorationOf"/> returns for <c>(000) 000-0000</c>.
     /// </summary>
-    private const string PhoneLiterals = "() -";
+    private const string PhoneDecoration = "() -";
 
     [Fact]
     public void Applies_Should_Be_True_When_A_NonBlank_Value_Masks_To_Blank()
@@ -25,7 +33,7 @@ public class MaskedValueDiagnosticTests
         // model, the field renders empty, and nothing says so.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("N/A", string.Empty, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies("N/A", string.Empty, PhoneDecoration);
 
         // Assert
         applies.ShouldBeTrue();
@@ -38,7 +46,7 @@ public class MaskedValueDiagnosticTests
         // nothing to report; warning here would make the diagnostic useless noise.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneDecoration);
 
         // Assert
         applies.ShouldBeFalse();
@@ -51,7 +59,7 @@ public class MaskedValueDiagnosticTests
         // overwhelmingly common case of a blank optional field and must stay silent.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies(string.Empty, string.Empty, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies(string.Empty, string.Empty, PhoneDecoration);
 
         // Assert
         applies.ShouldBeFalse();
@@ -63,7 +71,7 @@ public class MaskedValueDiagnosticTests
         // Arrange - the unset-model case, reached before a user has typed anything.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies(null, null, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies(null, null, PhoneDecoration);
 
         // Assert
         applies.ShouldBeFalse();
@@ -78,7 +86,7 @@ public class MaskedValueDiagnosticTests
         // TextMaskMap.Resolve reads a whitespace-only PATTERN as "no mask configured".
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("   ", string.Empty, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies("   ", string.Empty, PhoneDecoration);
 
         // Assert
         applies.ShouldBeFalse();
@@ -95,15 +103,13 @@ public class MaskedValueDiagnosticTests
     /// The full behaviour table: a discard is reported, a reformat is not.
     /// </summary>
     /// <remarks>
-    /// The rule is "strip the mask's own literals from both sides and compare". A reformat only ever
-    /// moves literals around, so the two sides reduce to the same characters; a discard loses
-    /// characters that no amount of reformatting can restore.
+    /// The rule reduces both sides to the characters that carry data — dropping punctuation and the
+    /// mask's own decoration — and compares those. A reformat only rearranges decoration, so the two
+    /// sides reduce to the same characters; a discard loses characters no reformatting can restore.
     /// <para>
-    /// Rows 5 and 6 are the ones that keep it honest, and neither is hypothetical. Stored data
-    /// routinely carries its OWN separators — <c>555 123 4567</c>, <c>555-123-4567</c> — and a rule
-    /// comparing raw strings, or testing whether the stored value survives as a subsequence of the
-    /// rendered one, reports both as discards. They are pure reformats: the same ten digits go in and
-    /// come out.
+    /// These rows all use <c>(000) 000-0000</c>, so they establish the behaviour table from the issue
+    /// but <b>cannot</b> distinguish a decoration-only rule from a correct one — see the class remark.
+    /// <see cref="Applies_Should_Not_Report_A_Value_Punctuated_Unlike_The_Mask"/> is what does that.
     /// </para>
     /// </remarks>
     [Theory]
@@ -119,10 +125,100 @@ public class MaskedValueDiagnosticTests
         bool expected)
     {
         // Act
-        var applies = MaskedValueDiagnostic.Applies(stored, rendered, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies(stored, rendered, PhoneDecoration);
 
         // Assert
         applies.ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// A value punctuated differently from the mask is a reformat, not a discard.
+    /// </summary>
+    /// <remarks>
+    /// The regression test for the bug an earlier #283 draft shipped past a green suite. That draft
+    /// stripped only the <b>mask's</b> literals from both sides, which leaves the stored value's own
+    /// separators standing whenever they are not also the pattern's: <c>000-00-0000</c> over
+    /// <c>"123 45 6789"</c> compared <c>"123 45 6789"</c> against <c>"123456789"</c> and reported a
+    /// discard for an SSN with every digit intact. Legacy data is punctuated however whoever stored
+    /// it felt like, and almost never the way the new mask is.
+    /// <para>
+    /// Every row pairs a pattern with a value punctuated some OTHER way, which is exactly what the
+    /// <c>(000) 000-0000</c> cases above cannot do. The last row is the control: under the same mask
+    /// as row 1, a value that really did lose characters still warns, so these are not passing
+    /// because the rule went silent everywhere.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("000-00-0000", "123 45 6789", "123-45-6789", false)]                        // SSN, spaces stored
+    [InlineData("000.000.0000", "555-123-4567", "555.123.4567", false)]                     // dots vs dashes
+    [InlineData("0000 0000 0000 0000", "4111-1111-1111-1111", "4111 1111 1111 1111", false)] // card
+    [InlineData("(000) 000-0000", "555.123.4567", "(555) 123-4567", false)]                 // dots stored
+    [InlineData("0000000000", "555-123-4567", "5551234567", false)]                         // no literals at all
+    [InlineData("000-00-0000", "N/A123456789", "123-45-6789", true)]                        // control: a real discard
+    public void Applies_Should_Not_Report_A_Value_Punctuated_Unlike_The_Mask(
+        string pattern,
+        string stored,
+        string rendered,
+        bool expected)
+    {
+        // Arrange - decoration derived from the pattern rather than hand-written, so the test cannot
+        // drift from what the production path actually computes.
+        var decoration = MaskedValueDiagnostic.DecorationOf(new PatternMask(pattern));
+
+        // Act
+        var applies = MaskedValueDiagnostic.Applies(stored, rendered, decoration);
+
+        // Assert
+        applies.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Applies_Should_Not_Report_A_Mask_Whose_Literal_Is_Itself_Alphanumeric()
+    {
+        // Arrange - the false positive in the OTHER direction, and the reason the rule is not simply
+        // "strip non-alphanumerics". A pattern may spell a literal that is itself alphanumeric: the
+        // "1" in "+1 000-0000" is decoration the mask contributes, so the rendered side holds a digit
+        // the stored side never had. Stripping punctuation alone would compare "5551234" against
+        // "15551234" and report a discard on a field that is working perfectly.
+        var decoration = MaskedValueDiagnostic.DecorationOf(new PatternMask("+1 000-0000"));
+
+        // Act
+        var applies = MaskedValueDiagnostic.Applies("5551234", "+1 555-1234", decoration);
+
+        // Assert
+        applies.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Applies_Should_Not_Report_Placeholder_Padding()
+    {
+        // Arrange - a PatternMask with a Placeholder pads the positions a short value does not reach,
+        // so the rendered text is LONGER than what was stored. Counting those pad characters as data
+        // reports a discard for characters the mask added -- and would do so for every value shorter
+        // than the pattern, on every render, which for a variable-length field is every value.
+        var mask = new PatternMask("(000) 000-0000") { Placeholder = '_' };
+        var decoration = MaskedValueDiagnostic.DecorationOf(mask);
+
+        // Act
+        var applies = MaskedValueDiagnostic.Applies("55512345", "(555) 123-45__", decoration);
+
+        // Assert
+        applies.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DecorationOf_Should_Include_The_Placeholder()
+    {
+        // Arrange - the placeholder is decoration by the same definition the literals are: the mask
+        // contributes it rather than taking it from the value.
+        var mask = new PatternMask("(000) 000-0000") { Placeholder = '_' };
+
+        // Act
+        var decoration = MaskedValueDiagnostic.DecorationOf(mask);
+
+        // Assert
+        decoration.ShouldNotBeNull();
+        decoration.ShouldContain('_');
     }
 
     [Fact]
@@ -135,8 +231,8 @@ public class MaskedValueDiagnosticTests
         // LiteralsOf the right input and GetCleanText the wrong one.
 
         // Act - what the field renders is identical either way; only the model write-back differs.
-        var reformat = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneLiterals);
-        var discard = MaskedValueDiagnostic.Applies("N/A5551234567", "(555) 123-4567", PhoneLiterals);
+        var reformat = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneDecoration);
+        var discard = MaskedValueDiagnostic.Applies("N/A5551234567", "(555) 123-4567", PhoneDecoration);
 
         // Assert
         reformat.ShouldBeFalse();
@@ -146,19 +242,19 @@ public class MaskedValueDiagnosticTests
     [Theory]
     [InlineData("N/A", "", true)]
     [InlineData("+1 555 123 4567", "(155) 512-3456", false)]
-    public void Applies_Should_Fall_Back_To_Total_Collapse_When_The_Literals_Are_Unknown(
+    public void Applies_Should_Fall_Back_To_Total_Collapse_When_The_Decoration_Is_Unknown(
         string stored,
         string rendered,
         bool expected)
     {
-        // Arrange - a null literal set means "no opinion", which LiteralsOf returns for a mask whose
+        // Arrange - null decoration means "no opinion", which DecorationOf returns for a mask whose
         // decoration cannot be read off a pattern (a RegexMask from the #265 factory) or whose
         // Transformation rewrites characters as it consumes them. Guessing there would report every
         // value of a correctly configured field. Falling back to #266's rule keeps the blank case
         // covered and reports nothing it cannot justify.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies(stored, rendered, maskLiterals: null);
+        var applies = MaskedValueDiagnostic.Applies(stored, rendered, maskDecoration: null);
 
         // Assert
         applies.ShouldBe(expected);
@@ -174,38 +270,38 @@ public class MaskedValueDiagnosticTests
         // a case #266 reported.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("()-", string.Empty, PhoneLiterals);
+        var applies = MaskedValueDiagnostic.Applies("()-", string.Empty, PhoneDecoration);
 
         // Assert
         applies.ShouldBeTrue();
     }
 
     [Fact]
-    public void LiteralsOf_Should_Return_The_Patterns_NonPlaceholder_Characters()
+    public void DecorationOf_Should_Return_The_Patterns_NonPlaceholder_Characters()
     {
         // Act
-        var literals = MaskedValueDiagnostic.LiteralsOf(new PatternMask("(000) 000-0000"));
+        var literals = MaskedValueDiagnostic.DecorationOf(new PatternMask("(000) 000-0000"));
 
         // Assert - distinct, in first-appearance order; the digits' placeholder '0' is not decoration.
-        literals.ShouldBe(PhoneLiterals);
+        literals.ShouldBe(PhoneDecoration);
     }
 
     [Fact]
-    public void LiteralsOf_Should_Be_Null_For_A_Mask_It_Cannot_Read()
+    public void DecorationOf_Should_Be_Null_For_A_Mask_It_Cannot_Read()
     {
         // Arrange - a RegexMask reaches the diagnostic through the #265 factory. Its Mask is a
         // regular expression, so its non-placeholder characters are metacharacters rather than
         // decoration, and stripping them would be nonsense dressed up as a rule.
 
         // Act
-        var literals = MaskedValueDiagnostic.LiteralsOf(new RegexMask(@"^\d{0,10}$"));
+        var literals = MaskedValueDiagnostic.DecorationOf(new RegexMask(@"^\d{0,10}$"));
 
         // Assert
         literals.ShouldBeNull();
     }
 
     [Fact]
-    public void LiteralsOf_Should_Be_Null_For_A_Transforming_Mask()
+    public void DecorationOf_Should_Be_Null_For_A_Transforming_Mask()
     {
         // Arrange - a Transformation rewrites characters as the mask consumes them, so the rendered
         // text legitimately differs from the stored value character for character and EVERY value
@@ -214,7 +310,7 @@ public class MaskedValueDiagnosticTests
         var mask = new PatternMask("aaa") { Transformation = char.ToUpperInvariant };
 
         // Act
-        var literals = MaskedValueDiagnostic.LiteralsOf(mask);
+        var literals = MaskedValueDiagnostic.DecorationOf(mask);
 
         // Assert
         literals.ShouldBeNull();

--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedValueDiagnosticTests.cs
@@ -12,6 +12,12 @@ namespace FormCraft.ForMudBlazor.UnitTests.Diagnostics;
 /// </summary>
 public class MaskedValueDiagnosticTests
 {
+    /// <summary>
+    /// The literal characters of <c>(000) 000-0000</c>, the pattern every case here is written
+    /// against — i.e. what <see cref="MaskedValueDiagnostic.LiteralsOf"/> returns for it.
+    /// </summary>
+    private const string PhoneLiterals = "() -";
+
     [Fact]
     public void Applies_Should_Be_True_When_A_NonBlank_Value_Masks_To_Blank()
     {
@@ -19,7 +25,7 @@ public class MaskedValueDiagnosticTests
         // model, the field renders empty, and nothing says so.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("N/A", string.Empty);
+        var applies = MaskedValueDiagnostic.Applies("N/A", string.Empty, PhoneLiterals);
 
         // Assert
         applies.ShouldBeTrue();
@@ -32,7 +38,7 @@ public class MaskedValueDiagnosticTests
         // nothing to report; warning here would make the diagnostic useless noise.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567");
+        var applies = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneLiterals);
 
         // Assert
         applies.ShouldBeFalse();
@@ -45,7 +51,7 @@ public class MaskedValueDiagnosticTests
         // overwhelmingly common case of a blank optional field and must stay silent.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies(string.Empty, string.Empty);
+        var applies = MaskedValueDiagnostic.Applies(string.Empty, string.Empty, PhoneLiterals);
 
         // Assert
         applies.ShouldBeFalse();
@@ -57,7 +63,7 @@ public class MaskedValueDiagnosticTests
         // Arrange - the unset-model case, reached before a user has typed anything.
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies(null, null);
+        var applies = MaskedValueDiagnostic.Applies(null, null, PhoneLiterals);
 
         // Assert
         applies.ShouldBeFalse();
@@ -72,10 +78,146 @@ public class MaskedValueDiagnosticTests
         // TextMaskMap.Resolve reads a whitespace-only PATTERN as "no mask configured".
 
         // Act
-        var applies = MaskedValueDiagnostic.Applies("   ", string.Empty);
+        var applies = MaskedValueDiagnostic.Applies("   ", string.Empty, PhoneLiterals);
 
         // Assert
         applies.ShouldBeFalse();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // #283(b) — the widened rule. A mask that discards PART of a value is reported too, because the
+    // model then diverges from the display just as surely as when it blanks. It is arguably the worse
+    // of the two: a blank field is visibly wrong, whereas "(155) 512-3456" is a plausible phone
+    // number that simply is not the one on record.
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The full behaviour table: a discard is reported, a reformat is not.
+    /// </summary>
+    /// <remarks>
+    /// The rule is "strip the mask's own literals from both sides and compare". A reformat only ever
+    /// moves literals around, so the two sides reduce to the same characters; a discard loses
+    /// characters that no amount of reformatting can restore.
+    /// <para>
+    /// Rows 5 and 6 are the ones that keep it honest, and neither is hypothetical. Stored data
+    /// routinely carries its OWN separators — <c>555 123 4567</c>, <c>555-123-4567</c> — and a rule
+    /// comparing raw strings, or testing whether the stored value survives as a subsequence of the
+    /// rendered one, reports both as discards. They are pure reformats: the same ten digits go in and
+    /// come out.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("N/A", "", true)]                             // total collapse — #266, unchanged
+    [InlineData("+1 555 123 4567", "(155) 512-3456", true)]   // #283(b): shifted, a DIFFERENT number
+    [InlineData("N/A5551234567", "(555) 123-4567", true)]     // #283(b): the letters were dropped
+    [InlineData("5551234567", "(555) 123-4567", false)]       // reformat
+    [InlineData("555 123 4567", "(555) 123-4567", false)]     // reformat, value had its own spaces
+    [InlineData("(555) 123-4567", "(555) 123-4567", false)]   // already formatted — nothing happened
+    public void Applies_Should_Report_A_Discard_But_Never_A_Reformat(
+        string stored,
+        string rendered,
+        bool expected)
+    {
+        // Act
+        var applies = MaskedValueDiagnostic.Applies(stored, rendered, PhoneLiterals);
+
+        // Assert
+        applies.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Applies_Should_Ignore_CleanDelimiters()
+    {
+        // Arrange - the #265 edge case the spec flagged: a mask that strips its own literals must not
+        // read as having discarded them. It cannot, because the rule removes those same literals from
+        // BOTH sides before comparing -- so the verdict is the same whichever way CleanDelimiters is
+        // set, even though the two produce different clean text. This is the property that made
+        // LiteralsOf the right input and GetCleanText the wrong one.
+
+        // Act - what the field renders is identical either way; only the model write-back differs.
+        var reformat = MaskedValueDiagnostic.Applies("5551234567", "(555) 123-4567", PhoneLiterals);
+        var discard = MaskedValueDiagnostic.Applies("N/A5551234567", "(555) 123-4567", PhoneLiterals);
+
+        // Assert
+        reformat.ShouldBeFalse();
+        discard.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("N/A", "", true)]
+    [InlineData("+1 555 123 4567", "(155) 512-3456", false)]
+    public void Applies_Should_Fall_Back_To_Total_Collapse_When_The_Literals_Are_Unknown(
+        string stored,
+        string rendered,
+        bool expected)
+    {
+        // Arrange - a null literal set means "no opinion", which LiteralsOf returns for a mask whose
+        // decoration cannot be read off a pattern (a RegexMask from the #265 factory) or whose
+        // Transformation rewrites characters as it consumes them. Guessing there would report every
+        // value of a correctly configured field. Falling back to #266's rule keeps the blank case
+        // covered and reports nothing it cannot justify.
+
+        // Act
+        var applies = MaskedValueDiagnostic.Applies(stored, rendered, maskLiterals: null);
+
+        // Assert
+        applies.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Applies_Should_Report_A_Value_Made_Only_Of_Literals()
+    {
+        // Arrange - the regression this rule could plausibly have introduced, which is why the blank
+        // case stays an explicit disjunct rather than being folded into the comparison. "()-" is
+        // non-blank but contains nothing the mask keeps, so it renders empty AND both sides reduce to
+        // "" -- meaning a pure strip-and-compare rule would call it a reformat and go silent, losing
+        // a case #266 reported.
+
+        // Act
+        var applies = MaskedValueDiagnostic.Applies("()-", string.Empty, PhoneLiterals);
+
+        // Assert
+        applies.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LiteralsOf_Should_Return_The_Patterns_NonPlaceholder_Characters()
+    {
+        // Act
+        var literals = MaskedValueDiagnostic.LiteralsOf(new PatternMask("(000) 000-0000"));
+
+        // Assert - distinct, in first-appearance order; the digits' placeholder '0' is not decoration.
+        literals.ShouldBe(PhoneLiterals);
+    }
+
+    [Fact]
+    public void LiteralsOf_Should_Be_Null_For_A_Mask_It_Cannot_Read()
+    {
+        // Arrange - a RegexMask reaches the diagnostic through the #265 factory. Its Mask is a
+        // regular expression, so its non-placeholder characters are metacharacters rather than
+        // decoration, and stripping them would be nonsense dressed up as a rule.
+
+        // Act
+        var literals = MaskedValueDiagnostic.LiteralsOf(new RegexMask(@"^\d{0,10}$"));
+
+        // Assert
+        literals.ShouldBeNull();
+    }
+
+    [Fact]
+    public void LiteralsOf_Should_Be_Null_For_A_Transforming_Mask()
+    {
+        // Arrange - a Transformation rewrites characters as the mask consumes them, so the rendered
+        // text legitimately differs from the stored value character for character and EVERY value
+        // would read as a discard. Firing on every value of a correctly configured field is the
+        // happy-path false positive the whole diagnostic is shaped to avoid.
+        var mask = new PatternMask("aaa") { Transformation = char.ToUpperInvariant };
+
+        // Act
+        var literals = MaskedValueDiagnostic.LiteralsOf(mask);
+
+        // Assert
+        literals.ShouldBeNull();
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -142,14 +284,19 @@ public class MaskedValueDiagnosticTests
     }
 
     /// <summary>
-    /// <c>GetCleanText()</c> reports the significant characters regardless of <c>CleanDelimiters</c>.
+    /// <c>GetCleanText()</c> tracks <c>CleanDelimiters</c> — it is not a stable "what survived".
     /// </summary>
     /// <remarks>
-    /// The edge case the spec flagged (#265): a mask that strips its own literals must not read as
-    /// having discarded them. This records that <c>CleanDelimiters</c> changes only what the mask
-    /// reports to the MODEL, not what <c>GetCleanText()</c> returns — so a rule written on
-    /// <c>GetCleanText()</c> is unaffected by the setting, and the same stored value yields the same
-    /// verdict either way. Without this, Task 3's rule would need a special case it does not need.
+    /// The measurement that ruled out the issue's proposed implementation. With the default
+    /// <c>CleanDelimiters = false</c> — what FormCraft configures unless <c>.WithMask(…, true)</c>
+    /// says otherwise (#265) — <c>GetCleanText()</c> hands back the formatted <c>Text</c>, literals
+    /// and all. Only with the flag set does it strip them.
+    /// <para>
+    /// So the same stored value would yield opposite verdicts under a <c>GetCleanText()</c>-based
+    /// rule depending on a setting that has nothing to do with whether data was lost. The rule uses
+    /// the mask's literal set instead, which is invariant across the flag — pinned from the rule's
+    /// side by <c>Applies_Should_Ignore_CleanDelimiters</c>.
+    /// </para>
     /// </remarks>
     [Theory]
     [InlineData(false, "(555) 123-4567")]

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
@@ -1038,6 +1038,133 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
     }
 
     [Fact]
+    public void TextField_With_A_Mask_Should_Warn_When_A_Rejected_Value_Arrives_After_First_Render()
+    {
+        // Arrange - #283(a). The canonical legacy-data case, and the one #266 could not see: the
+        // field renders before the fetch resolves, so CurrentValue is empty at OnInitialized and the
+        // diagnostic returns early. The value then lands, the field renders blank, the model keeps
+        // "N/A" -- the exact divergence #266 exists to report, unreported.
+        //
+        //     protected override async Task OnInitializedAsync()
+        //         => _model.Phone = await _api.GetPhoneAsync();   // "N/A"
+        //
+        // The spec's stated reason for the initial-value framing -- "a field the user legitimately
+        // cleared must not warn on a later render" -- is already covered independently, because the
+        // rule requires a NON-BLANK stored value. Clearing a field can never satisfy it, so emitting
+        // later costs nothing.
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Nothing was stored at first render, so there was nothing to report yet. Asserted rather
+        // than assumed: a warning here would make the post-arrival count below meaningless.
+        _logs.Warnings.ShouldBeEmpty();
+
+        // Act - the fetch resolves and the model is populated from outside the component.
+        model.Phone = "N/A";
+        component.Render();
+
+        // Assert - reported once, naming the field and the pattern like the OnInitialized path does.
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Phone");
+        warnings[0].ShouldContain("(000) 000-0000");
+    }
+
+    [Fact]
+    public void TextField_With_A_Mask_Should_Warn_Only_Once_Across_Later_Renders()
+    {
+        // Arrange - #283(a). Moving the emit off OnInitialized removes the thing that used to make
+        // "once per component lifetime" true for free. A plain field has no CollectionItemFieldScope
+        // and therefore no latch, so without a component-level one the warning would re-fire on every
+        // external model change -- flooding the console of the developer it is meant to help, which
+        // is how a useful diagnostic gets muted.
+        var model = new TestModel { Phone = "N/A" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Act - a second non-conforming value arrives, then a plain re-render.
+        model.Phone = "unknown";
+        component.Render();
+        component.Render();
+
+        // Assert
+        _logs.Warnings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TextField_With_A_Mask_Should_Not_Warn_When_The_User_Types_Into_It()
+    {
+        // Arrange - #283(a). The load-bearing negative for the widened emit point: this reports
+        // STORED data, never live editing. A user part-way through typing holds a value the mask has
+        // not finished formatting, and re-checking on every keystroke would report the field being
+        // filled in correctly. ShouldReloadValue() is what tells an external model change apart from
+        // an in-flight edit, and this pins that the emit sits downstream of it.
+        var model = new TestModel();
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Act - a partial entry, then a completed one.
+        component.Find("input").Input("555");
+        component.Find("input").Input("5551234567");
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TextField_With_A_Mask_Should_Not_Warn_When_The_User_Clears_It()
+    {
+        // Arrange - #283(a). The case the "initial value" framing was chosen to protect, kept
+        // honest now that the framing is gone: a field the user emptied on purpose must stay silent.
+        // It does so through the rule rather than the emit point -- Applies requires a non-blank
+        // stored value, and a cleared field has none.
+        var model = new TestModel { Phone = "5551234567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Act - cleared from outside the component, the harsher of the two ways to reach a blank
+        // value: it goes through the external-change path the new emit point sits on.
+        model.Phone = string.Empty;
+        component.Render();
+
+        // Assert
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void TextField_With_A_Blank_Mask_Should_Bind_No_Mask()
     {
         // Arrange - a whitespace-only pattern is not "a mask of one space", it is a

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
@@ -1250,6 +1250,66 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
     }
 
     [Theory]
+    [InlineData("000-00-0000", "123 45 6789", "123-45-6789")]
+    [InlineData("000.000.0000", "555-123-4567", "555.123.4567")]
+    [InlineData("0000 0000 0000 0000", "4111-1111-1111-1111", "4111 1111 1111 1111")]
+    [InlineData("0000000000", "555-123-4567", "5551234567")]
+    public void TextField_With_A_Mask_Should_Not_Warn_When_The_Value_Is_Punctuated_Unlike_The_Mask(
+        string pattern,
+        string stored,
+        string expectedDisplay)
+    {
+        // Arrange - end-to-end regression for the false-positive class that an earlier #283 draft
+        // shipped past a green suite, because every mask test used "(000) 000-0000" -- whose own
+        // decoration happens to contain the space and hyphen the test values were punctuated with.
+        // Legacy data carries whatever separators it was stored with, and they are rarely the ones a
+        // newly-added mask spells. Every row here is intact data being reformatted, and every one of
+        // them warned under that draft.
+        var model = new TestModel { Phone = stored };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", pattern))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert - nothing was lost, so nothing is reported.
+        component.Find("input").GetAttribute("value").ShouldBe(expectedDisplay);
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TextField_With_A_Placeholder_Mask_Should_Not_Warn_On_A_Short_Value()
+    {
+        // Arrange - a PatternMask carrying a Placeholder pads the positions a short value does not
+        // reach, so the rendered text is LONGER than what was stored. Counting the padding as data
+        // reports a discard for characters the mask ADDED -- on every value shorter than the pattern,
+        // which for a variable-length field is essentially every value. Reachable only through the
+        // #265 factory overload, which is how this is configured here.
+        var model = new TestModel { Phone = "55512345" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithMask(() => new PatternMask("(000) 000-0000") { Placeholder = '_' }))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert - the padding is visible in the display, and is not mistaken for lost data.
+        component.Find("input").GetAttribute("value").ShouldBe("(555) 123-45__");
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public void TextField_With_A_CleanDelimiters_Mask_Should_Not_Warn_On_A_Reformat(bool cleanDelimiters)

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/MudBlazorTextFieldComponentTests.cs
@@ -1165,6 +1165,145 @@ public class MudBlazorTextFieldComponentTests : MudBlazorTestBase
     }
 
     [Fact]
+    public void TextField_With_A_Mask_Should_Warn_When_It_Discards_Part_Of_A_Stored_Value()
+    {
+        // Arrange - #283(b), end-to-end against the real MudBlazor mask rather than the rule alone.
+        // "+1 555 123 4567" does not blank: it renders "(155) 512-3456", a perfectly plausible phone
+        // number that is NOT the one stored. The mask consumed the country code as the area code and
+        // dropped the final digit off the end. Nothing on screen looks wrong, which is exactly why
+        // this needs reporting more than the blank case does.
+        var model = new TestModel { Phone = "+1 555 123 4567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert - the divergence is real: the input shows one number, the model keeps another.
+        component.Find("input").GetAttribute("value").ShouldBe("(155) 512-3456");
+        model.Phone.ShouldBe("+1 555 123 4567");
+
+        // And the message names what is DISPLAYED, not "renders empty" -- the developer has to be
+        // able to recognise the field, and this one looks entirely healthy.
+        var warnings = _logs.Warnings;
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("Phone");
+        warnings[0].ShouldContain("(000) 000-0000");
+        warnings[0].ShouldContain("(155) 512-3456");
+        warnings[0].ShouldNotContain("renders empty");
+    }
+
+    [Fact]
+    public void TextField_With_A_Mask_Should_Warn_When_It_Discards_Leading_Junk()
+    {
+        // Arrange - #283(b), the second row of the issue's table. Here the SURVIVING digits are the
+        // right ones, so the rendered number is correct; what was silently dropped is the "N/A"
+        // marker that told a reader the record had no usable phone number.
+        var model = new TestModel { Phone = "N/A5551234567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Find("input").GetAttribute("value").ShouldBe("(555) 123-4567");
+        _logs.Warnings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TextField_With_A_Mask_Should_Not_Warn_When_The_Stored_Value_Has_Its_Own_Separators()
+    {
+        // Arrange - #283(b)'s load-bearing negative, and the shape of real legacy data. The stored
+        // value is already punctuated, just differently from the mask. Every significant character
+        // survives, so this is a reformat and must stay silent -- a rule comparing raw strings, or
+        // asking whether the stored value survives as a subsequence of the rendered one, reports it
+        // as a discard and fires on data that is perfectly fine.
+        var model = new TestModel { Phone = "555 123 4567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithAttribute("Mask", "(000) 000-0000"))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Find("input").GetAttribute("value").ShouldBe("(555) 123-4567");
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TextField_With_A_CleanDelimiters_Mask_Should_Not_Warn_On_A_Reformat(bool cleanDelimiters)
+    {
+        // Arrange - the #265 edge case the spec called out: a mask that strips its own literals out
+        // of the value it reports must not read as having DISCARDED them. It cannot, because the rule
+        // removes the mask's literals from both sides before comparing -- so the verdict is identical
+        // whichever way the flag is set, even though the two write different things to the model.
+        // Asserted through the builder rather than on the rule alone, because CleanDelimiters is a
+        // setting a caller chooses and this is the path they take.
+        var model = new TestModel { Phone = "5551234567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithMask("(000) 000-0000", cleanDelimiters: cleanDelimiters))
+            .Build();
+
+        // Act
+        var component = Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        component.Find("input").GetAttribute("value").ShouldBe("(555) 123-4567");
+        _logs.Warnings.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TextField_With_A_CleanDelimiters_Mask_Should_Still_Warn_On_A_Discard(bool cleanDelimiters)
+    {
+        // Arrange - the other half: CleanDelimiters must not SUPPRESS a real discard either. Same
+        // stored value as the discard test above, run through the typed builder with the flag both
+        // ways.
+        var model = new TestModel { Phone = "N/A5551234567" };
+        var config = FormBuilder<TestModel>
+            .Create()
+            .AddField(x => x.Phone, field => field
+                .WithLabel("Phone")
+                .WithMask("(000) 000-0000", cleanDelimiters: cleanDelimiters))
+            .Build();
+
+        // Act
+        Render<FormCraftComponent<TestModel>>(parameters => parameters
+            .Add(p => p.Model, model)
+            .Add(p => p.Configuration, config));
+
+        // Assert
+        _logs.Warnings.Count.ShouldBe(1);
+    }
+
+    [Fact]
     public void TextField_With_A_Blank_Mask_Should_Bind_No_Mask()
     {
         // Arrange - a whitespace-only pattern is not "a mask of one space", it is a

--- a/FormCraft.ForMudBlazor/Diagnostics/MaskedValueDiagnostic.cs
+++ b/FormCraft.ForMudBlazor/Diagnostics/MaskedValueDiagnostic.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
@@ -5,15 +6,23 @@ using MudBlazor;
 namespace FormCraft.ForMudBlazor;
 
 /// <summary>
-/// Reports a stored value that a configured mask rendered as blank (#266).
+/// Reports a stored value that a configured mask blanked (#266) or partly discarded (#283).
 /// </summary>
 /// <remarks>
 /// <para>
-/// The mechanism is MudBlazor's, not FormCraft's: on the first parameter pass <c>MudBaseInput</c>
-/// builds its display text by running the value through the mask with <c>updateValue: false</c>. A
-/// value the mask rejects collapses to empty, and because <c>updateValue</c> is false the model is
-/// never written back. The developer sees a blank field, the user submits without touching it, and
-/// the non-conforming value survives — with nothing logged and nothing thrown.
+/// The mechanism is MudBlazor's, not FormCraft's: <c>MudBaseInput</c> builds its display text by
+/// running the value through the mask with <c>updateValue: false</c>. Whatever the mask cannot place
+/// is dropped, and because <c>updateValue</c> is false the model is never written back. The user
+/// submits without touching the field and the non-conforming value survives — with nothing logged
+/// and nothing thrown.
+/// </para>
+/// <para>
+/// Two shapes, one consequence. The value collapses to empty, which is at least visibly wrong; or
+/// the mask keeps the characters that happen to fit and drops the rest, which is not visibly wrong
+/// at all — <c>"+1 555 123 4567"</c> under <c>(000) 000-0000</c> displays <c>(155) 512-3456</c>, a
+/// plausible phone number that is not the one on record. #266 reported only the first; #283 widened
+/// it to both, on the grounds that the display and the model diverge either way and the silent shape
+/// is the harder one to notice.
 /// </para>
 /// <para>
 /// Not new MudBlazor behaviour, but newly *reachable*: until #211 the <c>Mask</c> attribute did
@@ -57,11 +66,21 @@ internal static class MaskedValueDiagnostic
     /// is not.
     /// </para>
     /// <para>
-    /// The widened rule strips the mask's own literals from both sides and compares what is left. A
-    /// reformat only ever moves literals around, so the two sides reduce to the same characters; a
-    /// discard loses characters no reformatting could restore. Stripping <i>both</i> sides is what
-    /// keeps stored data that carries its own separators — <c>555 123 4567</c>, <c>555-123-4567</c>,
-    /// the normal shape of legacy data — from reading as a discard.
+    /// The widened rule reduces both sides to the characters that carry the <i>data</i> — dropping
+    /// punctuation and the mask's own decoration — and compares those. A reformat only rearranges
+    /// decoration, so the two sides reduce to the same characters; a discard loses characters no
+    /// reformatting could restore.
+    /// </para>
+    /// <para>
+    /// "Carries the data" is two conditions, and getting it down to one produces false positives in
+    /// opposite directions. Dropping only the <b>mask's literals</b> leaves the stored value's own
+    /// punctuation in place, so <c>000-00-0000</c> over a stored <c>"123 45 6789"</c> compares
+    /// <c>"123 45 6789"</c> against <c>"123456789"</c> and reports a discard for data that is
+    /// completely intact — legacy data carries its own separators, and they are rarely the pattern's.
+    /// Dropping only <b>non-alphanumerics</b> fails the other way: a pattern may spell a literal that
+    /// is itself alphanumeric (<c>+1 000-0000</c> contributes a <c>1</c>), which the rendered side
+    /// then holds and the stored side does not. So both apply: keep a character only if it could
+    /// match one of the mask's placeholders <b>and</b> is not decoration the mask contributes.
     /// </para>
     /// <para>
     /// The blank test stays an explicit disjunct rather than being folded into that comparison,
@@ -77,11 +96,12 @@ internal static class MaskedValueDiagnostic
     /// </remarks>
     /// <param name="configuredValue">The value held by the model before the mask was applied.</param>
     /// <param name="maskedResult">What that value renders as once run through the mask.</param>
-    /// <param name="maskLiterals">
-    /// The characters the mask inserts as decoration, from <see cref="LiteralsOf"/>, or <c>null</c>
-    /// when they could not be determined — in which case only the total-collapse test applies.
+    /// <param name="maskDecoration">
+    /// The characters the mask contributes rather than takes from the value, from
+    /// <see cref="DecorationOf"/>, or <c>null</c> when they could not be determined — in which case
+    /// only the total-collapse test applies.
     /// </param>
-    internal static bool Applies(string? configuredValue, string? maskedResult, string? maskLiterals)
+    internal static bool Applies(string? configuredValue, string? maskedResult, string? maskDecoration)
     {
         if (string.IsNullOrWhiteSpace(configuredValue))
         {
@@ -89,42 +109,65 @@ internal static class MaskedValueDiagnostic
         }
 
         // #266's rule, unchanged and checked first: something was stored and nothing came out.
-        if (string.IsNullOrWhiteSpace(maskedResult))
+        if (RendersEmpty(maskedResult))
         {
             return true;
         }
 
-        // LiteralsOf could not answer without guessing (a non-pattern or transforming mask). Report
+        // DecorationOf could not answer without guessing (a non-pattern or transforming mask). Report
         // nothing beyond the collapse case above rather than invent a verdict — the cost of a wrong
         // "yes" here is a warning on every value of a correctly configured field.
-        if (maskLiterals is null)
+        if (maskDecoration is null)
         {
             return false;
         }
 
         return !string.Equals(
-            WithoutLiterals(configuredValue, maskLiterals),
-            WithoutLiterals(maskedResult, maskLiterals),
+            DataCharacters(configuredValue, maskDecoration),
+            DataCharacters(maskedResult, maskDecoration),
             StringComparison.Ordinal);
     }
 
     /// <summary>
-    /// <paramref name="value"/> with every one of the mask's literal characters removed.
+    /// Whether the field renders nothing at all — #266's original signal.
     /// </summary>
     /// <remarks>
-    /// Applied to the stored value and the rendered text alike, which is the whole point: it reduces
-    /// both to the characters the mask treats as significant, so the comparison sees data rather than
-    /// punctuation. Ordinal throughout — these are literal characters from a pattern, not text being
-    /// collated.
+    /// One predicate with one home, because two callers depend on it: <see cref="Applies"/> decides
+    /// whether to report, and <see cref="Warn"/> decides which of the two messages to write. Spelling
+    /// it twice would let the rule and its explanation drift — a later refinement to the rule would
+    /// leave the emitter telling a developer their field "renders empty" while it is in fact
+    /// displaying a wrong value, which is the confusion the two messages exist to prevent.
     /// </remarks>
-    /// <param name="value">The stored value or the rendered text.</param>
-    /// <param name="literals">The mask's literal characters, from <see cref="LiteralsOf"/>.</param>
-    private static string WithoutLiterals(string value, string literals) =>
-        string.Concat(value.Where(c => !literals.Contains(c)));
+    /// <param name="maskedResult">What the field displays.</param>
+    internal static bool RendersEmpty([NotNullWhen(false)] string? maskedResult) =>
+        string.IsNullOrWhiteSpace(maskedResult);
 
     /// <summary>
-    /// The characters <paramref name="mask"/> inserts as decoration, or <c>null</c> when they cannot
-    /// be determined (#283).
+    /// <paramref name="value"/> reduced to the characters that carry data rather than format it.
+    /// </summary>
+    /// <remarks>
+    /// Applied to the stored value and the rendered text alike, which is the whole point: it puts
+    /// both in the same terms so the comparison sees data rather than punctuation.
+    /// <para>
+    /// A character survives only if it could match one of the mask's placeholders — approximated by
+    /// <see cref="char.IsLetterOrDigit(char)"/>, the union of the default <c>0</c>/<c>a</c>/<c>*</c>
+    /// alphabet — <b>and</b> is not something the mask itself contributes. A caller who narrows
+    /// <c>MaskChars</c> to a punctuation class through the #265 factory therefore has a character
+    /// treated as noise that the mask considers significant; that direction under-reports, which is
+    /// the side to err on.
+    /// </para>
+    /// <para>
+    /// Ordinal throughout — these are pattern characters, not text being collated.
+    /// </para>
+    /// </remarks>
+    /// <param name="value">The stored value or the rendered text.</param>
+    /// <param name="decoration">What the mask contributes, from <see cref="DecorationOf"/>.</param>
+    private static string DataCharacters(string value, string decoration) =>
+        new(value.Where(c => char.IsLetterOrDigit(c) && !decoration.Contains(c)).ToArray());
+
+    /// <summary>
+    /// The characters <paramref name="mask"/> contributes rather than takes from the value, or
+    /// <c>null</c> when they cannot be determined (#283).
     /// </summary>
     /// <remarks>
     /// <para>
@@ -136,10 +179,14 @@ internal static class MaskedValueDiagnostic
     /// correctly-masked field. Pinned by <c>MaskedValueDiagnosticTests</c>'s characterisation block.
     /// </para>
     /// <para>
-    /// Derived from the pattern rather than hardcoded: a literal is any pattern character that is not
-    /// one of the mask's own placeholders, and <c>MaskChars</c> is where those live. Reading them off
-    /// the instance keeps this correct for a caller who supplies custom <c>MaskChars</c> through the
-    /// #265 factory, which a hardcoded <c>0</c>/<c>a</c>/<c>*</c> list would silently get wrong.
+    /// Two sources, both read off the instance rather than hardcoded. The pattern's <b>literals</b>
+    /// are its characters that are not one of the mask's own placeholders, and <c>MaskChars</c> is
+    /// where those placeholders live — so a caller supplying custom <c>MaskChars</c> through the #265
+    /// factory is handled, which a hardcoded <c>0</c>/<c>a</c>/<c>*</c> list would get wrong. The
+    /// <b>placeholder</b> is what <c>PatternMask</c> pads unfilled positions with: a mask configured
+    /// with one renders <c>(555) 123-45__</c> for a short value, and counting those pad characters as
+    /// data would report a discard for characters the mask <i>added</i> — every value shorter than
+    /// the pattern, on every render.
     /// </para>
     /// <para>
     /// Returns <c>null</c> — meaning "no opinion", which <see cref="Applies"/> reads as a fall back to
@@ -149,7 +196,11 @@ internal static class MaskedValueDiagnostic
     /// <item>
     /// a mask that is not a <see cref="PatternMask"/>. The #265 factory can supply any
     /// <see cref="IMask"/>, and a <c>RegexMask</c>'s <c>Mask</c> is a regular expression whose
-    /// non-placeholder characters are metacharacters, not decoration.
+    /// non-placeholder characters are metacharacters, not decoration. Note the hierarchy on 9.8.0:
+    /// <c>RegexMask</c> and <c>BlockMask</c> land here, while <c>DateMask</c> and <c>MultiMask</c>
+    /// derive from <see cref="PatternMask"/> and take the path below — correctly, since both spell a
+    /// real pattern. <c>MultiMask</c> rewrites its own <c>Mask</c> as it matches, which is why the
+    /// caller reads the pattern and the decoration <i>after</i> feeding the mask its value.
     /// </item>
     /// <item>
     /// a mask carrying a <c>Transformation</c>. That hook rewrites characters as they are consumed —
@@ -162,7 +213,7 @@ internal static class MaskedValueDiagnostic
     /// </list>
     /// </remarks>
     /// <param name="mask">The mask that produced the rendered text.</param>
-    internal static string? LiteralsOf(IMask mask)
+    internal static string? DecorationOf(IMask mask)
     {
         if (mask is not PatternMask pattern
             || pattern.Mask is null
@@ -173,8 +224,14 @@ internal static class MaskedValueDiagnostic
         }
 
         var placeholders = pattern.MaskChars.Select(maskChar => maskChar.Char).ToHashSet();
+        var decoration = pattern.Mask.Where(c => !placeholders.Contains(c));
 
-        return new string(pattern.Mask.Where(c => !placeholders.Contains(c)).Distinct().ToArray());
+        if (pattern.Placeholder is { } pad)
+        {
+            decoration = decoration.Append(pad);
+        }
+
+        return new string(decoration.Distinct().ToArray());
     }
 
     /// <summary>
@@ -216,7 +273,9 @@ internal static class MaskedValueDiagnostic
                 "leaves the stored value unchanged. Correct the data, widen the mask, or drop the " +
                 "mask if the stored format is intentional.";
 
-            if (string.IsNullOrWhiteSpace(maskedResult))
+            // The SAME predicate Applies used to reach its verdict, not a second copy of it: the
+            // wording must follow from the decision rather than re-derive it.
+            if (RendersEmpty(maskedResult))
             {
                 logger?.LogWarning(
                     "Field '{Field}' holds a value that its mask '{Mask}' rejects, so the field " +

--- a/FormCraft.ForMudBlazor/Diagnostics/MaskedValueDiagnostic.cs
+++ b/FormCraft.ForMudBlazor/Diagnostics/MaskedValueDiagnostic.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FormCraft.ForMudBlazor;
 
@@ -37,26 +38,144 @@ internal static class MaskedValueDiagnostic
     internal const string Category = "FormCraft.ForMudBlazor.MaskedValue";
 
     /// <summary>
-    /// Whether the mask rejected the stored value outright, rather than reformatting it.
+    /// Whether the mask changed what the stored value <i>means</i> — by blanking it, or by discarding
+    /// part of it — rather than merely reformatting it.
     /// </summary>
     /// <remarks>
-    /// Total collapse is the signal, not mere difference. A mask that turns <c>5551234567</c> into
-    /// <c>(555) 123-4567</c> is doing precisely its job; warning whenever the two strings differ
-    /// would fire on every correctly-masked field in every form, and a diagnostic that fires on the
-    /// happy path is one the developer mutes. Only "a value went in and nothing came out" means the
-    /// value was rejected and is about to disappear from view while surviving in the model.
     /// <para>
-    /// Both tests are <see cref="string.IsNullOrWhiteSpace"/>. On the value side, a whitespace-only
-    /// string is a blank field wearing a different hat — a padded column, a trimmed-to-blank setting
-    /// — and there is nothing to lose; the same reading <see cref="TextMaskMap.Resolve"/> gives a
-    /// whitespace-only *pattern*. On the result side, a mask whose surviving output is only its own
-    /// literal spacing has kept nothing of what the user stored, which is the reported case.
+    /// Difference is not the signal. A mask that turns <c>5551234567</c> into <c>(555) 123-4567</c>
+    /// is doing precisely its job; warning whenever the two strings differ would fire on every
+    /// correctly-masked field in every form, and a diagnostic that fires on the happy path is one the
+    /// developer mutes — taking the real signal with it. <b>Loss</b> is the signal.
+    /// </para>
+    /// <para>
+    /// #266 measured loss as total collapse: a value went in and nothing came out. #283 found that
+    /// too narrow. <c>"+1 555 123 4567"</c> under <c>(000) 000-0000</c> renders
+    /// <c>(155) 512-3456</c> — a perfectly plausible phone number that is not the one on record,
+    /// shown to the user while the model keeps the original. That is the same divergence as the blank
+    /// case and a worse one to be left undiagnosed, because a blank field is visibly wrong and this
+    /// is not.
+    /// </para>
+    /// <para>
+    /// The widened rule strips the mask's own literals from both sides and compares what is left. A
+    /// reformat only ever moves literals around, so the two sides reduce to the same characters; a
+    /// discard loses characters no reformatting could restore. Stripping <i>both</i> sides is what
+    /// keeps stored data that carries its own separators — <c>555 123 4567</c>, <c>555-123-4567</c>,
+    /// the normal shape of legacy data — from reading as a discard.
+    /// </para>
+    /// <para>
+    /// The blank test stays an explicit disjunct rather than being folded into that comparison,
+    /// because a value made only of the mask's literals (<c>"()-"</c>) reduces to the empty string on
+    /// both sides and would otherwise read as a reformat — silently dropping a case #266 reported.
+    /// Both blank tests are <see cref="string.IsNullOrWhiteSpace"/>: on the value side a
+    /// whitespace-only string is a blank field wearing a different hat — a padded column, a
+    /// trimmed-to-blank setting — and there is nothing to lose, the same reading
+    /// <see cref="TextMaskMap.Resolve"/> gives a whitespace-only <i>pattern</i>; on the result side a
+    /// mask whose surviving output is only its own literal spacing has kept nothing of what was
+    /// stored.
     /// </para>
     /// </remarks>
     /// <param name="configuredValue">The value held by the model before the mask was applied.</param>
     /// <param name="maskedResult">What that value renders as once run through the mask.</param>
-    internal static bool Applies(string? configuredValue, string? maskedResult) =>
-        !string.IsNullOrWhiteSpace(configuredValue) && string.IsNullOrWhiteSpace(maskedResult);
+    /// <param name="maskLiterals">
+    /// The characters the mask inserts as decoration, from <see cref="LiteralsOf"/>, or <c>null</c>
+    /// when they could not be determined — in which case only the total-collapse test applies.
+    /// </param>
+    internal static bool Applies(string? configuredValue, string? maskedResult, string? maskLiterals)
+    {
+        if (string.IsNullOrWhiteSpace(configuredValue))
+        {
+            return false;
+        }
+
+        // #266's rule, unchanged and checked first: something was stored and nothing came out.
+        if (string.IsNullOrWhiteSpace(maskedResult))
+        {
+            return true;
+        }
+
+        // LiteralsOf could not answer without guessing (a non-pattern or transforming mask). Report
+        // nothing beyond the collapse case above rather than invent a verdict — the cost of a wrong
+        // "yes" here is a warning on every value of a correctly configured field.
+        if (maskLiterals is null)
+        {
+            return false;
+        }
+
+        return !string.Equals(
+            WithoutLiterals(configuredValue, maskLiterals),
+            WithoutLiterals(maskedResult, maskLiterals),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <paramref name="value"/> with every one of the mask's literal characters removed.
+    /// </summary>
+    /// <remarks>
+    /// Applied to the stored value and the rendered text alike, which is the whole point: it reduces
+    /// both to the characters the mask treats as significant, so the comparison sees data rather than
+    /// punctuation. Ordinal throughout — these are literal characters from a pattern, not text being
+    /// collated.
+    /// </remarks>
+    /// <param name="value">The stored value or the rendered text.</param>
+    /// <param name="literals">The mask's literal characters, from <see cref="LiteralsOf"/>.</param>
+    private static string WithoutLiterals(string value, string literals) =>
+        string.Concat(value.Where(c => !literals.Contains(c)));
+
+    /// <summary>
+    /// The characters <paramref name="mask"/> inserts as decoration, or <c>null</c> when they cannot
+    /// be determined (#283).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the input the discard rule needs, and it exists because the obvious source does not
+    /// work. The issue assumed <c>PatternMask.GetCleanText()</c> returns the mask-significant
+    /// characters; measured against MudBlazor 9.8.0 it returns <c>Text</c> verbatim unless
+    /// <c>CleanDelimiters</c> is set — which FormCraft leaves <c>false</c> by default — so a rule
+    /// built on it would have compared a formatted string against a raw one and fired on every
+    /// correctly-masked field. Pinned by <c>MaskedValueDiagnosticTests</c>'s characterisation block.
+    /// </para>
+    /// <para>
+    /// Derived from the pattern rather than hardcoded: a literal is any pattern character that is not
+    /// one of the mask's own placeholders, and <c>MaskChars</c> is where those live. Reading them off
+    /// the instance keeps this correct for a caller who supplies custom <c>MaskChars</c> through the
+    /// #265 factory, which a hardcoded <c>0</c>/<c>a</c>/<c>*</c> list would silently get wrong.
+    /// </para>
+    /// <para>
+    /// Returns <c>null</c> — meaning "no opinion", which <see cref="Applies"/> reads as a fall back to
+    /// the #266 total-collapse rule — in the two cases where an answer would be a guess:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// a mask that is not a <see cref="PatternMask"/>. The #265 factory can supply any
+    /// <see cref="IMask"/>, and a <c>RegexMask</c>'s <c>Mask</c> is a regular expression whose
+    /// non-placeholder characters are metacharacters, not decoration.
+    /// </item>
+    /// <item>
+    /// a mask carrying a <c>Transformation</c>. That hook rewrites characters as they are consumed —
+    /// upper-casing, say — so the rendered text legitimately differs from the stored value character
+    /// for character, and every value would read as a discard. A diagnostic that fires on every value
+    /// of a correctly configured field is the happy-path false positive #266 was shaped to avoid, and
+    /// reporting it as "the mask discarded input" would be the wrong explanation as well as the wrong
+    /// verdict.
+    /// </item>
+    /// </list>
+    /// </remarks>
+    /// <param name="mask">The mask that produced the rendered text.</param>
+    internal static string? LiteralsOf(IMask mask)
+    {
+        if (mask is not PatternMask pattern
+            || pattern.Mask is null
+            || pattern.MaskChars is null
+            || pattern.Transformation is not null)
+        {
+            return null;
+        }
+
+        var placeholders = pattern.MaskChars.Select(maskChar => maskChar.Char).ToHashSet();
+
+        return new string(pattern.Mask.Where(c => !placeholders.Contains(c)).Distinct().ToArray());
+    }
 
     /// <summary>
     /// Emits the warning, degrading silently when no logging stack is registered.
@@ -65,11 +184,19 @@ internal static class MaskedValueDiagnostic
     /// <param name="fieldName">The field's name, used when it has no label.</param>
     /// <param name="label">Display name for the message.</param>
     /// <param name="pattern">The configured mask, quoted back so the message is concrete.</param>
+    /// <param name="maskedResult">
+    /// What the field actually displays. It selects the wording, and it is the difference between a
+    /// useful report and a misleading one: the blank case and the partial-discard case share a cause
+    /// but look nothing alike to the person reading the log. Telling someone their field "renders
+    /// empty" when it is in fact showing a plausible wrong phone number sends them looking for a
+    /// blank field they will never find (#283).
+    /// </param>
     internal static void Warn(
         IServiceProvider? services,
         string fieldName,
         string? label,
-        string? pattern)
+        string? pattern,
+        string? maskedResult)
     {
         // A diagnostic must never break a render, so everything here — including the service
         // resolution, which is the one call that can realistically fail on a torn-down circuit —
@@ -80,14 +207,35 @@ internal static class MaskedValueDiagnostic
                 .GetService<ILoggerFactory>()?
                 .CreateLogger(Category);
 
+            var field = string.IsNullOrWhiteSpace(label) ? fieldName : label;
+
+            // The shared half of both messages: WHY the divergence persists, and what to do about it.
+            const string Mechanism =
+                "MudBlazor builds the display text by running the value through the mask and does " +
+                "not write the result back, so a user who submits without touching this field " +
+                "leaves the stored value unchanged. Correct the data, widen the mask, or drop the " +
+                "mask if the stored format is intentional.";
+
+            if (string.IsNullOrWhiteSpace(maskedResult))
+            {
+                logger?.LogWarning(
+                    "Field '{Field}' holds a value that its mask '{Mask}' rejects, so the field " +
+                    "renders empty while the model keeps the original. " + Mechanism,
+                    field,
+                    pattern);
+
+                return;
+            }
+
+            // The #283 case. It names what is on screen because that is the only way the developer
+            // can recognise it: nothing looks wrong, so "your field shows (155) 512-3456" is the
+            // fact that turns an abstract warning into something checkable against the record.
             logger?.LogWarning(
-                "Field '{Field}' holds a value that its mask '{Mask}' rejects, so the field renders " +
-                "empty while the model keeps the original. MudBlazor builds the display text by " +
-                "running the value through the mask and does not write the result back, so a user " +
-                "who submits without touching this field leaves the stored value unchanged. Correct " +
-                "the data, widen the mask, or drop the mask if the stored format is intentional.",
-                string.IsNullOrWhiteSpace(label) ? fieldName : label,
-                pattern);
+                "Field '{Field}' holds a value that its mask '{Mask}' only partly accepts, so the " +
+                "field displays '{Displayed}' — which is not what the model holds. " + Mechanism,
+                field,
+                pattern,
+                maskedResult);
         }
         catch
         {

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -10,9 +10,11 @@ public partial class MudBlazorTextFieldComponent<TModel>
     private string? _localValue;
 
     /// <summary>
-    /// Whether this instance has already emitted the masked-value diagnostic (#283).
+    /// Whether this instance is done with the masked-value diagnostic — it either reported, or
+    /// learned that another row already had (#283).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Needed because the emit is no longer confined to <see cref="OnInitialized"/>. That confinement
     /// was what made "at most once per component lifetime" true for free, and only a field inside a
     /// collection has a <see cref="MudBlazorFieldComponentBase{TModel, TValue}.ItemFieldScope"/> latch
@@ -20,8 +22,18 @@ public partial class MudBlazorTextFieldComponent<TModel>
     /// repeatedly (a dependency callback, a poll, a reset) would re-report the same field on every
     /// external change. The scope latch stays: it answers a different question, once per FIELD across
     /// every row, which a per-instance flag cannot.
+    /// </para>
+    /// <para>
+    /// "Settled" rather than "reported", and checked before any work rather than after it, because
+    /// the emit path is no longer cold. Resolving a mask allocates, and on the #265 factory path it
+    /// invokes arbitrary caller code; doing that on every external model change of every masked
+    /// field, forever, is the cost of asking the question late. A row that loses the race for the
+    /// scope latch never reports at all, and <c>ShouldWarnOnce</c> is a <c>HashSet.Add</c> that can
+    /// never go back to <c>true</c> — so such a row is just as finished as one that did report, and
+    /// recording that is what keeps the other 49 rows of a collection from redoing the work.
+    /// </para>
     /// </remarks>
-    private bool _maskedValueReported;
+    private bool _maskedValueReportingSettled;
 
     public int Lines { get; set; } = 1;
 
@@ -113,7 +125,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
         // actually render — which since #265 may come from a factory rather than the pattern string
         // — so it cannot run until both are loaded, or it would report on a mask the field does not
         // use.
-        WarnIfMaskBlanksTheStoredValue();
+        WarnIfMaskChangesTheStoredValue();
 
         // Load adornment configuration
         var customAdornment = GetAttribute<Adornment?>("Adornment");
@@ -166,7 +178,8 @@ public partial class MudBlazorTextFieldComponent<TModel>
     }
 
     /// <summary>
-    /// Reports a stored value that the configured mask rejects outright (#266).
+    /// Reports a stored value that the configured mask rejects outright (#266) or partly discards
+    /// (#283).
     /// </summary>
     /// <remarks>
     /// <para>
@@ -198,8 +211,17 @@ public partial class MudBlazorTextFieldComponent<TModel>
     /// <c>null</c> without constructing one.
     /// </para>
     /// </remarks>
-    private void WarnIfMaskBlanksTheStoredValue()
+    private void WarnIfMaskChangesTheStoredValue()
     {
+        // First, and before any work: this instance has nothing left to say, so resolving a mask and
+        // running a value through it would be pure waste on a path that now runs on every external
+        // model change. Safe to consult early precisely because it has no side effect on anything
+        // shared — unlike ShouldWarnOnce below, which must stay after the rule (#274).
+        if (_maskedValueReportingSettled)
+        {
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(CurrentValue))
         {
             return;
@@ -207,7 +229,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
 
         string? maskedResult;
         string? pattern;
-        string? literals;
+        string? decoration;
         try
         {
             var mask = GetMask();
@@ -216,16 +238,18 @@ public partial class MudBlazorTextFieldComponent<TModel>
                 return;
             }
 
+            mask.SetText(CurrentValue);
+            maskedResult = mask.Text;
+
+            // Both read AFTER SetText, so they describe the mask that produced `maskedResult` rather
+            // than the one it started as. MudBlazor's MultiMask derives from PatternMask and rewrites
+            // its own Mask as it matches, so reading the pattern first can quote — and strip the
+            // decoration of — a different mask than the one that rendered the text (#283).
+            //
             // Read off the resolved mask, not from the Mask property: a factory-supplied mask has
             // its own pattern and no configured string to quote back.
             pattern = mask.Mask;
-
-            // Read BEFORE SetText, so the rule is judged on the mask's configuration rather than on
-            // whatever state feeding it a value leaves behind (#283).
-            literals = MaskedValueDiagnostic.LiteralsOf(mask);
-
-            mask.SetText(CurrentValue);
-            maskedResult = mask.Text;
+            decoration = MaskedValueDiagnostic.DecorationOf(mask);
         }
         catch
         {
@@ -238,18 +262,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
             return;
         }
 
-        if (!MaskedValueDiagnostic.Applies(CurrentValue, maskedResult, literals))
-        {
-            return;
-        }
-
-        // Two latches, both consulted AFTER the rule rather than before it, and in this order.
-        //
-        // The instance latch (#283) is what keeps "at most once per component lifetime" true now
-        // that the emit is no longer confined to OnInitialized; it is checked first because it is
-        // free and side-effect-free, and because an instance that has already reported must not
-        // consult the shared latch again.
-        if (_maskedValueReported)
+        if (!MaskedValueDiagnostic.Applies(CurrentValue, maskedResult, decoration))
         {
             return;
         }
@@ -264,10 +277,14 @@ public partial class MudBlazorTextFieldComponent<TModel>
         // that the same field also trips — the property the two separate HashSets used to provide.
         if (!(ItemFieldScope?.ShouldWarnOnce(MaskedValueDiagnostic.Category, DiagnosticFieldKey) ?? true))
         {
+            // Another row got there first, and that verdict is permanent — so this instance is done
+            // too, and must stop re-resolving its mask on every later model change.
+            _maskedValueReportingSettled = true;
+
             return;
         }
 
-        _maskedValueReported = true;
+        _maskedValueReportingSettled = true;
 
         // Reported under the collection-qualified identity, not the bare field name — the same
         // reason the LATCH keys on it. A form with Contacts[].Phone and Suppliers[].Phone masked
@@ -321,7 +338,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
             // SetValueWithoutNotification has already made CurrentValue and _localValue agree, so
             // this condition is false. Reached through the same condition that was already here
             // for exactly that reason, rather than a second one that could drift from it.
-            WarnIfMaskBlanksTheStoredValue();
+            WarnIfMaskChangesTheStoredValue();
         }
     }
 

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -9,6 +9,20 @@ public partial class MudBlazorTextFieldComponent<TModel>
     private bool _passwordVisible;
     private string? _localValue;
 
+    /// <summary>
+    /// Whether this instance has already emitted the masked-value diagnostic (#283).
+    /// </summary>
+    /// <remarks>
+    /// Needed because the emit is no longer confined to <see cref="OnInitialized"/>. That confinement
+    /// was what made "at most once per component lifetime" true for free, and only a field inside a
+    /// collection has a <see cref="MudBlazorFieldComponentBase{TModel, TValue}.ItemFieldScope"/> latch
+    /// to fall back on — an ordinary field has none, so without this a form whose model is written
+    /// repeatedly (a dependency callback, a poll, a reset) would re-report the same field on every
+    /// external change. The scope latch stays: it answers a different question, once per FIELD across
+    /// every row, which a per-instance flag cannot.
+    /// </remarks>
+    private bool _maskedValueReported;
+
     public int Lines { get; set; } = 1;
 
     /// <summary>
@@ -156,10 +170,19 @@ public partial class MudBlazorTextFieldComponent<TModel>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Called from <see cref="OnInitialized"/>, so it judges the value the field was *given* rather
-    /// than one the user has since edited. That framing is what keeps it quiet when someone
-    /// legitimately clears a field: the emptiness that matters is the one that was there before
-    /// anyone touched it.
+    /// Called from <see cref="OnInitialized"/> and, since #283, from the external-model-change branch
+    /// of <see cref="OnParametersSet"/> — so it judges any value the field is *given*, not only the
+    /// one it happened to hold at first render. Confining it to init made it blind to the canonical
+    /// legacy-data case, a model populated by an async fetch that resolves after the field is already
+    /// on screen.
+    /// </para>
+    /// <para>
+    /// Widening the emit point does not widen what is reported to values the *user* produced, on two
+    /// counts. The caller is the external-change branch, which an in-flight edit cannot reach; and
+    /// the rule itself requires a non-blank stored value, so a field the user legitimately cleared
+    /// can never satisfy it. That second point is worth stating because it, rather than the init-only
+    /// framing, was always what made the cleared-field case safe — the framing's stated
+    /// justification was load-bearing in the prose and redundant in the code.
     /// </para>
     /// <para>
     /// The masked result is computed the same way <c>MudBaseInput</c> is about to compute it — run
@@ -214,6 +237,17 @@ public partial class MudBlazorTextFieldComponent<TModel>
             return;
         }
 
+        // Two latches, both consulted AFTER the rule rather than before it, and in this order.
+        //
+        // The instance latch (#283) is what keeps "at most once per component lifetime" true now
+        // that the emit is no longer confined to OnInitialized; it is checked first because it is
+        // free and side-effect-free, and because an instance that has already reported must not
+        // consult the shared latch again.
+        if (_maskedValueReported)
+        {
+            return;
+        }
+
         // Latched per field, and latched AFTER the rule rather than before it. A collection renders
         // one instance per row, so an unlatched warning fires once per ROW about a single field.
         // But rows hold different values, and ShouldWarnOnce has a side effect: consulting it for a
@@ -226,6 +260,8 @@ public partial class MudBlazorTextFieldComponent<TModel>
         {
             return;
         }
+
+        _maskedValueReported = true;
 
         // Reported under the collection-qualified identity, not the bare field name — the same
         // reason the LATCH keys on it. A form with Contacts[].Phone and Suppliers[].Phone masked
@@ -264,6 +300,21 @@ public partial class MudBlazorTextFieldComponent<TModel>
         if (CurrentValue != _localValue)
         {
             _localValue = CurrentValue;
+
+            // #283(a). The second emit point, and the one that covers the canonical legacy-data
+            // case: a model populated AFTER first render — an async fetch, a
+            // `.DependsOn(...).WithValueProvider(...)`, a form reset — was empty when OnInitialized
+            // ran its check, so the field rendered blank and the divergence went unreported.
+            //
+            // This branch is the external-model-change signal rather than merely "a render
+            // happened", which is what keeps it off the keystroke path.
+            // FieldComponentBase.OnParametersSet reloads CurrentValue from the model only when its
+            // private ShouldReloadValue() says the component and the model have SETTLED and then
+            // diverged; an in-flight user edit fails that test, and by the time it settles
+            // SetValueWithoutNotification has already made CurrentValue and _localValue agree, so
+            // this condition is false. Reached through the same condition that was already here
+            // for exactly that reason, rather than a second one that could drift from it.
+            WarnIfMaskBlanksTheStoredValue();
         }
     }
 

--- a/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
+++ b/FormCraft.ForMudBlazor/Fields/TextField/MudBlazorTextFieldComponent.razor.cs
@@ -207,6 +207,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
 
         string? maskedResult;
         string? pattern;
+        string? literals;
         try
         {
             var mask = GetMask();
@@ -218,6 +219,11 @@ public partial class MudBlazorTextFieldComponent<TModel>
             // Read off the resolved mask, not from the Mask property: a factory-supplied mask has
             // its own pattern and no configured string to quote back.
             pattern = mask.Mask;
+
+            // Read BEFORE SetText, so the rule is judged on the mask's configuration rather than on
+            // whatever state feeding it a value leaves behind (#283).
+            literals = MaskedValueDiagnostic.LiteralsOf(mask);
+
             mask.SetText(CurrentValue);
             maskedResult = mask.Text;
         }
@@ -232,7 +238,7 @@ public partial class MudBlazorTextFieldComponent<TModel>
             return;
         }
 
-        if (!MaskedValueDiagnostic.Applies(CurrentValue, maskedResult))
+        if (!MaskedValueDiagnostic.Applies(CurrentValue, maskedResult, literals))
         {
             return;
         }
@@ -271,7 +277,8 @@ public partial class MudBlazorTextFieldComponent<TModel>
             DiagnosticServiceProvider,
             DiagnosticFieldKey,
             QualifiedLabel,
-            pattern);
+            pattern,
+            maskedResult);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,23 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
   **Three things to check before you upgrade**, if you already pass `Mask` — it did nothing until now, so all three are newly reachable:
 
   1. **The model stores the *masked* text.** With the mask above, `model.Phone` becomes `"(555) 123-4567"`, not `"5551234567"`. Validation, database columns and APIs keyed to raw digits will see the delimiters. This is still the default, but it is no longer the only option: `.WithMask("(000) 000-0000", cleanDelimiters: true)` stores `"5551234567"` instead — see the `.WithMask(...)` entry below (#265).
-  2. **An existing value that doesn't fit the pattern renders as an empty field** — while the model quietly keeps the original. The user sees a blank input, submits without touching it, and the old value survives. FormCraft now **says so** instead of leaving you to find it in a bug report: a warning under the `FormCraft.ForMudBlazor.MaskedValue` category names the field and the pattern, on both render paths, once per field — a fifty-row collection reports once, not fifty times (#266). It judges whichever mask the field actually renders with, a factory supplied via `.WithMask(...)` included. It fires only when the mask rejects a value *outright*; a value it merely reformats (`5551234567` → `(555) 123-4567`) is the mask working, and stays silent. The diagnostic reports only — the stored value is never rewritten, on any path, including read-only views. Still worth auditing stored data against the pattern before turning a mask on; the warning tells you where to look. Silence it by configuring that log category off.
+  2. **An existing value that doesn't fit the pattern is displayed wrongly** — while the model quietly keeps the original. Either it renders as an empty field, or, less obviously, the mask keeps the characters that happen to fit and drops the rest. The user submits without touching the field and the old value survives. FormCraft now **says so** instead of leaving you to find it in a bug report: a warning under the `FormCraft.ForMudBlazor.MaskedValue` category names the field and the pattern, on both render paths, once per field — a fifty-row collection reports once, not fifty times (#266). It judges whichever mask the field actually renders with, a factory supplied via `.WithMask(...)` included.
+
+      **What it reports** is the mask changing what the value *means*, not merely how it looks (#283):
+
+      | Stored | Renders as | Reported |
+      |---|---|---|
+      | `"N/A"` | `""` | ✅ the value was rejected outright |
+      | `"+1 555 123 4567"` | `(155) 512-3456` | ✅ **a different phone number** — the country code was consumed as the area code and the last digit dropped |
+      | `"N/A5551234567"` | `(555) 123-4567` | ✅ the digits survived, the `N/A` marker did not |
+      | `"5551234567"` | `(555) 123-4567` | — reformatting is the mask working |
+      | `"555 123 4567"` | `(555) 123-4567` | — same, even though the stored value had its own separators |
+
+      The middle row is the one worth knowing about: nothing looks wrong on screen, so the message quotes the text the field displays, which is what lets you check it against the record. Reformatting stays silent whichever way `cleanDelimiters` is set — the rule compares both sides with the mask's own literals removed, so the flag cannot turn a reformat into a false alarm or hide a real discard. A mask FormCraft cannot read that way — a `RegexMask` from the factory overload, or one carrying a `Transformation` — falls back to reporting outright rejection only, rather than guessing.
+
+      **It also fires for values that arrive after the field is on screen** (#283) — the async-fetch case, where the model is populated once the request resolves and the field was empty at first render. It was previously checked only at initialisation, so precisely the legacy data most likely to predate the mask went unreported. It never fires for a value *you* type, and never for a field you clear: it reports stored data, not live editing.
+
+      The diagnostic reports only — the stored value is never rewritten, on any path, including read-only views. Still worth auditing stored data against the pattern before turning a mask on; the warning tells you where to look. Silence it by configuring that log category off.
   3. **Masked fields render through MudBlazor's `MudMask`**, which MudBlazor documents as *"recommended to be used in WASM projects only because it has known problems in BSS, especially with high network latency"*. On Blazor Server, test the field under realistic latency before shipping it.
 
   A field that configures no mask is untouched by all of this.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ Experience FormCraft in action! Visit our [interactive demo](https://phmatray.gi
       | `"N/A5551234567"` | `(555) 123-4567` | ✅ the digits survived, the `N/A` marker did not |
       | `"5551234567"` | `(555) 123-4567` | — reformatting is the mask working |
       | `"555 123 4567"` | `(555) 123-4567` | — same, even though the stored value had its own separators |
+      | `"123 45 6789"` under `000-00-0000` | `123-45-6789` | — same again, and the separators aren't the mask's either |
 
-      The middle row is the one worth knowing about: nothing looks wrong on screen, so the message quotes the text the field displays, which is what lets you check it against the record. Reformatting stays silent whichever way `cleanDelimiters` is set — the rule compares both sides with the mask's own literals removed, so the flag cannot turn a reformat into a false alarm or hide a real discard. A mask FormCraft cannot read that way — a `RegexMask` from the factory overload, or one carrying a `Transformation` — falls back to reporting outright rejection only, rather than guessing.
+      The `+1` row is the one worth knowing about: nothing looks wrong on screen, so the message quotes the text the field displays, which is what lets you check it against the record.
+
+      **Reformatting stays silent however the value happens to be punctuated.** The rule reduces both sides to the characters that carry the data — dropping punctuation, the mask's own literals, and its placeholder padding — and compares those, so stored data keeps its meaning whether it arrives as `5551234567`, `555 123 4567` or `555.123.4567`, and whether or not those separators are the ones the mask spells. That matters because legacy data is punctuated however whoever stored it felt like, which is rarely the way a newly-added mask is. `cleanDelimiters` does not enter into it either way. A mask FormCraft cannot read like that — a `RegexMask` from the factory overload, or one carrying a `Transformation` — falls back to reporting outright rejection only, rather than guessing.
 
       **It also fires for values that arrive after the field is on screen** (#283) — the async-fetch case, where the model is populated once the request resolves and the field was empty at first render. It was previously checked only at initialisation, so precisely the legacy data most likely to predate the mask went unreported. It never fires for a value *you* type, and never for a field you clear: it reports stored data, not live editing.
 


### PR DESCRIPTION
Implements #283.

Closes #283.

Widens `MaskedValueDiagnostic` on two axes deferred from #274:

- **(a)** it fires on external model change, not only from `OnInitialized` — so a value fetched after first render is reported;
- **(b)** it reports a mask that *discards part of* a stored value, not only one that blanks it outright, while staying silent on a plain reformat.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are ticked as each task lands. Opened as a draft — will be marked ready after the final task and a code-review pass.

### Plan
- [x] Task 1: Emit when the value arrives after first render
- [x] Task 2: Verify what MudBlazor actually gives us for a partial discard
- [x] Task 3: Widen the rule to catch a partial discard
- [x] Task 4: Update the README

### Code review

A review of `dev...HEAD` found — and reproduced end-to-end — a false-positive class in the first draft of the rule, plus several smaller issues. All fixed in `b2bf82f`:

- **The rule stripped only the *mask's* literals from both sides**, so a stored value punctuated any other way was reported as a discard with nothing lost: `000-00-0000` + `"123 45 6789"`, `000.000.0000` + `"555-123-4567"`, and a credit card with dashes under a space-separated mask all warned. The whole suite was blind to it because every mask test used `(000) 000-0000`, whose decoration `"() -"` happens to contain the separators the tests supplied — so the row described as "the one that keeps it honest" passed for the wrong reason. The rule now keeps a character only if it could match a placeholder **and** is not decoration the mask contributes; stripping non-alphanumerics alone was rejected because a pattern can spell an alphanumeric literal (`+1 000-0000`). Pinned by cases that pair a pattern with a value punctuated differently, at both the rule and component level — verified to fail 9 tests against the old rule.
- **`PatternMask.Placeholder` was not treated as decoration**, so a mask that pads short values (`(555) 123-45__`) warned on essentially every value of a variable-length field.
- **The instance latch was consulted after the mask had already been resolved and run**, so the now-hot `OnParametersSet` path re-did the work — including invoking a caller-supplied mask factory — on every external model change forever. Hoisted, and now also set when a sibling row has already claimed the shared latch.
- Pattern and decoration are read **after** `SetText`, since `MultiMask` rewrites its own `Mask` as it matches.
- `Warn` no longer re-derives which case applies; both it and `Applies` call one `RendersEmpty` predicate, so the rule and the message cannot drift.
- Renamed `WarnIfMaskBlanksTheStoredValue` → `WarnIfMaskChangesTheStoredValue` and `LiteralsOf` → `DecorationOf` to match what they now do.

## Follow-ups

Not addressed here, deliberately — both are pre-existing and wider than this issue:

- **Mask attributes are read only in `OnInitialized`.** A component instance re-parameterised with a new `Context` (swapping `Configuration`, or unkeyed collection rows shifting) judges the new value against the previous field's mask. This is pre-existing for *rendering* too — `Mask="@GetMask()"` has the same staleness — so fixing it only for the diagnostic would be incoherent; it wants its own issue covering both.
- **`MultiMask` is untested here.** It derives from `PatternMask` and rewrites its own `Mask` as it matches. Reading the pattern after `SetText` is the right order for it, but nothing pins the behaviour, and I could not get it to switch via `SetText` alone on 9.8.0 — so it is a reasoned assumption rather than a measured one.
