### PR TITLE
test(mudblazor): finish adopting the shared collection-item fixture (#282)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
@@ -302,9 +302,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
         var config = MultiFieldItemForm(
             configureBoolean: field => field.WithAttribute("DisplayStyle", BooleanDisplayStyle.Switch));
 
-        var component = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
-            .Add(p => p.Model, NewMixedItems(new MixedItem()))
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewMixedItems(new MixedItem()), config);
 
         component.FindComponents<MudSwitch<bool>>().Count.ShouldBe(1);
         component.FindComponents<MudCheckBox<bool>>().ShouldBeEmpty();
@@ -332,9 +330,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
                 .WithAttribute("MinDate", new DateTime(2020, 1, 1))
                 .WithAttribute("MaxDate", new DateTime(2030, 12, 31)));
 
-        var picker = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
-                .Add(p => p.Model, NewMixedItems(new MixedItem()))
-                .Add(p => p.Configuration, config))
+        var picker = this.RenderItemForm(NewMixedItems(new MixedItem()), config)
             .FindComponent<MudDatePicker>().Instance;
 
         picker.MinDate.ShouldBe(new DateTime(2020, 1, 1));
@@ -352,9 +348,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
                 .WithAttribute("Min", 5)
                 .WithAttribute("Max", 50));
 
-        var numeric = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
-                .Add(p => p.Model, NewMixedItems(new MixedItem()))
-                .Add(p => p.Configuration, config))
+        var numeric = this.RenderItemForm(NewMixedItems(new MixedItem()), config)
             .FindComponent<MudNumericField<int>>().Instance;
 
         numeric.Min.ShouldBe(5);
@@ -408,10 +402,15 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     }
 
     /// <summary>
-    /// Renders a four-kind item form (text / numeric / bool / date) next to a
-    /// <see cref="MudPopoverProvider"/> so the date picker works, and hands back the form's
-    /// <see cref="EditContext"/>.
+    /// Renders the fixture's four-kind item form (text / numeric / bool / date) next to a
+    /// <see cref="MudPopoverProvider"/>, and hands back the form's <see cref="EditContext"/>.
     /// </summary>
+    /// <remarks>
+    /// The provider hosts the date picker's <i>overlay</i>; it is not needed merely to render a
+    /// <c>MudDatePicker</c>. Sibling tests here — and the fixture's own self-tests — render this
+    /// same form through <c>RenderItemForm</c> with no provider and pass, so read this as "a picker
+    /// that could be opened", not as a precondition for the picker existing.
+    /// </remarks>
     private (IRenderedComponent<FormCraftComponent<MixedItemModel>> Component, EditContext? EditContext)
         RenderMixedForm(MixedItemModel model)
     {

--- a/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
@@ -433,5 +433,4 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
 
         return (host.FindComponent<FormCraftComponent<MixedItemModel>>(), editContext);
     }
-
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Components/CollectionRenderCharacterisationTests.cs
@@ -125,7 +125,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public void Editing_A_Text_Item_Field_Should_Notify_The_Parent_EditContext()
     {
         // Arrange
-        var model = new MixedModel { Rows = { new MixedRow() } };
+        var model = NewMixedItems(new MixedItem());
         var (component, editContext) = RenderMixedForm(model);
 
         // Act
@@ -144,7 +144,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public async Task Editing_A_Numeric_Item_Field_Should_Notify_The_Parent_EditContext()
     {
         // Arrange
-        var model = new MixedModel { Rows = { new MixedRow() } };
+        var model = NewMixedItems(new MixedItem());
         var (component, editContext) = RenderMixedForm(model);
         var numeric = component.FindComponent<MudNumericField<int>>();
 
@@ -161,7 +161,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public async Task Editing_A_Boolean_Item_Field_Should_Notify_The_Parent_EditContext()
     {
         // Arrange
-        var model = new MixedModel { Rows = { new MixedRow() } };
+        var model = NewMixedItems(new MixedItem());
         var (component, editContext) = RenderMixedForm(model);
         var checkbox = component.FindComponent<MudCheckBox<bool>>();
 
@@ -178,7 +178,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public async Task Editing_A_Date_Item_Field_Should_Notify_The_Parent_EditContext()
     {
         // Arrange
-        var model = new MixedModel { Rows = { new MixedRow() } };
+        var model = NewMixedItems(new MixedItem());
         var (component, editContext) = RenderMixedForm(model);
         var picker = component.FindComponent<MudDatePicker>();
 
@@ -196,7 +196,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     {
         // Arrange - the validation message component is emitted per item field by RenderItemFields,
         // keyed to the nested identifier. Converging the render path must not drop it for any kind.
-        var model = new MixedModel { Rows = { new MixedRow(), new MixedRow() } };
+        var model = NewMixedItems(new MixedItem(), new MixedItem());
         var (component, _) = RenderMixedForm(model);
 
         // Assert - one slot per field per row (4 fields x 2 rows)
@@ -218,7 +218,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public void Text_Item_Field_Should_Render_Its_Attribute_Set()
     {
         // Arrange & Act
-        var field = RenderMixedForm(new MixedModel { Rows = { new MixedRow() } }).Component
+        var field = RenderMixedForm(NewMixedItems(new MixedItem())).Component
             .FindComponents<MudTextField<string>>()
             .First(t => t.Instance.Label == "Name")
             .Instance;
@@ -240,7 +240,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public void Numeric_Item_Field_Should_Render_Its_Attribute_Set()
     {
         // Arrange & Act
-        var field = RenderMixedForm(new MixedModel { Rows = { new MixedRow() } }).Component
+        var field = RenderMixedForm(NewMixedItems(new MixedItem())).Component
             .FindComponent<MudNumericField<int>>().Instance;
 
         // Assert
@@ -259,7 +259,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public void Date_Item_Field_Should_Render_Its_Attribute_Set()
     {
         // Arrange & Act
-        var field = RenderMixedForm(new MixedModel { Rows = { new MixedRow() } }).Component
+        var field = RenderMixedForm(NewMixedItems(new MixedItem())).Component
             .FindComponent<MudDatePicker>().Instance;
 
         // Assert - MudDatePicker's own End + calendar icon survives, per #217
@@ -276,7 +276,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     public void Boolean_Item_Field_Should_Render_Its_Attribute_Set()
     {
         // Arrange & Act
-        var field = RenderMixedForm(new MixedModel { Rows = { new MixedRow() } }).Component
+        var field = RenderMixedForm(NewMixedItems(new MixedItem())).Component
             .FindComponent<MudCheckBox<bool>>().Instance;
 
         // Assert - MudCheckBox has no Variant/Placeholder/HelperText concept, so the shared
@@ -299,18 +299,11 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
         // Was: Today_A_Boolean_Item_Field_Ignores_DisplayStyle. RenderBooleanField hard-coded
         // MudCheckBox and never read the attribute, so the same configuration rendered a checkbox
         // inside .WithItemForm(...) and a switch outside it.
-        var config = FormBuilder<MixedModel>
-            .Create()
-            .AddCollectionField(x => x.Rows, collection => collection
-                .WithLabel("Rows")
-                .WithItemForm(item => item
-                    .AddField(x => x.IsGift, field => field
-                        .WithLabel("Gift")
-                        .WithAttribute("DisplayStyle", BooleanDisplayStyle.Switch))))
-            .Build();
+        var config = MultiFieldItemForm(
+            configureBoolean: field => field.WithAttribute("DisplayStyle", BooleanDisplayStyle.Switch));
 
-        var component = Render<FormCraftComponent<MixedModel>>(parameters => parameters
-            .Add(p => p.Model, new MixedModel { Rows = { new MixedRow() } })
+        var component = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
+            .Add(p => p.Model, NewMixedItems(new MixedItem()))
             .Add(p => p.Configuration, config));
 
         component.FindComponents<MudSwitch<bool>>().Count.ShouldBe(1);
@@ -322,7 +315,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     {
         // Was: Today_A_Date_Item_Field_Is_Not_Editable. The component binds Editable="true"; the
         // hand-rolled path bound nothing, so an item field's date could be picked but never typed.
-        RenderMixedForm(new MixedModel { Rows = { new MixedRow() } }).Component
+        RenderMixedForm(NewMixedItems(new MixedItem())).Component
             .FindComponent<MudDatePicker>().Instance.Editable.ShouldBeTrue();
     }
 
@@ -334,19 +327,13 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
         // RenderPipelineParityTests.DateTimeField_Should_Pass_MinDate_And_MaxDate_To_DatePicker),
         // never forwarded by the collection path — so an item field silently accepted dates its
         // standalone twin refused.
-        var config = FormBuilder<MixedModel>
-            .Create()
-            .AddCollectionField(x => x.Rows, collection => collection
-                .WithLabel("Rows")
-                .WithItemForm(item => item
-                    .AddField(x => x.When, field => field
-                        .WithLabel("When")
-                        .WithAttribute("MinDate", new DateTime(2020, 1, 1))
-                        .WithAttribute("MaxDate", new DateTime(2030, 12, 31)))))
-            .Build();
+        var config = MultiFieldItemForm(
+            configureDate: field => field
+                .WithAttribute("MinDate", new DateTime(2020, 1, 1))
+                .WithAttribute("MaxDate", new DateTime(2030, 12, 31)));
 
-        var picker = Render<FormCraftComponent<MixedModel>>(parameters => parameters
-                .Add(p => p.Model, new MixedModel { Rows = { new MixedRow() } })
+        var picker = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
+                .Add(p => p.Model, NewMixedItems(new MixedItem()))
                 .Add(p => p.Configuration, config))
             .FindComponent<MudDatePicker>().Instance;
 
@@ -360,19 +347,13 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
         // Was: Today_A_Numeric_Item_Field_Ignores_Min_Max_And_Step. The bound range is what stops
         // the spinner and the browser going out of range, so dropping it made an item field accept
         // values its standalone twin rejected.
-        var config = FormBuilder<MixedModel>
-            .Create()
-            .AddCollectionField(x => x.Rows, collection => collection
-                .WithLabel("Rows")
-                .WithItemForm(item => item
-                    .AddField(x => x.Quantity, field => field
-                        .WithLabel("Quantity")
-                        .WithAttribute("Min", 5)
-                        .WithAttribute("Max", 50))))
-            .Build();
+        var config = MultiFieldItemForm(
+            configureNumeric: field => field
+                .WithAttribute("Min", 5)
+                .WithAttribute("Max", 50));
 
-        var numeric = Render<FormCraftComponent<MixedModel>>(parameters => parameters
-                .Add(p => p.Model, new MixedModel { Rows = { new MixedRow() } })
+        var numeric = Render<FormCraftComponent<MixedItemModel>>(parameters => parameters
+                .Add(p => p.Model, NewMixedItems(new MixedItem()))
                 .Add(p => p.Configuration, config))
             .FindComponent<MudNumericField<int>>().Instance;
 
@@ -431,19 +412,10 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
     /// <see cref="MudPopoverProvider"/> so the date picker works, and hands back the form's
     /// <see cref="EditContext"/>.
     /// </summary>
-    private (IRenderedComponent<FormCraftComponent<MixedModel>> Component, EditContext? EditContext)
-        RenderMixedForm(MixedModel model)
+    private (IRenderedComponent<FormCraftComponent<MixedItemModel>> Component, EditContext? EditContext)
+        RenderMixedForm(MixedItemModel model)
     {
-        var config = FormBuilder<MixedModel>
-            .Create()
-            .AddCollectionField(x => x.Rows, collection => collection
-                .WithLabel("Rows")
-                .WithItemForm(item => item
-                    .AddField(x => x.Name, field => field.WithLabel("Name"))
-                    .AddField(x => x.Quantity, field => field.WithLabel("Quantity"))
-                    .AddField(x => x.IsGift, field => field.WithLabel("Gift"))
-                    .AddField(x => x.When, field => field.WithLabel("When"))))
-            .Build();
+        var config = MultiFieldItemForm();
 
         EditContext? editContext = null;
 
@@ -451,7 +423,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
         {
             builder.OpenComponent<MudPopoverProvider>(0);
             builder.CloseComponent();
-            builder.OpenComponent<FormCraftComponent<MixedModel>>(1);
+            builder.OpenComponent<FormCraftComponent<MixedItemModel>>(1);
             builder.AddComponentParameter(2, "Model", model);
             builder.AddComponentParameter(3, "Configuration", config);
             builder.AddComponentParameter(4, "OnEditContextCreated",
@@ -459,22 +431,7 @@ public class CollectionRenderCharacterisationTests : MudBlazorTestBase
             builder.CloseComponent();
         });
 
-        return (host.FindComponent<FormCraftComponent<MixedModel>>(), editContext);
+        return (host.FindComponent<FormCraftComponent<MixedItemModel>>(), editContext);
     }
 
-    private class MixedModel
-    {
-        public List<MixedRow> Rows { get; set; } = new();
-    }
-
-    private class MixedRow
-    {
-        public string Name { get; set; } = string.Empty;
-
-        public int Quantity { get; set; }
-
-        public bool IsGift { get; set; }
-
-        public DateTime When { get; set; }
-    }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedLinesDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/MaskedLinesDiagnosticTests.cs
@@ -1,5 +1,7 @@
+using FormCraft.ForMudBlazor.UnitTests.Fields;
 using FormCraft.ForMudBlazor.UnitTests.TestSupport;
 using Microsoft.Extensions.Logging;
+using static FormCraft.ForMudBlazor.UnitTests.Fields.CollectionItemFixture;
 
 namespace FormCraft.ForMudBlazor.UnitTests.Diagnostics;
 
@@ -47,13 +49,16 @@ public class MaskedLinesDiagnosticTests : MudBlazorTestBase
     [Fact]
     public void Should_Warn_For_An_Item_Field_Too()
     {
-        // Arrange - the collection path builds its tree with RenderTreeBuilder rather than through
-        // MudBlazorFieldComponentBase, so it needs its own wiring and its own coverage. The clear
-        // text bug was identical on both paths; the diagnostic must be too.
-        var config = BuildItemFormConfiguration(f => f.AsPassword().AsTextArea(lines: 4));
+        // Arrange - the item placement was a render path of its own when this was written, so it
+        // needed its own wiring and its own coverage. The clear text bug was identical on both
+        // paths; the diagnostic must be too.
+        var config = TextItemForm(f => f
+            .WithLabel("Secret")
+            .AsPassword()
+            .AsTextArea(lines: 4));
 
         // Act
-        RenderItemForm(config);
+        this.RenderItemForm(NewOrder("hunter2"), config);
 
         // Assert
         var warnings = _logs.Warnings;
@@ -128,43 +133,7 @@ public class MaskedLinesDiagnosticTests : MudBlazorTestBase
             .Add(p => p.Configuration, config));
     }
 
-    private IRenderedComponent<FormCraftComponent<CredentialsModel>> RenderItemForm(
-        IFormConfiguration<CredentialsModel> config)
-    {
-        var model = new CredentialsModel { Items = { new Credential { Secret = "hunter2" } } };
-
-        return Render<FormCraftComponent<CredentialsModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, config));
-    }
-
-    private static IFormConfiguration<CredentialsModel> BuildItemFormConfiguration(
-        Action<FieldBuilder<Credential, string>> configureItemField)
-    {
-        return FormBuilder<CredentialsModel>
-            .Create()
-            .AddCollectionField(x => x.Items, collection => collection
-                .WithLabel("Credentials")
-                .WithItemForm(item => item
-                    .AddField(x => x.Secret, field =>
-                    {
-                        field.WithLabel("Secret");
-                        configureItemField(field);
-                    })))
-            .Build();
-    }
-
     private class TestModel
-    {
-        public string Secret { get; set; } = string.Empty;
-    }
-
-    private class CredentialsModel
-    {
-        public List<Credential> Items { get; set; } = new();
-    }
-
-    private class Credential
     {
         public string Secret { get; set; } = string.Empty;
     }

--- a/FormCraft.ForMudBlazor.UnitTests/Diagnostics/PasswordAdornmentDiagnosticTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Diagnostics/PasswordAdornmentDiagnosticTests.cs
@@ -1,5 +1,7 @@
+using FormCraft.ForMudBlazor.UnitTests.Fields;
 using FormCraft.ForMudBlazor.UnitTests.TestSupport;
 using Microsoft.Extensions.Logging;
+using static FormCraft.ForMudBlazor.UnitTests.Fields.CollectionItemFixture;
 
 namespace FormCraft.ForMudBlazor.UnitTests.Diagnostics;
 
@@ -134,23 +136,13 @@ public class PasswordAdornmentDiagnosticTests : MudBlazorTestBase
         // without a latch a three-row collection reports the same field's configuration three times.
         // A 50-row one would report it fifty times. The configuration is a property of the FIELD, not
         // of a row, so the correct count is one however many rows exist.
-        var config = FormBuilder<VaultModel>
-            .Create()
-            .AddCollectionField(x => x.Entries, collection => collection
-                .WithLabel("Entries")
-                .WithItemForm(item => item
-                    .AddField(x => x.Secret, f => f
-                        .WithLabel("Password")
-                        .WithAdornment(Icons.Material.Filled.Search, Adornment.End, onClick: _ => { })
-                        .AsPassword())))
-            .Build();
-
-        var model = new VaultModel { Entries = { new VaultEntry(), new VaultEntry(), new VaultEntry() } };
+        var config = TextItemForm(f => f
+            .WithLabel("Password")
+            .WithAdornment(Icons.Material.Filled.Search, Adornment.End, onClick: _ => { })
+            .AsPassword());
 
         // Act
-        var component = Render<FormCraftComponent<VaultModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, config));
+        var component = this.RenderItemForm(NewOrderWithItems("", "", ""), config);
 
         // Assert - three rows really did render, and produced one warning between them.
         component.FindComponents<MudTextField<string>>().Count.ShouldBe(3);
@@ -170,22 +162,14 @@ public class PasswordAdornmentDiagnosticTests : MudBlazorTestBase
         // Latching on the field alone would report one of these and hide the other for good — a
         // silent loss of a security-adjacent warning, which is the shape of bug this whole issue is
         // about.
-        var config = FormBuilder<VaultModel>
-            .Create()
-            .AddCollectionField(x => x.Entries, collection => collection
-                .WithLabel("Entries")
-                .WithItemForm(item => item
-                    .AddField(x => x.Secret, f => f
-                        .WithLabel("Password")
-                        .WithAdornment(Icons.Material.Filled.Search, Adornment.End, onClick: _ => { })
-                        .AsPassword()
-                        .AsTextArea(lines: 4))))
-            .Build();
+        var config = TextItemForm(f => f
+            .WithLabel("Password")
+            .WithAdornment(Icons.Material.Filled.Search, Adornment.End, onClick: _ => { })
+            .AsPassword()
+            .AsTextArea(lines: 4));
 
         // Act
-        Render<FormCraftComponent<VaultModel>>(parameters => parameters
-            .Add(p => p.Model, new VaultModel { Entries = { new VaultEntry() } })
-            .Add(p => p.Configuration, config));
+        this.RenderItemForm(NewOrder(), config);
 
         // Assert - one of each, not one in total.
         var warnings = _logs.Warnings;
@@ -201,16 +185,6 @@ public class PasswordAdornmentDiagnosticTests : MudBlazorTestBase
             .Add(p => p.Configuration, config));
 
     private class TestModel
-    {
-        public string Secret { get; set; } = string.Empty;
-    }
-
-    private class VaultModel
-    {
-        public List<VaultEntry> Entries { get; set; } = new();
-    }
-
-    private class VaultEntry
     {
         public string Secret { get; set; } = string.Empty;
     }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -209,8 +209,8 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         // This needs one item form holding fields of DIFFERENT types, which the fixture's
         // one-field-per-path builders cannot express — so it goes through MultiFieldItemForm, the
         // shared four-field row added for exactly this (#282). Only the text and collection
-        // callbacks are used here: the numeric and boolean fields render at their defaults, which
-        // keeps the rows' frame counts uneven, which is the property under test.
+        // callbacks are used here; the numeric and boolean fields render at their defaults and are
+        // incidental to this test, which asserts on the adorned text fields and the date pickers.
         var model = NewMixedItems(
             new MixedItem { Name = "first", When = new DateTime(2020, 1, 1) },
             new MixedItem { Name = "second", When = new DateTime(2030, 12, 31) });

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -248,5 +248,4 @@ public class CollectionAdornmentTests : MudBlazorTestBase
             .Select(p => p.Instance.Date)
             .ShouldBe(new DateTime?[] { new DateTime(2030, 12, 31), new DateTime(2020, 1, 1) });
     }
-
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionAdornmentTests.cs
@@ -27,10 +27,13 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// local helper, which is how the two suites' copies drifted in the first place.
 /// </para>
 /// <para>
-/// The reorder test at the bottom keeps its own <c>MixedModel</c> and its <c>MudPopoverProvider</c>
-/// wrapper. It needs two rows of *differing* field types in one item form, which is the opposite of
-/// what the fixture provides, and bending the fixture to absorb it would make it worse for the nine
-/// tests above.
+/// The reorder test at the bottom keeps its own <c>MudPopoverProvider</c> wrapper, but its model now
+/// comes from the fixture too (#282). It needs rows of <i>differing</i> field types in one item form
+/// — which the one-field-per-path builders cannot express — so the fixture grew
+/// <see cref="CollectionItemFixture.MultiFieldItemForm"/> for it and for
+/// <c>CollectionRenderCharacterisationTests</c>, the two suites that were each carrying a private
+/// <c>MixedRow</c>. The two copies had already drifted apart, which is what made the shared row worth
+/// adding rather than a speculative generalisation.
 /// </para>
 /// </summary>
 public class CollectionAdornmentTests : MudBlazorTestBase
@@ -203,34 +206,24 @@ public class CollectionAdornmentTests : MudBlazorTestBase
         // sequence numbers were computed rather than source-position constants, Blazor would pair
         // frames positionally across a reorder and a value could stay on the row it was on.
         //
-        // Deliberately NOT on the shared fixture (#205): this needs one item form holding two fields
-        // of different types, which is exactly what the fixture's one-field-per-path models are not.
-        var model = new MixedModel
-        {
-            Rows =
-            {
-                new MixedRow { Name = "first", When = new DateTime(2020, 1, 1) },
-                new MixedRow { Name = "second", When = new DateTime(2030, 12, 31) },
-            },
-        };
+        // This needs one item form holding fields of DIFFERENT types, which the fixture's
+        // one-field-per-path builders cannot express — so it goes through MultiFieldItemForm, the
+        // shared four-field row added for exactly this (#282). Only the text and collection
+        // callbacks are used here: the numeric and boolean fields render at their defaults, which
+        // keeps the rows' frame counts uneven, which is the property under test.
+        var model = NewMixedItems(
+            new MixedItem { Name = "first", When = new DateTime(2020, 1, 1) },
+            new MixedItem { Name = "second", When = new DateTime(2030, 12, 31) });
 
-        var config = FormBuilder<MixedModel>
-            .Create()
-            .AddCollectionField(x => x.Rows, collection => collection
-                .WithLabel("Rows")
-                .AllowReorder()
-                .WithItemForm(item => item
-                    .AddField(x => x.Name, field => field
-                        .WithLabel("Name")
-                        .WithAdornment(Icons.Material.Filled.Search, Adornment.Start))
-                    .AddField(x => x.When, field => field.WithLabel("When"))))
-            .Build();
+        var config = MultiFieldItemForm(
+            configureText: field => field.WithAdornment(Icons.Material.Filled.Search, Adornment.Start),
+            configureCollection: collection => collection.AllowReorder());
 
         var component = Render(builder =>
         {
             builder.OpenComponent<MudPopoverProvider>(0);
             builder.CloseComponent();
-            builder.OpenComponent<FormCraftComponent<MixedModel>>(1);
+            builder.OpenComponent<FormCraftComponent<MixedItemModel>>(1);
             builder.AddComponentParameter(2, "Model", model);
             builder.AddComponentParameter(3, "Configuration", config);
             builder.CloseComponent();
@@ -256,15 +249,4 @@ public class CollectionAdornmentTests : MudBlazorTestBase
             .ShouldBe(new DateTime?[] { new DateTime(2030, 12, 31), new DateTime(2020, 1, 1) });
     }
 
-    private class MixedModel
-    {
-        public List<MixedRow> Rows { get; set; } = new();
-    }
-
-    private class MixedRow
-    {
-        public string Name { get; set; } = string.Empty;
-
-        public DateTime When { get; set; }
-    }
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
@@ -77,7 +77,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - unchanged from before #189; guards the forward against regressing the
         // ordinary case into some other input type.
-        var component = RenderOrderForm(TextItemForm(_ => { }));
+        var component = RenderOrderForm(TextItemForm());
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.InputType
@@ -146,7 +146,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - measured, not assumed: MudTextField's own default is 1, and the component
         // path's fallback is also 1, so the two agree and forwarding changes nothing when unset.
-        var component = RenderOrderForm(TextItemForm(_ => { }));
+        var component = RenderOrderForm(TextItemForm());
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
@@ -171,7 +171,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // renders int.MaxValue when nothing is configured. Parity is with the component path, so
         // that is the value to match — copying MudBlazor's bare default here would make the two
         // paths disagree by exactly the amount this issue exists to remove.
-        var component = RenderOrderForm(TextItemForm(_ => { }));
+        var component = RenderOrderForm(TextItemForm());
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.MaxLength.ShouldBe(int.MaxValue);
@@ -239,7 +239,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // an empty pattern rather than PatternMask(""). MudTextField swaps its input implementation
         // for a MudMask as soon as Mask is non-null, so a non-null empty mask would reroute every
         // unmasked item field through a different component and quietly drop MaxLines with it.
-        var component = RenderOrderForm(TextItemForm(field => field.WithLabel("Product")));
+        var component = RenderOrderForm(TextItemForm());
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.Mask.ShouldBeNull();
@@ -428,10 +428,9 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         int rows,
         string value = "N/A")
     {
-        var productNames = new string[rows];
-        Array.Fill(productNames, value);
-
-        return this.RenderItemForm(NewOrderWithItems(productNames), config);
+        return this.RenderItemForm(
+            NewOrderWithItems(Enumerable.Repeat(value, rows).ToArray()),
+            config);
     }
 
     private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionInputTypeTests.cs
@@ -1,5 +1,6 @@
 using FormCraft.ForMudBlazor.UnitTests.TestSupport;
 using Microsoft.Extensions.Logging;
+using static FormCraft.ForMudBlazor.UnitTests.Fields.CollectionItemFixture;
 
 namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 
@@ -34,7 +35,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     public void ItemField_With_AsPassword_Should_Render_A_Password_Input()
     {
         // Arrange & Act - the bug this issue was filed for: the characters were displayed.
-        var component = RenderOrderForm(BuildConfiguration(field => field.AsPassword()));
+        var component = RenderOrderForm(TextItemForm(field => field.AsPassword()));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.InputType
@@ -47,7 +48,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // Arrange & Act - AsPassword() also writes EnablePasswordToggle, which the collection path
         // does not implement. Masking must not depend on that: the toggle is a convenience, the
         // masking is the security-relevant half.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.AsPassword(enableVisibilityToggle: false)));
 
         // Assert
@@ -61,7 +62,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // Arrange & Act - the parameter assertions above prove the value was forwarded; this proves
         // it reaches the DOM the user actually looks at. That is the whole claim of this issue, and
         // a component parameter that never made it onto the <input> would satisfy the others.
-        var component = RenderOrderForm(BuildConfiguration(field => field.AsPassword()));
+        var component = RenderOrderForm(TextItemForm(field => field.AsPassword()));
 
         // Assert - `type="password"` is the whole of the fix: it is what makes the browser mask the
         // characters. Deliberately NOT asserting the value is absent from the markup — a bound
@@ -76,7 +77,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - unchanged from before #189; guards the forward against regressing the
         // ordinary case into some other input type.
-        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+        var component = RenderOrderForm(TextItemForm(_ => { }));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.InputType
@@ -95,7 +96,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - MudBlazorTextFieldComponent.GetInputType() owns this mapping; the two
         // paths must agree on all of it, not just on "password".
-        var component = RenderOrderForm(BuildConfiguration(field => field.WithInputType(configured)));
+        var component = RenderOrderForm(TextItemForm(field => field.WithInputType(configured)));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.InputType.ShouldBe(expected);
@@ -105,7 +106,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     public void ItemField_Should_Map_An_Unrecognised_Input_Type_To_Text()
     {
         // Arrange & Act - the component path's fallback arm, mirrored.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithInputType("definitely-not-an-input-type")));
 
         // Assert
@@ -119,7 +120,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // Arrange & Act - WithInputType writes the first-class Field.InputType property, but the
         // component path also accepts a raw "InputType" attribute as a fallback. Resolve both, or
         // a field configured the second way keeps rendering in clear text.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithAttribute("InputType", "password")));
 
         // Assert
@@ -131,7 +132,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     public void ItemField_Should_Render_Its_Configured_Lines()
     {
         // Arrange & Act
-        var component = RenderOrderForm(BuildConfiguration(field => field.AsTextArea(lines: 4)));
+        var component = RenderOrderForm(TextItemForm(field => field.AsTextArea(lines: 4)));
 
         // Assert - the parameter, and the consequence of it. MudTextField switches element on
         // Lines > 1, so this is the one forwarded attribute whose effect is visible in the markup
@@ -145,7 +146,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - measured, not assumed: MudTextField's own default is 1, and the component
         // path's fallback is also 1, so the two agree and forwarding changes nothing when unset.
-        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+        var component = RenderOrderForm(TextItemForm(_ => { }));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.Lines.ShouldBe(1);
@@ -155,7 +156,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     public void ItemField_Should_Render_Its_Configured_MaxLength()
     {
         // Arrange & Act
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.AsTextArea(lines: 3, maxLength: 500)));
 
         // Assert
@@ -170,7 +171,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // renders int.MaxValue when nothing is configured. Parity is with the component path, so
         // that is the value to match — copying MudBlazor's bare default here would make the two
         // paths disagree by exactly the amount this issue exists to remove.
-        var component = RenderOrderForm(BuildConfiguration(_ => { }));
+        var component = RenderOrderForm(TextItemForm(_ => { }));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.MaxLength.ShouldBe(int.MaxValue);
@@ -181,7 +182,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - the component path treats a zero/negative MaxLength as "no limit"; the
         // item path must not turn it into a field that accepts nothing.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithAttribute("MaxLength", 0)));
 
         // Assert
@@ -194,7 +195,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // Arrange & Act - MudTextField has no Autocomplete parameter at all (verified by
         // reflection), so the component path emits a raw lowercase "autocomplete" HTML attribute
         // that lands in the unmatched-attribute bag. The item path has to do the same.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithAutocomplete("current-password")));
 
         // Assert
@@ -207,7 +208,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange & Act - guard the guard: UserAttributes is only a staging dictionary. Assert the
         // attribute actually survives onto the <input>, which is what a password manager reads.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithAutocomplete("current-password")));
 
         // Assert
@@ -221,7 +222,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // path, so it asserted null and said "pinned so that whoever implements masks does it on both
         // paths at once". That is now done — FormCraft's mask string is resolved to a MudBlazor IMask
         // through the shared TextMaskMap, so the item path and the standalone path agree.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.WithAttribute("Mask", "0000-0000")));
 
         // Assert - the pattern rather than the instance: each path builds its own IMask, so the
@@ -238,7 +239,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // an empty pattern rather than PatternMask(""). MudTextField swaps its input implementation
         // for a MudMask as soon as Mask is non-null, so a non-null empty mask would reroute every
         // unmasked item field through a different component and quietly drop MaxLines with it.
-        var component = RenderOrderForm(BuildConfiguration(field => field.WithLabel("Product")));
+        var component = RenderOrderForm(TextItemForm(field => field.WithLabel("Product")));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.Mask.ShouldBeNull();
@@ -256,7 +257,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // mobile keypad and the native picker. #189 carried the recognised set over unchanged on
         // purpose, so widening it is a behaviour change rather than a parity fix — but because both
         // paths resolve through TextInputTypeMap, it lands on both at once.
-        var component = RenderOrderForm(BuildConfiguration(field => field.WithInputType(configured)));
+        var component = RenderOrderForm(TextItemForm(field => field.WithInputType(configured)));
 
         // Assert
         component.FindComponent<MudTextField<string>>().Instance.InputType.ShouldBe(expected);
@@ -272,7 +273,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // it reaches the element the browser reads, which is what actually selects the keypad or the
         // picker. A forwarded parameter that never lands on the <input> is the failure mode both
         // #189 and #207 hit.
-        var component = RenderOrderForm(BuildConfiguration(field => field.WithInputType(configured)));
+        var component = RenderOrderForm(TextItemForm(field => field.WithInputType(configured)));
 
         // Assert
         component.Find("input").GetAttribute("type").ShouldBe(configured);
@@ -285,7 +286,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // `type` attribute at all, so the masking was silently dropped and the credential was
         // displayed. There is no such thing as a masked textarea, so the security-relevant half of
         // the configuration wins and the field renders as a single-line password input.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.AsPassword().AsTextArea(lines: 4)));
 
         // Assert - the markup, not just the parameter: asserting only MudTextField.InputType would
@@ -301,7 +302,7 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // Arrange & Act - order-independence is not a nicety here: AsTextArea lives in the core
         // FormCraft project and AsPassword in FormCraft.ForMudBlazor, so neither builder method
         // ever sees the other's setting. Only the render path can reconcile them.
-        var component = RenderOrderForm(BuildConfiguration(field =>
+        var component = RenderOrderForm(TextItemForm(field =>
             field.AsTextArea(lines: 4).AsPassword()));
 
         // Assert
@@ -317,10 +318,12 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // from OnInitialized, so an unlatched warning reports a single field's CONFIGURATION once
         // per row: fifty rows, fifty identical lines, and the signal is buried in its own noise.
         // The latch is what makes this a report about a field rather than about a list.
-        var config = BuildConfiguration(field => field.WithAttribute("Mask", "(000) 000-0000"));
+        var config = TextItemForm(field => field
+            .WithLabel("Secret")
+            .WithAttribute("Mask", "(000) 000-0000"));
 
         // Act
-        RenderCredentials(config, rows: 5);
+        RenderRows(config, rows: 5);
 
         // Assert
         var warnings = _logs.Warnings;
@@ -337,13 +340,13 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // shared between them would report whichever fired first and hide the rest for good. The
         // code this replaced kept two separate HashSets for exactly this; the category-qualified key
         // is how that survives now that the latch is shared infrastructure.
-        var config = BuildConfiguration(field => field
+        var config = TextItemForm(field => field
             .WithAttribute("Mask", "(000) 000-0000")
             .AsPassword()
             .AsTextArea(lines: 4));
 
         // Act
-        RenderCredentials(config, rows: 5);
+        RenderRows(config, rows: 5);
 
         // Assert - one masked-lines warning and one masked-value warning, each still latched to one
         // per field rather than one per row.
@@ -358,10 +361,10 @@ public class CollectionInputTypeTests : MudBlazorTestBase
     {
         // Arrange - the negative that keeps the latch honest. Nothing is rejected here, so the
         // absence of a warning must come from the rule, not from a latch that swallowed it.
-        var config = BuildConfiguration(field => field.WithAttribute("Mask", "(000) 000-0000"));
+        var config = TextItemForm(field => field.WithAttribute("Mask", "(000) 000-0000"));
 
         // Act
-        RenderCredentials(config, rows: 5, value: "5551234567");
+        RenderRows(config, rows: 5, value: "5551234567");
 
         // Assert
         _logs.Warnings.ShouldBeEmpty();
@@ -376,21 +379,21 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         // CollectionItemFieldScope.DiagnosticKey exists to remove, and it has to reach the MESSAGE
         // and not just the latch key to be worth anything.
         var model = new TwoCollectionModel();
-        model.Contacts.Add(new Credential { Secret = "N/A" });
-        model.Suppliers.Add(new Credential { Secret = "N/A" });
+        model.Contacts.Add(new OrderItem { ProductName = "N/A" });
+        model.Suppliers.Add(new OrderItem { ProductName = "N/A" });
 
         var config = FormBuilder<TwoCollectionModel>
             .Create()
             .AddCollectionField(x => x.Contacts, collection => collection
                 .WithLabel("Contacts")
                 .WithItemForm(item => item
-                    .AddField(x => x.Secret, field => field
+                    .AddField(x => x.ProductName, field => field
                         .WithLabel("Secret")
                         .WithAttribute("Mask", "(000) 000-0000"))))
             .AddCollectionField(x => x.Suppliers, collection => collection
                 .WithLabel("Suppliers")
                 .WithItemForm(item => item
-                    .AddField(x => x.Secret, field => field
+                    .AddField(x => x.ProductName, field => field
                         .WithLabel("Secret")
                         .WithAttribute("Mask", "(000) 000-0000"))))
             .Build();
@@ -407,56 +410,31 @@ public class CollectionInputTypeTests : MudBlazorTestBase
         warnings.ShouldContain(w => w.Contains("Suppliers[].Secret"));
     }
 
+    /// <summary>
+    /// Two collections of the same item type in one form — the shape the fixture deliberately does
+    /// not provide, because it exists for this suite's own question (which collection does a
+    /// diagnostic name?) rather than for a field type. Its <i>item</i> type still comes from the
+    /// fixture; only the two-collection root is local.
+    /// </summary>
     private class TwoCollectionModel
     {
-        public List<Credential> Contacts { get; set; } = new();
+        public List<OrderItem> Contacts { get; set; } = new();
 
-        public List<Credential> Suppliers { get; set; } = new();
+        public List<OrderItem> Suppliers { get; set; } = new();
     }
 
-    private IRenderedComponent<FormCraftComponent<CredentialsModel>> RenderCredentials(
-        IFormConfiguration<CredentialsModel> config,
+    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderRows(
+        IFormConfiguration<OrderModel> config,
         int rows,
         string value = "N/A")
     {
-        var model = new CredentialsModel();
-        for (var i = 0; i < rows; i++)
-        {
-            model.Items.Add(new Credential { Secret = value });
-        }
+        var productNames = new string[rows];
+        Array.Fill(productNames, value);
 
-        return Render<FormCraftComponent<CredentialsModel>>(parameters => parameters
-            .Add(p => p.Model, model)
-            .Add(p => p.Configuration, config));
+        return this.RenderItemForm(NewOrderWithItems(productNames), config);
     }
 
-    private IRenderedComponent<FormCraftComponent<CredentialsModel>> RenderOrderForm(
-        IFormConfiguration<CredentialsModel> config)
-        => RenderCredentials(config, rows: 1, value: "hunter2");
-
-    private static IFormConfiguration<CredentialsModel> BuildConfiguration(
-        Action<FieldBuilder<Credential, string>> configureItemField)
-    {
-        return FormBuilder<CredentialsModel>
-            .Create()
-            .AddCollectionField(x => x.Items, collection => collection
-                .WithLabel("Credentials")
-                .WithItemForm(item => item
-                    .AddField(x => x.Secret, field =>
-                    {
-                        field.WithLabel("Secret");
-                        configureItemField(field);
-                    })))
-            .Build();
-    }
-
-    private class CredentialsModel
-    {
-        public List<Credential> Items { get; set; } = new();
-    }
-
-    private class Credential
-    {
-        public string Secret { get; set; } = string.Empty;
-    }
+    private IRenderedComponent<FormCraftComponent<OrderModel>> RenderOrderForm(
+        IFormConfiguration<OrderModel> config)
+        => RenderRows(config, rows: 1, value: "hunter2");
 }

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
@@ -212,6 +212,15 @@ internal static class CollectionItemFixture
     /// four parallel arrays would be worse at the call site than the object initialiser it replaced.
     /// Pass <c>new MixedItem()</c> for a blank row — the seeds stay the caller's choice here as
     /// everywhere else in this fixture.
+    /// <para>
+    /// ⚠️ <b>Give each row its own <see cref="MixedItem"/>.</b> This is the one factory here that
+    /// stores instances the caller supplied rather than constructing them itself, so
+    /// <c>NewMixedItems(row, row)</c> — or a seed hoisted out of a loop — puts the <i>same object</i>
+    /// in both rows. A reorder test then compares two aliases that cannot disagree, and a
+    /// per-row-binding test asserting row 1's edit left row 0 alone passes without proving anything.
+    /// The sibling factories cannot be misused this way because they build their items internally;
+    /// this one trades that safety for the ability to seed four members at once.
+    /// </para>
     /// </remarks>
     internal static MixedItemModel NewMixedItems(params MixedItem[] rows)
     {

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixture.cs
@@ -28,11 +28,20 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// is the whole reason the boolean model lives here rather than being left to each suite.
 /// </para>
 /// <para>
-/// <b>One shape beyond the field types.</b> Every builder above produces a form containing nothing but
-/// a collection. <see cref="NamedOrderModel"/> / <see cref="NamedOrderItem"/> and
-/// <see cref="RootFieldAndItemForm"/> are the exception: a root-level field <i>beside</i> the
-/// collection, with the two members sharing the name <c>Name</c>. Look here before hand-rolling a
-/// model for a form that is not collection-only (#213, #258).
+/// <b>Two shapes beyond the field types.</b> Every builder above produces a form containing nothing
+/// but a collection, whose item form holds exactly one field. Two members break each of those
+/// assumptions in turn:
+/// <list type="bullet">
+/// <item><description><see cref="NamedOrderModel"/> / <see cref="NamedOrderItem"/> and
+/// <see cref="RootFieldAndItemForm"/> — a root-level field <i>beside</i> the collection, with the
+/// two members sharing the name <c>Name</c>. Look here before hand-rolling a model for a form that
+/// is not collection-only (#213, #258).</description></item>
+/// <item><description><see cref="MixedItemModel"/> / <see cref="MixedItem"/> and
+/// <see cref="MultiFieldItemForm"/> — <i>four</i> fields in one item row, one of each of the four
+/// original component types. The shape a suite needs when its subject is rows of differing
+/// render-tree frame counts in a keyless loop, which a single-field row cannot express
+/// (#282).</description></item>
+/// </list>
 /// </para>
 /// <para>
 /// ⚠️ <b>These were four separate render paths when this fixture was written (#205).</b> Item fields
@@ -195,6 +204,94 @@ internal static class CollectionItemFixture
             .Build();
 
     /// <summary>
+    /// Creates a mixed-row model with one row per <paramref name="rows"/> entry, in order.
+    /// </summary>
+    /// <remarks>
+    /// Takes whole rows rather than a params list of scalars the way
+    /// <see cref="NewOrderWithItems"/> does: four members cannot each be seeded from one value, and
+    /// four parallel arrays would be worse at the call site than the object initialiser it replaced.
+    /// Pass <c>new MixedItem()</c> for a blank row — the seeds stay the caller's choice here as
+    /// everywhere else in this fixture.
+    /// </remarks>
+    internal static MixedItemModel NewMixedItems(params MixedItem[] rows)
+    {
+        var model = new MixedItemModel();
+        foreach (var row in rows)
+        {
+            model.Rows.Add(row);
+        }
+
+        return model;
+    }
+
+    /// <summary>
+    /// A collection whose item form holds <b>four fields in one row</b> — <c>string</c>,
+    /// <c>int</c>, <c>bool</c> and <c>DateTime</c> together — rather than one field per model pair.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every other builder here produces a single-field item form, which is the right default: a
+    /// suite asking "does this attribute reach a numeric item field?" should not have to read past
+    /// three fields it does not care about. But two suites need rows of <i>differing render-tree
+    /// frame counts inside one keyless loop</i>, which only a multi-field row produces —
+    /// <c>CollectionAdornmentTests</c>' reorder test (an adornment makes a text row emit more frames
+    /// than a date row) and <c>CollectionRenderCharacterisationTests</c> (#282). Both carried their
+    /// own <c>MixedRow</c>, and the two copies had already drifted — one declared
+    /// <c>{ Name, When }</c>, the other <c>{ Name, Quantity, IsGift, When }</c> — which is the harm
+    /// #205 predicted, observed.
+    /// </para>
+    /// <para>
+    /// The row carries the union of the two, which happens to be one of each of the four original
+    /// component types. So it doubles as the "several field types in one row" case rather than being
+    /// a bespoke shape for one suite. A consumer that wants only two of the fields configures only
+    /// those two; the others still render, which is what makes the row mixed.
+    /// </para>
+    /// <para>
+    /// <paramref name="configureCollection"/> is the one callback here that reaches the
+    /// <i>collection</i> rather than a field. The reorder test needs <c>.AllowReorder()</c>, which is
+    /// a property of the collection, and without it that suite would have to hand-roll the whole
+    /// configuration — and would keep its own model copy along with it, which is the duplication
+    /// this member exists to remove.
+    /// </para>
+    /// </remarks>
+    internal static IFormConfiguration<MixedItemModel> MultiFieldItemForm(
+        Action<FieldBuilder<MixedItem, string>>? configureText = null,
+        Action<FieldBuilder<MixedItem, int>>? configureNumeric = null,
+        Action<FieldBuilder<MixedItem, bool>>? configureBoolean = null,
+        Action<FieldBuilder<MixedItem, DateTime>>? configureDate = null,
+        Action<CollectionFieldBuilder<MixedItemModel, MixedItem>>? configureCollection = null) =>
+        FormBuilder<MixedItemModel>
+            .Create()
+            .AddCollectionField(x => x.Rows, collection =>
+            {
+                collection
+                    .WithLabel("Rows")
+                    .WithItemForm(item => item
+                        .AddField(x => x.Name, field =>
+                        {
+                            field.WithLabel("Name");
+                            configureText?.Invoke(field);
+                        })
+                        .AddField(x => x.Quantity, field =>
+                        {
+                            field.WithLabel("Quantity");
+                            configureNumeric?.Invoke(field);
+                        })
+                        .AddField(x => x.IsGift, field =>
+                        {
+                            field.WithLabel("Gift");
+                            configureBoolean?.Invoke(field);
+                        })
+                        .AddField(x => x.When, field =>
+                        {
+                            field.WithLabel("When");
+                            configureDate?.Invoke(field);
+                        }));
+                configureCollection?.Invoke(collection);
+            })
+            .Build();
+
+    /// <summary>
     /// A root-level <c>string</c> field <i>beside</i> a collection whose item form holds a
     /// <c>string</c> field of the same name — the only shape here that is not a form containing
     /// nothing but a collection.
@@ -309,6 +406,34 @@ internal sealed class NamedOrderModel
 internal sealed class NamedOrderItem
 {
     public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>Root model for the multi-field row shape.</summary>
+internal sealed class MixedItemModel
+{
+    public List<MixedItem> Rows { get; set; } = new();
+}
+
+/// <summary>
+/// Item for the multi-field row — four members of four different types, so one item form renders a
+/// <c>MudTextField</c>, a <c>MudNumericField&lt;int&gt;</c>, a <c>MudCheckBox</c> and a
+/// <c>MudDatePicker</c> side by side (#282).
+/// <para>
+/// The union of the two <c>MixedRow</c> copies this replaced, not a widening of
+/// <see cref="OrderItem"/>: growing a shared model one field per consumer is the failure #205 set
+/// out to prevent, and a row that is multi-field <i>by design</i> is a different thing from a
+/// single-field row that accreted three more.
+/// </para>
+/// </summary>
+internal sealed class MixedItem
+{
+    public string Name { get; set; } = string.Empty;
+
+    public int Quantity { get; set; }
+
+    public bool IsGift { get; set; }
+
+    public DateTime When { get; set; }
 }
 
 /// <summary>

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
@@ -22,8 +22,9 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// </para>
 /// </para>
 /// <para>
-/// <b>Beyond the field types</b>, the fixture also carries one shape — a root-level field beside the
-/// collection (<c>RootFieldAndItemForm</c>) — which is guarded here too.
+/// <b>Beyond the field types</b>, the fixture carries two shapes — a root-level field beside the
+/// collection (<c>RootFieldAndItemForm</c>), and one item form holding four fields at once
+/// (<c>MultiFieldItemForm</c>, #282) — both guarded here too.
 /// </para>
 /// <para>
 /// <b>The seed is the caller's choice.</b> <c>CollectionRequiredTests</c> needs a blank
@@ -141,6 +142,98 @@ public class CollectionItemFixtureTests : MudBlazorTestBase
         date.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("Renamed");
         boolean.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Renamed");
         dec.FindComponent<MudNumericField<decimal>>().Instance.Label.ShouldBe("Renamed");
+    }
+
+    [Fact]
+    public void MultiFieldItemForm_Should_Render_All_Four_Fields_In_One_Row()
+    {
+        // Arrange & Act - the shape every other builder here is not: ONE item form holding four
+        // fields at once, rather than one field per model pair. CollectionAdornmentTests and
+        // CollectionRenderCharacterisationTests are the named consumers (#282) — both were carrying
+        // their own MixedRow, and the two copies had already drifted apart.
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewMixedItems(new MixedItem()),
+            CollectionItemFixture.MultiFieldItemForm());
+
+        // Assert - one of each component type, in the order the builder declares them. MudDatePicker
+        // embeds a MudTextField<string> of its own, so the text field is selected by label rather
+        // than by FindComponent, which would return whichever came first in the tree.
+        component.FindComponents<MudTextField<string>>()
+            .Select(f => f.Instance.Label)
+            .ShouldContain("Name");
+        component.FindComponent<MudNumericField<int>>().Instance.Label.ShouldBe("Quantity");
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
+        component.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("When");
+    }
+
+    [Fact]
+    public void MultiFieldItemForm_Should_Route_Each_Callback_To_Its_Own_Field()
+    {
+        // Arrange & Act - four callbacks, four destinations. A builder that wired two of them to the
+        // same field, or dropped one, would leave a suite configuring nothing while still looking
+        // configured at the call site. Renamed apart so the assertions can tell them apart: with a
+        // shared label this test would pass on a builder that applied one callback four times.
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewMixedItems(new MixedItem()),
+            CollectionItemFixture.MultiFieldItemForm(
+                configureText: field => field.WithLabel("Renamed text"),
+                configureNumeric: field => field.WithLabel("Renamed numeric"),
+                configureBoolean: field => field.WithLabel("Renamed boolean"),
+                configureDate: field => field.WithLabel("Renamed date")));
+
+        // Assert
+        component.FindComponents<MudTextField<string>>()
+            .Select(f => f.Instance.Label)
+            .ShouldContain("Renamed text");
+        component.FindComponent<MudNumericField<int>>().Instance.Label.ShouldBe("Renamed numeric");
+        component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Renamed boolean");
+        component.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("Renamed date");
+    }
+
+    [Fact]
+    public void MultiFieldItemForm_Should_Apply_The_Callers_Collection_Configuration()
+    {
+        // Arrange & Act - the collection itself, not just its fields. CollectionAdornmentTests'
+        // reorder test needs .AllowReorder(), which is a property of the COLLECTION; without this
+        // callback that suite would have to hand-roll the whole configuration and would keep its own
+        // model copy with it, which is the duplication this fixture exists to remove.
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewMixedItems(new MixedItem(), new MixedItem()),
+            CollectionItemFixture.MultiFieldItemForm(
+                configureCollection: collection => collection.AllowReorder()));
+
+        // Assert - reorder controls only render when the collection allows reordering
+        component.FindAll("button[aria-label='Move up']").ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void NewMixedItems_Should_Seed_Each_Row_And_Preserve_Order()
+    {
+        // Arrange & Act - the multi-row factory for the four-member row. It takes whole rows rather
+        // than a params list of scalars because four members cannot be seeded from one value each
+        // the way NewOrderWithItems' product names can.
+        var model = CollectionItemFixture.NewMixedItems(
+            new MixedItem { Name = "first", Quantity = 1, IsGift = true, When = new DateTime(2020, 1, 1) },
+            new MixedItem { Name = "second", Quantity = 2, IsGift = false, When = new DateTime(2030, 12, 31) });
+
+        // Assert - every member survived, and the rows kept their order
+        model.Rows.Count.ShouldBe(2);
+        model.Rows.Select(r => r.Name).ShouldBe(new[] { "first", "second" });
+        model.Rows.Select(r => r.Quantity).ShouldBe(new[] { 1, 2 });
+        model.Rows.Select(r => r.IsGift).ShouldBe(new[] { true, false });
+        model.Rows.Select(r => r.When)
+            .ShouldBe(new[] { new DateTime(2020, 1, 1), new DateTime(2030, 12, 31) });
+
+        // ...and in what renders, as the other seed tests do. Asserting the POCO alone would stay
+        // green if the builder bound a field to the wrong property.
+        var component = this.RenderItemForm(model, CollectionItemFixture.MultiFieldItemForm());
+        component.FindComponents<MudTextField<string>>()
+            .Where(f => f.Instance.Label == "Name")
+            .Select(f => f.Instance.Value)
+            .ShouldBe(new[] { "first", "second" });
+        component.FindComponents<MudNumericField<int>>()
+            .Select(f => f.Instance.Value)
+            .ShouldBe(new[] { 1, 2 });
     }
 
     [Fact]

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemFixtureTests.cs
@@ -155,15 +155,34 @@ public class CollectionItemFixtureTests : MudBlazorTestBase
             CollectionItemFixture.NewMixedItems(new MixedItem()),
             CollectionItemFixture.MultiFieldItemForm());
 
-        // Assert - one of each component type, in the order the builder declares them. MudDatePicker
-        // embeds a MudTextField<string> of its own, so the text field is selected by label rather
-        // than by FindComponent, which would return whichever came first in the tree.
+        // Assert - one of each component type. MudDatePicker embeds a MudTextField<string> of its
+        // own, so the text field is selected by label rather than by FindComponent, which would
+        // return whichever came first in the tree.
         component.FindComponents<MudTextField<string>>()
             .Select(f => f.Instance.Label)
             .ShouldContain("Name");
         component.FindComponent<MudNumericField<int>>().Instance.Label.ShouldBe("Quantity");
         component.FindComponent<MudCheckBox<bool>>().Instance.Label.ShouldBe("Gift");
         component.FindComponent<MudDatePicker>().Instance.Label.ShouldBe("When");
+    }
+
+    [Fact]
+    public void MultiFieldItemForm_Should_Declare_Its_Four_Fields_In_A_Stable_Order()
+    {
+        // Arrange & Act - the order is not cosmetic: CollectionRenderCharacterisationTests'
+        // Every_Item_Field_Kind_Should_Render_Its_Own_Nested_Validation_Slot asserts the exact
+        // sequence Rows[0].Name, Rows[0].Quantity, Rows[0].IsGift, Rows[0].When. Swapping two
+        // AddField calls in the builder would turn that consumer red while every assertion in this
+        // file — the one that exists to pin what the suites rely on and cannot check themselves —
+        // stayed green, sending the next maintainer to debug the wrong file.
+        var component = this.RenderItemForm(
+            CollectionItemFixture.NewMixedItems(new MixedItem()),
+            CollectionItemFixture.MultiFieldItemForm());
+
+        // Assert - the validation slots carry the item field names in declaration order
+        component.FindComponents<FieldValidationMessage>()
+            .Select(m => m.Instance.FieldName)
+            .ShouldBe(new[] { "Rows[0].Name", "Rows[0].Quantity", "Rows[0].IsGift", "Rows[0].When" });
     }
 
     [Fact]
@@ -197,13 +216,22 @@ public class CollectionItemFixtureTests : MudBlazorTestBase
         // reorder test needs .AllowReorder(), which is a property of the COLLECTION; without this
         // callback that suite would have to hand-roll the whole configuration and would keep its own
         // model copy with it, which is the duplication this fixture exists to remove.
-        var component = this.RenderItemForm(
+        var reorderable = this.RenderItemForm(
             CollectionItemFixture.NewMixedItems(new MixedItem(), new MixedItem()),
             CollectionItemFixture.MultiFieldItemForm(
                 configureCollection: collection => collection.AllowReorder()));
 
+        // ...and the same form WITHOUT the callback, which is the half that makes this a test of the
+        // callback rather than of MudBlazor. Asserting only that the buttons appear would stay green
+        // if reordering ever became the default, or if a regression rendered the controls
+        // unconditionally — proving nothing about the parameter the test is named for.
+        var plain = this.RenderItemForm(
+            CollectionItemFixture.NewMixedItems(new MixedItem(), new MixedItem()),
+            CollectionItemFixture.MultiFieldItemForm());
+
         // Assert - reorder controls only render when the collection allows reordering
-        component.FindAll("button[aria-label='Move up']").ShouldNotBeEmpty();
+        reorderable.FindAll("button[aria-label='Move up']").ShouldNotBeEmpty();
+        plain.FindAll("button[aria-label='Move up']").ShouldBeEmpty();
     }
 
     [Fact]
@@ -234,6 +262,16 @@ public class CollectionItemFixtureTests : MudBlazorTestBase
         component.FindComponents<MudNumericField<int>>()
             .Select(f => f.Instance.Value)
             .ShouldBe(new[] { 1, 2 });
+
+        // All four, not just the two easy ones: this is the only test seeding every member with
+        // per-row distinguishable values, so if it checks half of them it is the reason a
+        // mis-bound bool or DateTime would reach a consumer suite unnoticed.
+        component.FindComponents<MudCheckBox<bool>>()
+            .Select(f => f.Instance.Value)
+            .ShouldBe(new[] { true, false });
+        component.FindComponents<MudDatePicker>()
+            .Select(f => f.Instance.Date)
+            .ShouldBe(new DateTime?[] { new DateTime(2020, 1, 1), new DateTime(2030, 12, 31) });
     }
 
     [Fact]


### PR DESCRIPTION
Implements #282.

Closes #282.

All four plan tasks are complete and every checkbox on the issue is ticked.

### Plan
- [x] Task 1: Migrate the three Group 1 suites onto `TextItemForm`
- [x] Task 2: Add the multi-field item row to the fixture
- [x] Task 3: Migrate the two Group 2 suites
- [x] Task 4: Close the verification gap that let these survive

### What landed

All five suites now use `CollectionItemFixture`; the five private model copies are gone.

| Commit | Change |
|---|---|
| `c854085` | `CollectionInputTypeTests`, `MaskedLinesDiagnosticTests`, `PasswordAdornmentDiagnosticTests` → `TextItemForm`; `CredentialsModel`/`Credential` and `VaultModel`/`VaultEntry` deleted along with the two copy-pasted config builders |
| `23368a7` | Fixture gains `MixedItemModel`/`MixedItem`, `NewMixedItems`, `MultiFieldItemForm` + self-tests |
| `31edd4e` | `CollectionAdornmentTests`, `CollectionRenderCharacterisationTests` → `MultiFieldItemForm`; both drifted `MixedModel`/`MixedRow` copies deleted |
| `6cccb87` | whitespace left by the deleted models |
| `3a8d4e0` | code-review findings |

**Verification**
- Per-suite test counts unchanged for every migrated file: 32 / 5 / 7 / 10 / 18.
- Project total 464 → **469**: the four fixture self-tests plus one field-order guard added in review. Never lower.
- **Mutation check** (Task 3 Step 4): with the text-field adornment forward broken, the *same 18 tests* go red before and after the migration — including the migrated `Reordering_A_Mixed_Item_Form_Should_Move_Values_With_Their_Rows`. The migrated tests still bite.
- **No production file changed** — `git diff --name-only dev...HEAD` is entirely within `FormCraft.ForMudBlazor.UnitTests/`.
- `dotnet build -c Release --no-incremental` → 0 warnings; `./build.sh Test` → green; up to date with `dev`.

**Shape-based sweep (Task 4).** Only three private test models still declare a collection, and none is a copy of anything the fixture provides:
- `ShrinkLabelKeyCollisionTests.TwoCollectionModel` and `CollectionInputTypeTests.TwoCollectionModel` — the two-collection *root* is local (a documented non-goal), but both now hold fixture item types (`NamedOrderItem`, `OrderItem`).
- `CollectionNumericTypeTests.NumericsModel`/`NumericsRow` — seven numeric types in one row (`int/decimal/double/float/long/short/byte`), which is that suite's entire subject (#209). The fixture supplies two of the seven; absorbing the rest is the row-combinator this issue explicitly rejected as approach C.

### Deviation from the plan

`MultiFieldItemForm` takes a **fifth** optional parameter beyond the four the plan specified —
`configureCollection`. `CollectionAdornmentTests`' reorder test needs `.AllowReorder()`, which is a
property of the *collection*, not of a field; without it that suite would have had to hand-roll its
whole configuration and would have kept its model copy with it, defeating the migration. Covered by
its own self-test, including a negative control.

### Code review

Eleven findings; **nine applied**, two disputed.

Applied: corrected a factually wrong comment I introduced in the reorder test (both rows render
identical fields, so their frame counts are *equal* — what differs is frames *between fields within*
a row); added a test pinning `MultiFieldItemForm`'s field declaration order, which a consumer suite
asserts exactly but nothing guarded; added a negative control to the `configureCollection` test;
render-asserted all four members in the seeding test rather than two; documented that
`NewMixedItems` stores caller-supplied instances, so passing one row twice aliases it; routed three
open-coded renders through the fixture's `RenderItemForm`; corrected the stale claim that
`MudPopoverProvider` is needed for a date picker to *render* (it hosts the overlay); dropped four
no-op callbacks left over from the deleted `BuildConfiguration`; replaced an allocate-then-fill with
`Enumerable.Repeat`.

Disputed:
- *"The PR adds a second private `TwoCollectionModel`"* — it does not. `git show dev:…CollectionInputTypeTests.cs` has it at line 410 with `List<Credential>`; this PR only re-pointed the item type to the fixture's `OrderItem`. The observation that its doc in `ShrinkLabelKeyCollisionTests` ("no other suite needs it") is stale is fair, but it was stale before this branch and consolidating the two is an explicit non-goal of #282.
- *"Give `configureCollection` to all six builders and collapse `RenderOrderForm`"* — a real reuse opportunity, but it widens a scoped test refactor into a fixture API change with five more call-site surfaces. Filed as a follow-up instead.

## Follow-ups

- **The verification gap is closed by hand, not by a test.** Task 4's sweep is a one-off; nothing stops a sixth suite from declaring a private collection-item model tomorrow. A guard test — assert no type outside `CollectionItemFixture` declares a `List<T>` whose `T` has a single scalar member — would make #258's lesson permanent.
- **Give the other five item-form builders the `configureCollection` callback** that `MultiFieldItemForm` now has. `CollectionRenderCharacterisationTests.RenderOrderForm` still hand-rolls a configuration byte-identical to `TextItemForm()` plus `AllowReorder`/`AllowAdd`/`AllowRemove`; the callback would collapse it to one call, and the escape hatch would become a property of the fixture rather than a special case on one builder.
- **`ShrinkLabelKeyCollisionTests.TwoCollectionModel` and `CollectionInputTypeTests.TwoCollectionModel` now express the same shape** (two same-typed collections on one model, for form-wide diagnostics keyed by collection name). The former's doc still claims no other suite needs it. Worth reconciling — either share the shape or correct the doc.
