### PR TITLE
docs: correct CLAUDE.md's test commands for Microsoft.Testing.Platform (#299)

### DIFF
--- a/.claude/skills/repo-profile.md
+++ b/.claude/skills/repo-profile.md
@@ -59,9 +59,10 @@
       `Zero tests ran` (exit `8`), which is easy to skim past as success. A wildcard
       (`--filter-method '*Clearing_A_Standalone*'`) is the ergonomic escape.
     - ⚠️ **`--filter-trait` is dead weight here:** no test in this repo carries a `[Trait]`, so
-      `--filter-trait 'Category=Builder'` returns `Zero tests ran`. Note `CLAUDE.md` still
-      advertises `dotnet test --filter "Category=Builder"`, which is wrong twice over — the option
-      is inert *and* the trait does not exist. Filter by class or namespace instead.
+      `--filter-trait 'Category=Builder'` returns `Zero tests ran`. Filter by class or namespace
+      instead. (`CLAUDE.md` used to advertise `dotnet test --filter "Category=Builder"`, wrong twice
+      over — inert option, non-existent trait. Corrected in #299, which also added
+      `FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests` to stop it coming back.)
   - ⛔ **`dotnet test --filter …` really is inert** — the true half of the advice this bullet
     replaced. It is a VSTest option forwarded as an MSBuild property that MTP ignores, warning
     `MTP0001: VSTest-specific properties are set but will be ignored … VSTestTestCaseFilter` while
@@ -90,11 +91,13 @@
     and reports green on a command that failed — this single form defeats the rule directly above,
     which is why the example names its project.
   - **Scope:** this is *within-task* iteration only. It does **not** replace the *CI gates* below —
-    `./build.cmd Test` stays the pre-merge gate and still runs everything: 808 + 464 + 68 = 1340
-    tests, ~30s including `Compile`. Bare `dotnet test -c Release` runs the same three suites in
-    ~11s warm. ⚠️ **Neither prints a `1340` aggregate** — you get one `Passed!` line *per assembly*,
-    in nondeterministic order, so a check that reads the first one accepts `Total: 68` as the whole
-    suite. Confirm all three assemblies reported, or trust the process exit code for the full run
+    `./build.cmd Test` stays the pre-merge gate and still runs everything: **~1,550 tests** across
+    the three projects, ~30s including `Compile`. Bare `dotnet test -c Release` runs the same three
+    suites in ~11s warm. (Approximate on purpose — the precise `808 + 464 + 68 = 1340` recorded here
+    by #290 was stale within a day, which is the whole failure mode this section is about.)
+    ⚠️ **Neither prints an aggregate** — you get one `Passed!` line *per assembly*,
+    in nondeterministic order, so a check that reads the first one accepts one project's total as the
+    whole suite. Confirm all three assemblies reported, or trust the process exit code for the full run
     (unpiped). Filter to iterate; run one of these before you claim done.
 - **Format/lint apply:** `dotnet format FormCraft.sln`
 - **Format/lint verify (the gate):** *CI runs no `dotnet format` check.* The enforcing gate is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,14 @@ see the warning below the commands, which is the part that costs time if you ski
 ```bash
 # Run everything — ~1,550 tests across the three test projects (approximate on purpose: the
 # exact figure drifts with every merge, and a stale precise number reads as authoritative)
-dotnet test
+dotnet test -c Release
 
-# Run one test project
-dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj
-dotnet test FormCraft.ForMudBlazor.UnitTests/FormCraft.ForMudBlazor.UnitTests.csproj
-dotnet test FormCraft.ForFluentUI.UnitTests/FormCraft.ForFluentUI.UnitTests.csproj
+# Run one test project. `-c Release` throughout: CI runs Release, and the host path
+# below is a Release path — mixing configurations is how you end up running one build
+# and inspecting another.
+dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj -c Release
+dotnet test FormCraft.ForMudBlazor.UnitTests/FormCraft.ForMudBlazor.UnitTests.csproj -c Release
+dotnet test FormCraft.ForFluentUI.UnitTests/FormCraft.ForFluentUI.UnitTests.csproj -c Release
 
 # Run one class — everything after `--` is forwarded to the test host.
 # Always name the .csproj: run solution-wide, the filter is applied to all three
@@ -43,14 +45,16 @@ dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj -c Release \
   -- --filter-class FormCraft.UnitTests.Ci.GitignoreTests
 
 # Same filter without the build step (~200ms). Run `dotnet build -c Release` first,
-# or you are testing a stale binary.
+# or you are testing a stale binary. On Windows the host is `...\FormCraft.UnitTests.exe`.
 FormCraft.UnitTests/bin/Release/net10.0/FormCraft.UnitTests \
   --filter-class FormCraft.UnitTests.Ci.GitignoreTests
 ```
 
-Filters: `--filter-class`, `--filter-method`, `--filter-namespace`, their `--filter-not-*`
-counterparts, and `--filter-uid`. `*` wildcards work at either end. `--filter-method` wants the
-**fully-qualified** name (`<namespace>.<class>.<method>`) — a bare method name matches nothing.
+Filters: `--filter-class`, `--filter-method`, `--filter-namespace`, `--filter-trait`, `--filter-uid`,
+`--filter-query`, plus a `--filter-not-*` counterpart for class/method/namespace/trait. `*` wildcards
+work at either end, and the simple filters cannot be combined with `--filter-query`.
+`--filter-method` wants the **fully-qualified** name (`<namespace>.<class>.<method>`) — a bare method
+name matches nothing. `--filter-trait` is useless here: no test in this repo carries a `[Trait]`.
 
 ⛔ **The VSTest spellings are silently ignored here.** Passing `--filter` to `dotnet test` (rather
 than after `--`) forwards it as an MSBuild property that Microsoft.Testing.Platform discards with a
@@ -58,18 +62,31 @@ lone `MTP0001` warning — **the whole suite runs** while the command looks filt
 The same applies to `--collect:"XPlat Code Coverage"`, which additionally writes no coverage file at
 all; coverage is not currently wired up for these projects (no MTP coverage extension is referenced),
 so there is no working substitute to reach for. Filtering by `Category=…` never worked either: no
-test in this repo carries a `[Trait]`. `FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests` fails the
-build if these spellings return to this file.
+test in this repo carries a `[Trait]`. The MSBuild-property spellings (`-p:VSTestTestCaseFilter=…`,
+`-p:VSTestCollect=…`) are inert for the same reason. `FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests`
+fails — it is a unit test, so `dotnet test` catches this, **not** `dotnet build` — if any of these
+return to this file.
 
-⚠️ **Check the summary line, not the exit code.** A mistyped flag prints `--help`, runs nothing, and
-emits no summary at all — so `grep 'Failed!'` finds nothing and reads as green — while a pipe
-(`| tail`, `| grep`) replaces `$?` with the pipe's `0`. A filter matching nothing reports
-`Zero tests ran` from the host, or `Failed! … Total: 0` via `dotnet test`. Require a real
-`Passed!`/`Failed!` line **and** a plausible count.
+⚠️ **A green-looking run may have run nothing, and the two paths fail differently.**
 
-Full trap list and the measurements behind all of this:
-[`.claude/skills/repo-profile.md`](.claude/skills/repo-profile.md) → *Build & test* → *Single-suite
-filter*. Kept there rather than duplicated here so the two cannot drift apart.
+- **Summary lines are printed *per assembly*, with no aggregate.** A solution-wide filtered run
+  prints `Passed! … Total: 6` for the assembly that matched and `Failed! … Total: 0` for the two
+  that did not — exit `1`. "I saw a `Passed!` line" therefore proves nothing on its own: confirm
+  **every** assembly reported, or read the exit code of an **unpiped** run.
+- **`$?` is only meaningful unpiped.** `| tail` / `| grep` replaces it with the pipe's `0`.
+- **Mistyped flag, direct host** → `Unknown option '--…'` plus the full `--help`, nothing runs, and
+  **no summary line at all** (so `grep 'Failed!'` reads it as green); exit `5`.
+- **Mistyped flag, `dotnet test`** → the diagnostic never reaches stdout. You get only
+  `error run failed: Tests failed: '<path>/TestResults/<assembly>_net10.0_arm64.log'` and exit `1` —
+  wording that blames the tests for what is an argument error. **Read that log before debugging any
+  source.**
+- **Filter matching nothing** → `Zero tests ran` (direct host, exit `8`) or `Failed! … Total: 0`
+  (`dotnet test`, exit `1`). Check for `Total: 0` before hunting a phantom regression.
+
+**This block is a summary.** The authoritative version — the full flag list, both failure paths, and
+the measurements behind every claim — is [`.claude/skills/repo-profile.md`](.claude/skills/repo-profile.md)
+→ *Build & test* → *Single-suite filter*. Where the two disagree, **the profile wins and this block is
+the stale one**; keep corrections there and re-summarise here rather than growing a second copy.
 
 ### Running the Demo Application
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,26 +22,53 @@ dotnet build /p:TreatWarningsAsErrors=true
 ```
 
 ### Running Tests
+
+The test projects are **Microsoft.Testing.Platform** hosts, not VSTest. That changes how you filter —
+see the warning below the commands, which is the part that costs time if you skip it.
+
 ```bash
-# Run all tests (600+ unit tests across 2 test projects)
+# Run everything — 1340 tests across the three test projects (808 + 464 + 68)
 dotnet test
 
-# Run specific test project
+# Run one test project
 dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj
 dotnet test FormCraft.ForMudBlazor.UnitTests/FormCraft.ForMudBlazor.UnitTests.csproj
+dotnet test FormCraft.ForFluentUI.UnitTests/FormCraft.ForFluentUI.UnitTests.csproj
 
-# Run tests with coverage
-dotnet test --collect:"XPlat Code Coverage"
+# Run one class — everything after `--` is forwarded to the test host.
+# Always name the .csproj: run solution-wide, the filter is applied to all three
+# assemblies and the two that match nothing report Failed!, exiting 1.
+dotnet test FormCraft.UnitTests/FormCraft.UnitTests.csproj -c Release \
+  -- --filter-class FormCraft.UnitTests.Ci.GitignoreTests
 
-# Run specific test class or method
-dotnet test --filter "FullyQualifiedName~FormBuilderTests"
-dotnet test --filter "DisplayName~Should_Build_Valid_Configuration"
-
-# Run tests by category
-dotnet test --filter "Category=Builder"
-dotnet test --filter "Category=Renderer"
-dotnet test --filter "Category=Security"
+# Same filter without the build step (~200ms). Run `dotnet build -c Release` first,
+# or you are testing a stale binary.
+FormCraft.UnitTests/bin/Release/net10.0/FormCraft.UnitTests \
+  --filter-class FormCraft.UnitTests.Ci.GitignoreTests
 ```
+
+Filters: `--filter-class`, `--filter-method`, `--filter-namespace`, their `--filter-not-*`
+counterparts, and `--filter-uid`. `*` wildcards work at either end. `--filter-method` wants the
+**fully-qualified** name (`<namespace>.<class>.<method>`) — a bare method name matches nothing.
+
+⛔ **The VSTest spellings are silently ignored here.** Passing `--filter` to `dotnet test` (rather
+than after `--`) forwards it as an MSBuild property that Microsoft.Testing.Platform discards with a
+lone `MTP0001` warning — **the whole suite runs** while the command looks filtered, and exits `0`.
+The same applies to `--collect:"XPlat Code Coverage"`, which additionally writes no coverage file at
+all; coverage is not currently wired up for these projects (no MTP coverage extension is referenced),
+so there is no working substitute to reach for. Filtering by `Category=…` never worked either: no
+test in this repo carries a `[Trait]`. `FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests` fails the
+build if these spellings return to this file.
+
+⚠️ **Check the summary line, not the exit code.** A mistyped flag prints `--help`, runs nothing, and
+emits no summary at all — so `grep 'Failed!'` finds nothing and reads as green — while a pipe
+(`| tail`, `| grep`) replaces `$?` with the pipe's `0`. A filter matching nothing reports
+`Zero tests ran` from the host, or `Failed! … Total: 0` via `dotnet test`. Require a real
+`Passed!`/`Failed!` line **and** a plausible count.
+
+Full trap list and the measurements behind all of this:
+[`.claude/skills/repo-profile.md`](.claude/skills/repo-profile.md) → *Build & test* → *Single-suite
+filter*. Kept there rather than duplicated here so the two cannot drift apart.
 
 ### Running the Demo Application
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ The test projects are **Microsoft.Testing.Platform** hosts, not VSTest. That cha
 see the warning below the commands, which is the part that costs time if you skip it.
 
 ```bash
-# Run everything — 1340 tests across the three test projects (808 + 464 + 68)
+# Run everything — ~1,550 tests across the three test projects (approximate on purpose: the
+# exact figure drifts with every merge, and a stale precise number reads as authoritative)
 dotnet test
 
 # Run one test project

--- a/FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests.cs
+++ b/FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+
+namespace FormCraft.UnitTests.Ci;
+
+/// <summary>
+/// Guards <c>CLAUDE.md</c> against VSTest-era test invocations (#299). The test projects run on
+/// Microsoft.Testing.Platform (<c>OutputType=Exe</c> + <c>UseMicrosoftTestingPlatformRunner=true</c>),
+/// which <b>ignores</b> VSTest options: <c>--filter</c> arrives as the MSBuild property
+/// <c>VSTestTestCaseFilter</c> and <c>--collect:</c> as <c>VSTestCollect</c>, both discarded with a
+/// single <c>MTP0001</c> build warning.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure is <b>silent and green</b>, which is why it needs a guard rather than a reader. A
+/// filtered run executes the <i>entire</i> suite and still prints <c>Passed!</c> with exit <c>0</c>;
+/// a <c>--collect:"XPlat Code Coverage"</c> run writes <b>no coverage file at all</b> and also exits
+/// <c>0</c>. Nothing in either outcome looks like a mistake, so the stale instruction survives every
+/// casual read — it survived in <c>CLAUDE.md</c> until #277 measured it, and <c>CLAUDE.md</c> is the
+/// file auto-loaded into every session.
+/// </para>
+/// <para>
+/// <b>Asserted on the command form, not on the bare substring, deliberately.</b> The corrected prose
+/// has to be able to <i>name</i> the broken flags in order to warn about them ("⛔ <c>dotnet test
+/// --filter</c> is inert"), so a substring check would forbid the very sentence that prevents the
+/// regression. Only a line that <i>is</i> a command — one whose code begins <c>dotnet test</c> —
+/// counts, and inline-code prose never does.
+/// </para>
+/// <para>
+/// Continued lines are joined before matching. A wrapped command is the obvious way this guard would
+/// otherwise be evaded by accident: the <c>--filter</c> sits on a continuation line that does not
+/// itself begin <c>dotnet test</c>, so a naive per-line scan reads it as prose and passes.
+/// </para>
+/// <para>
+/// The working replacements are <c>dotnet test &lt;csproj&gt; -c Release -- --filter-class &lt;FQN&gt;</c>
+/// (everything after <c>--</c> reaches the test host) or the built host directly — documented with
+/// their traps in <c>.claude/skills/repo-profile.md</c> under <i>Build &amp; test</i>. Note
+/// <c>--filter-class</c> must keep passing this guard, which is why the pattern below requires
+/// <c>--filter</c> to be followed by something other than a name character.
+/// </para>
+/// </remarks>
+public class ClaudeMdTestCommandsTests
+{
+    /// <summary>The always-loaded briefing this guard protects, relative to the repo root.</summary>
+    private const string ClaudeMd = "CLAUDE.md";
+
+    /// <summary>
+    /// Matches a VSTest option that Microsoft.Testing.Platform silently discards.
+    /// <c>(?![-\w])</c> is load-bearing: it lets the working <c>--filter-class</c> /
+    /// <c>--filter-method</c> / <c>--filter-namespace</c> through while still catching a bare
+    /// <c>--filter</c> that is followed by a space, a quote, or the end of the line.
+    /// </summary>
+    private static readonly Regex InertVsTestOption =
+        new(@"--(?:filter(?![-\w])|collect)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every shell command in <c>CLAUDE.md</c> that invokes <c>dotnet test</c>, with backslash
+    /// continuations already folded into the line that starts them.
+    /// </summary>
+    private static IReadOnlyList<string> DotnetTestCommands()
+    {
+        string[] lines = File.ReadAllLines(Path.Combine(WorkflowSource.RepoRoot, ClaudeMd));
+        List<string> commands = [];
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i].Trim();
+            if (!line.StartsWith("dotnet test", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Fold `\`-continued lines so a wrapped command is matched as the single command it is.
+            while (line.EndsWith('\\') && i + 1 < lines.Length)
+            {
+                line = string.Concat(line.AsSpan(0, line.Length - 1).TrimEnd(), " ", lines[++i].Trim());
+            }
+
+            commands.Add(line);
+        }
+
+        return commands;
+    }
+
+    [Fact]
+    public void ClaudeMd_Should_Not_Teach_Test_Commands_That_The_Runner_Ignores()
+    {
+        string[] offenders = DotnetTestCommands()
+            .Where(command => InertVsTestOption.IsMatch(command))
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            $"CLAUDE.md documents {offenders.Length} `dotnet test` command(s) using VSTest options that "
+            + "Microsoft.Testing.Platform ignores (MTP0001) — the whole suite runs, or no coverage file "
+            + "is written, and either way the command exits 0. Use `dotnet test <csproj> -c Release "
+            + "-- --filter-class <FQN>` instead; see .claude/skills/repo-profile.md (Build & test). "
+            + $"Offending command(s): {string.Join(" | ", offenders)}");
+    }
+
+    [Fact]
+    public void The_Guarded_Briefing_Should_Still_Be_Where_This_File_Guards_It()
+    {
+        // A rename would make the assertion above vacuous rather than failing, so it is asserted
+        // instead of assumed — the same reason GitignoreTests pins the profile's path.
+        File.Exists(Path.Combine(WorkflowSource.RepoRoot, ClaudeMd))
+            .ShouldBeTrue($"{ClaudeMd} was not found at the repo root; this guard would silently pass");
+    }
+}

--- a/FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests.cs
+++ b/FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests.cs
@@ -15,27 +15,36 @@ namespace FormCraft.UnitTests.Ci;
 /// filtered run executes the <i>entire</i> suite and still prints <c>Passed!</c> with exit <c>0</c>;
 /// a <c>--collect:"XPlat Code Coverage"</c> run writes <b>no coverage file at all</b> and also exits
 /// <c>0</c>. Nothing in either outcome looks like a mistake, so the stale instruction survives every
-/// casual read — it survived in <c>CLAUDE.md</c> until #277 measured it, and <c>CLAUDE.md</c> is the
-/// file auto-loaded into every session.
+/// casual read — it did survive, in the file auto-loaded into every session, until #277 measured it.
 /// </para>
 /// <para>
-/// <b>Asserted on the command form, not on the bare substring, deliberately.</b> The corrected prose
-/// has to be able to <i>name</i> the broken flags in order to warn about them ("⛔ <c>dotnet test
-/// --filter</c> is inert"), so a substring check would forbid the very sentence that prevents the
-/// regression. Only a line that <i>is</i> a command — one whose code begins <c>dotnet test</c> —
-/// counts, and inline-code prose never does.
+/// <b>Both spellings are covered.</b> The flag form (<c>--filter</c>, <c>--collect</c>) and the
+/// MSBuild-property form (<c>-p:VSTestTestCaseFilter=…</c>) are equally inert — the property form was
+/// measured for #299 and produced <c>MTP0001</c> with all 158 tests of the target project running.
+/// <see cref="TestReportingTests.BuildScript_Should_Not_Set_The_VSTest_Properties_That_Mtp_Ignores" />
+/// pins the same class of mistake in <c>build/Build.cs</c>; this class covers the documentation.
 /// </para>
 /// <para>
-/// Continued lines are joined before matching. A wrapped command is the obvious way this guard would
-/// otherwise be evaded by accident: the <c>--filter</c> sits on a continuation line that does not
-/// itself begin <c>dotnet test</c>, so a naive per-line scan reads it as prose and passes.
+/// <b>Scanned at command position, not by substring.</b> The corrected prose has to be able to
+/// <i>name</i> the broken flags in order to warn about them ("⛔ <c>dotnet test --filter</c> is
+/// inert"), so a substring check would forbid the very sentence that prevents the regression. Only a
+/// line whose <i>command</i> is a test run counts: the start of a line or the start of a
+/// shell-separated clause. Inline-code prose and <c>#</c> comments therefore never match, which is
+/// deliberate — the sanctioned way to warn about a broken flag is prose, not a commented-out example.
 /// </para>
 /// <para>
-/// The working replacements are <c>dotnet test &lt;csproj&gt; -c Release -- --filter-class &lt;FQN&gt;</c>
-/// (everything after <c>--</c> reaches the test host) or the built host directly — documented with
-/// their traps in <c>.claude/skills/repo-profile.md</c> under <i>Build &amp; test</i>. Note
-/// <c>--filter-class</c> must keep passing this guard, which is why the pattern below requires
-/// <c>--filter</c> to be followed by something other than a name character.
+/// The scan covers the direct-host invocation as well as <c>dotnet test</c>. <c>CLAUDE.md</c> now
+/// leads with the host binary for fast iteration, so that is the most likely place a future inert
+/// flag lands — anchoring only on <c>dotnet test</c> would leave the recommended path unguarded.
+/// Continuations are folded first: a wrapped command puts its flags on a line that does not itself
+/// begin a command, which a naive per-line scan reads as prose.
+/// </para>
+/// <para>
+/// <b><see cref="The_Scan_Should_Actually_Find_The_Documented_Commands" /> is the load-bearing
+/// test.</b> Every other assertion here is of the form "no offender was found", which is also what an
+/// empty scan reports. Reformat the code fence — a <c>$ </c> prompt, a different indent, a renamed
+/// binary — and a scanner without that assertion passes forever while the broken commands sit
+/// unread three lines below.
 /// </para>
 /// </remarks>
 public class ClaudeMdTestCommandsTests
@@ -44,27 +53,39 @@ public class ClaudeMdTestCommandsTests
     private const string ClaudeMd = "CLAUDE.md";
 
     /// <summary>
-    /// Matches a VSTest option that Microsoft.Testing.Platform silently discards.
-    /// <c>(?![-\w])</c> is load-bearing: it lets the working <c>--filter-class</c> /
-    /// <c>--filter-method</c> / <c>--filter-namespace</c> through while still catching a bare
-    /// <c>--filter</c> that is followed by a space, a quote, or the end of the line.
+    /// A test run at command position: line start or after a shell separator, optionally behind a
+    /// <c>$ </c> prompt. Matches <c>dotnet test</c> (any spacing) and the built MTP hosts, whose
+    /// file name is the project name, with or without the Windows <c>.exe</c>.
     /// </summary>
-    private static readonly Regex InertVsTestOption =
-        new(@"--(?:filter(?![-\w])|collect)", RegexOptions.Compiled);
+    private static readonly Regex TestInvocation = new(
+        @"(?:^|[;&|]\s*)\$?\s*(?:dotnet\s+test\b|\S*FormCraft\.\w*\.?UnitTests(?:\.exe)?(?=\s|$))",
+        RegexOptions.Compiled);
 
     /// <summary>
-    /// Every shell command in <c>CLAUDE.md</c> that invokes <c>dotnet test</c>, with backslash
-    /// continuations already folded into the line that starts them.
+    /// A VSTest option Microsoft.Testing.Platform silently discards, in either spelling.
+    /// <c>(?![-\w])</c> is load-bearing: it lets the working <c>--filter-class</c> /
+    /// <c>--filter-method</c> / <c>--filter-namespace</c> through while still catching a bare
+    /// <c>--filter</c> followed by a space, a quote, or the end of the line.
     /// </summary>
-    private static IReadOnlyList<string> DotnetTestCommands()
+    private static readonly Regex InertVsTestOption = new(
+        @"--(?:filter(?![-\w])|collect)|[-/]p:VSTest\w+",
+        RegexOptions.Compiled);
+
+    private static string ClaudeMdPath => Path.Combine(WorkflowSource.RepoRoot, ClaudeMd);
+
+    /// <summary>
+    /// Every shell command in <c>CLAUDE.md</c> that runs tests, with backslash continuations folded
+    /// into the line that starts them.
+    /// </summary>
+    private static IReadOnlyList<string> TestCommands()
     {
-        string[] lines = File.ReadAllLines(Path.Combine(WorkflowSource.RepoRoot, ClaudeMd));
+        string[] lines = File.ReadAllLines(ClaudeMdPath);
         List<string> commands = [];
 
         for (int i = 0; i < lines.Length; i++)
         {
             string line = lines[i].Trim();
-            if (!line.StartsWith("dotnet test", StringComparison.Ordinal))
+            if (!TestInvocation.IsMatch(line))
             {
                 continue;
             }
@@ -82,14 +103,25 @@ public class ClaudeMdTestCommandsTests
     }
 
     [Fact]
+    public void The_Scan_Should_Actually_Find_The_Documented_Commands()
+    {
+        // Without this, every other assertion below is vacuously true the moment the scan stops
+        // matching — which a formatting change alone is enough to cause.
+        TestCommands().ShouldNotBeEmpty(
+            $"no test command was found in {ClaudeMd}, so the guards in this class assert nothing. "
+            + "Either the Running Tests examples were removed, or their formatting changed in a way "
+            + $"{nameof(TestInvocation)} no longer recognises — fix the pattern, not this assertion.");
+    }
+
+    [Fact]
     public void ClaudeMd_Should_Not_Teach_Test_Commands_That_The_Runner_Ignores()
     {
-        string[] offenders = DotnetTestCommands()
+        string[] offenders = TestCommands()
             .Where(command => InertVsTestOption.IsMatch(command))
             .ToArray();
 
         offenders.ShouldBeEmpty(
-            $"CLAUDE.md documents {offenders.Length} `dotnet test` command(s) using VSTest options that "
+            $"CLAUDE.md documents {offenders.Length} test command(s) using VSTest options that "
             + "Microsoft.Testing.Platform ignores (MTP0001) — the whole suite runs, or no coverage file "
             + "is written, and either way the command exits 0. Use `dotnet test <csproj> -c Release "
             + "-- --filter-class <FQN>` instead; see .claude/skills/repo-profile.md (Build & test). "
@@ -97,11 +129,25 @@ public class ClaudeMdTestCommandsTests
     }
 
     [Fact]
-    public void The_Guarded_Briefing_Should_Still_Be_Where_This_File_Guards_It()
+    public void Every_Documented_Filter_Class_Should_Resolve_To_A_Real_Test_Class()
     {
-        // A rename would make the assertion above vacuous rather than failing, so it is asserted
-        // instead of assumed — the same reason GitignoreTests pins the profile's path.
-        File.Exists(Path.Combine(WorkflowSource.RepoRoot, ClaudeMd))
-            .ShouldBeTrue($"{ClaudeMd} was not found at the repo root; this guard would silently pass");
+        // A documented filter that matches nothing reports `Zero tests ran` / `Total: 0` — which the
+        // profile itself calls indistinguishable at a glance from a real regression. So a rename must
+        // break this test rather than quietly turn the flagship example into a no-op.
+        string[] documented = Regex
+            .Matches(File.ReadAllText(ClaudeMdPath), @"--filter-class\s+([A-Za-z0-9_.]+)")
+            .Select(match => match.Groups[1].Value)
+            .Where(fqn => fqn.StartsWith("FormCraft.UnitTests.", StringComparison.Ordinal))
+            .Distinct()
+            .ToArray();
+
+        documented.ShouldNotBeEmpty($"{ClaudeMd} no longer shows a --filter-class example to verify");
+
+        foreach (string fqn in documented)
+        {
+            typeof(ClaudeMdTestCommandsTests).Assembly.GetType(fqn).ShouldNotBeNull(
+                $"{ClaudeMd} documents `--filter-class {fqn}`, but no such type exists in this "
+                + "assembly — the documented command would run zero tests and still look plausible");
+        }
     }
 }


### PR DESCRIPTION
Implements #299.

Closes #299.

`CLAUDE.md`'s **Running Tests** section is VSTest-era. The repo runs on Microsoft.Testing.Platform, which ignores VSTest options — so most of what that section teaches does nothing, exits `0`, and says so only in an `MTP0001` warning nobody reads. #290 fixed this class of error one level up in `.claude/skills/repo-profile.md`; this is the same fix in the file that is auto-loaded into *every* session.

Executing the implementation plan task-by-task; the checklist below — and the plan on the issue — are
ticked as each task lands. Opened as a draft — will be marked ready after the final task and a
code-review pass.

### Plan
- [x] Task 1: Guard the invariant (failing test first)
- [x] Task 2: Correct the Running Tests section
- [x] Task 3: Verify end-to-end

### What changed

`CLAUDE.md`'s *Running Tests* section now documents commands that actually do what they say, and a
static guard stops the old ones coming back.

| Was | Now |
|---|---|
| 5 × `dotnet test --filter …` | `dotnet test <csproj> -c Release -- --filter-class <FQN>`, plus the direct-host fast path (~200 ms) |
| `--filter "Category=Builder\|Renderer\|Security"` | removed — **no test in this repo carries a `[Trait]`**, so these never matched anything |
| `--collect:"XPlat Code Coverage"` | removed, with the reason stated: MTP discards `VSTestCollect` *and* no coverage extension is referenced, so no file was ever written |
| "600+ unit tests across 2 test projects" | "~1,550 across the three", deliberately approximate |
| 2 test projects listed | all three (FluentUI was missing) |

`FormCraft.UnitTests/Ci/ClaudeMdTestCommandsTests` fails the build if a `dotnet test` command in
`CLAUDE.md` regains `--filter`/`--collect`. It matches on the **command form**, not the bare
substring, so the corrected prose can still *name* the broken flags in order to warn about them — and
it folds `\`-continued lines first, since a wrapped command is the obvious way the guard would
otherwise be evaded by accident. `--filter-class` and friends deliberately still pass.

Red→green evidence: the guard failed on first run listing exactly the 6 offending commands, and
passes now. `./build.sh Test` is green — 1548 tests across the three projects.

### Code review

A review over `dev...HEAD` returned 12 findings; each was re-measured before acting. Ten were real
and are fixed in `fix: address code-review findings`. The ones that mattered:

- **The guard could go permanently vacuous.** Every assertion was of the form "no offender found",
  which is also what an *empty scan* reports — so a formatting change to the code fence would have
  made it pass forever while the broken commands sat unread. There is now an explicit
  `The_Scan_Should_Actually_Find_The_Documented_Commands` test. (The review also correctly showed my
  original companion test guarded a hole that cannot exist: `File.ReadAllLines` throws on a missing
  file, so it would never "silently pass". Replaced.)
- **The scan missed the path the doc recommends.** Anchoring on `dotnet test` left the direct-host
  invocation — the fast path CLAUDE.md now leads with, and so the likeliest place a future inert flag
  lands — completely unguarded. Verified by injecting
  `…/FormCraft.UnitTests --collect:"XPlat Code Coverage"`: the original guard passed, the new one
  fails with that exact line.
- **The verification rule was self-defeating.** "Require a real `Passed!`/`Failed!` line and a
  plausible count" is *satisfied* by the first `Passed! … Total: 6` of a solution-wide run whose other
  two assemblies reported `Failed! … Total: 0` with exit 1 — i.e. it green-lit the precise false pass
  this PR exists to prevent. Rewritten around per-assembly reporting and the unpiped exit code.
- **The mistyped-flag advice described only one path.** The `--help`/exit-5 behaviour is direct-host;
  via `dotnet test` the diagnostic never reaches stdout and you get `error run failed: Tests failed`
  pointing at a log — wording that sends you debugging source for an argument typo. Both documented.
- **"Fails the build" was simply wrong** — it is a unit test, so `dotnet test` catches it, not
  `dotnet build`. An agent validating with the build gate would have shipped the regression.
- **Debug/Release were mixed**: `dotnet test` with no `-c` builds Debug, then the documented Release
  host path does not exist. The block is uniformly Release now, matching CI.
- Also: MSBuild-property spellings (`-p:VSTestTestCaseFilter=…`) are now guarded and documented
  (measured — `MTP0001`, all 158 tests of the target project ran); a new test asserts every
  documented `--filter-class` FQN still resolves, so a rename cannot quietly turn the flagship
  example into a `Zero tests ran` no-op; Windows `.exe` caveat restored; flag list realigned.

**Scope call.** Two of my own changes falsified statements in `.claude/skills/repo-profile.md`, which
the plan lists as a non-goal to edit. It said *"`CLAUDE.md` still advertises `--filter "Category=Builder"`"*
— false as of this PR — and CLAUDE.md now names the profile authoritative, so leaving it would have
the two files contradicting each other. Its `808 + 464 + 68 = 1340` count had also gone stale within a
day (the real total is ~1,550). Both corrected minimally; not a broader profile audit.

**Dismissed:** the dangling `coverlet.collector` pin — real, but `.csproj`/props changes are forbidden
by the plan and it is already recorded below.

## Follow-ups

Adjacent findings, deliberately **not** fixed here (the plan forbids `.csproj`/props changes, and the
spec lists coverage work as out of scope):

- **`coverlet.collector` is a dead pin.** `Directory.Packages.props` carries a `PackageVersion` for it,
  but **no test project references it** and no CI workflow collects coverage — so the removed
  `--collect:` command could never have produced a file even on VSTest. Either wire coverage up
  (`Microsoft.Testing.Extensions.CodeCoverage` is the MTP route) or drop the pin.
- **There is currently no way to measure coverage in this repo.** Worth a decision either way; right
  now `CLAUDE.md` simply says so rather than offering a command that does nothing.
