### PR TITLE
test(mudblazor): allowlist the record-item model the shape guard flags (#297)

### DIFF
--- a/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemShapeGuardTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/CollectionItemShapeGuardTests.cs
@@ -23,12 +23,44 @@ namespace FormCraft.ForMudBlazor.UnitTests.Fields;
 /// </remarks>
 public class CollectionItemShapeGuardTests
 {
+    /// <summary>
+    /// Collection roots that re-declare a fixture shape <b>deliberately</b>, each with the reason the
+    /// fixture cannot serve.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ⚠️ <b>Every entry here is a hole in the guard</b>, so an entry has to say what the fixture
+    /// <i>cannot express</i> — not that a local copy was quicker. "Convenience" is the case the guard
+    /// exists to catch.
+    /// </para>
+    /// <para>
+    /// <see cref="Every_Allowlisted_Type_Should_Still_Be_An_Offender_Without_The_Allowlist"/> keeps
+    /// this list honest: an entry whose suite has since migrated to the fixture stops suppressing
+    /// anything, and a stale entry would silently absolve a <i>future</i> copy of that same type.
+    /// </para>
+    /// </remarks>
+    private static readonly IReadOnlySet<Type> DeliberateLocalCopies = new HashSet<Type>
+    {
+        // FieldConfigurationRefreshTests.EqualityItemModel (#298) — holds a `record` item, and the
+        // record IS the test: that suite reproduces the duplicate-key render error a keyed collection
+        // loop raises for two rows comparing EQUAL BY VALUE. Every CollectionItemFixture model is a
+        // plain class with reference equality, so adopting the fixture would make the test vacuous —
+        // it would stop reproducing the error at all.
+        //
+        // The guard compares member types, which here are identical ("String"). The salient
+        // difference is the type's equality semantics, which a shape signature deliberately does not
+        // encode — widening the signature to include it would make the guard miss the real copies it
+        // was built for (#258's CredentialsModel/VaultModel), so the escape hatch is the right tool.
+        typeof(FieldConfigurationRefreshTests.EqualityItemModel),
+    };
+
     [Fact]
     public void No_Suite_Should_Re_Declare_A_Collection_Item_Shape_The_Fixture_Provides()
     {
         // Arrange & Act - the guard as CI runs it, over the whole assembly.
         var offenders = CollectionItemShapeGuard.FindOffenders(
-            CollectionItemShapeGuard.TestAssemblyTypes().Where(t => t.DeclaringType != typeof(Offending)));
+            CollectionItemShapeGuard.TestAssemblyTypes().Where(t => t.DeclaringType != typeof(Offending)),
+            DeliberateLocalCopies);
 
         // Assert - the message has to name the offender AND say what to do, because the reader is a
         // contributor who has just watched a green build turn red on a file they did not touch.
@@ -37,6 +69,31 @@ public class CollectionItemShapeGuardTests
             + "model and item-form builder instead (#205, #258, #282). If a local copy is genuinely "
             + "warranted, pass it to FindOffenders' allowlist with the reason:\n  "
             + string.Join("\n  ", offenders.Select(o => o.Detail)));
+    }
+
+    [Fact]
+    public void Every_Allowlisted_Type_Should_Still_Be_An_Offender_Without_The_Allowlist()
+    {
+        // Arrange - the allowlist's own guard. An entry stops suppressing anything the day its suite
+        // adopts the fixture, and a stale entry is worse than none: it silently absolves a FUTURE
+        // re-declaration of that same type. This is the same failure the file's header describes for
+        // the detection path — a check that has quietly stopped checking still reports green.
+        var universe = CollectionItemShapeGuard.TestAssemblyTypes()
+            .Where(t => t.DeclaringType != typeof(Offending))
+            .ToList();
+
+        // Act - the identical run, minus the allowlist.
+        var withoutAllowlist = CollectionItemShapeGuard.FindOffenders(universe);
+
+        // Assert - each entry must be carrying its weight, and be named if it is not.
+        foreach (var allowed in DeliberateLocalCopies)
+        {
+            withoutAllowlist.ShouldContain(
+                o => o.Owner == allowed,
+                $"{allowed.Name} is on the deliberate-local-copies allowlist but is no longer an "
+                + "offender. Either its suite adopted CollectionItemFixture — in which case delete "
+                + "the entry — or the guard stopped detecting it, which is the more serious reading.");
+        }
     }
 
     [Fact]

--- a/FormCraft.ForMudBlazor.UnitTests/Fields/FieldConfigurationRefreshTests.cs
+++ b/FormCraft.ForMudBlazor.UnitTests/Fields/FieldConfigurationRefreshTests.cs
@@ -274,12 +274,26 @@ public class FieldConfigurationRefreshTests : MudBlazorTestBase
         component.FindAll("input").Count.ShouldBe(3);
     }
 
-    private sealed record EqualityItem
+    /// <summary>
+    /// A value-equality row. <b>The <c>record</c> is the point</b> — see
+    /// <see cref="Rows_Whose_Items_Compare_Equal_Should_Render_Without_A_Duplicate_Key_Error"/>.
+    /// </summary>
+    /// <remarks>
+    /// ⛔ Do not "share this with the fixture". Every <c>CollectionItemFixture</c> model is a plain
+    /// class with reference equality, so swapping one in makes that test vacuous — it would stop
+    /// reproducing the duplicate-key error entirely. <c>internal</c> rather than <c>private</c> only
+    /// so <c>CollectionItemShapeGuardTests</c> can name it in its deliberate-copies allowlist (#297).
+    /// </remarks>
+    internal sealed record EqualityItem
     {
         public string ProductName { get; set; } = string.Empty;
     }
 
-    private sealed class EqualityItemModel
+    /// <summary>
+    /// The collection root for <see cref="EqualityItem"/>. Allowlisted in
+    /// <c>CollectionItemShapeGuardTests</c> — see the reason recorded there.
+    /// </summary>
+    internal sealed class EqualityItemModel
     {
         public List<EqualityItem> Items { get; set; } = [];
     }


### PR DESCRIPTION
**`dev` is red — this unblocks it.**

Two PRs that never saw each other landed on `dev` and are individually fine but collectively red:

- **#306** (from #297) added `CollectionItemShapeGuardTests` — fails the build when a suite
  re-declares a collection-item shape `CollectionItemFixture` already provides.
- **#308** (from #298) added `FieldConfigurationRefreshTests` with its own `EqualityItemModel` /
  `EqualityItem` — a one-string row, which is exactly `OrderItem`'s shape.

Each was green against the `dev` it branched from. Together:

```
CollectionItemShapeGuardTests.No_Suite_Should_Re_Declare_A_Collection_Item_Shape_The_Fixture_Provides
  offenders should be empty but had 2 items:
    FieldConfigurationRefreshTests.EqualityItemModel holds List<EqualityItem>, whose shape (String)
      is already a CollectionItemFixture item type
    FieldConfigurationRefreshTests.EqualityItemModel is a collection root whose composition (String)
      is already modelled by CollectionItemFixture.NamedOrderModel or OrderModel
```

### The fix: the allowlist, not the fixture

This is a **true positive with a legitimate exception**, not a guard bug — so the guard is not
weakened and the suite is not migrated.

`EqualityItem` is a `record`, and that is the entire test. `FieldConfigurationRefreshTests` reproduces
the duplicate-key render error a *keyed* collection loop raises for two rows comparing **equal by
value** — the hazard #298's README entry documents as the reason collection rows are deliberately not
keyed. Every `CollectionItemFixture` model is a plain class with **reference** equality, so adopting
the fixture would not share code, it would **make the test vacuous**: it would stop reproducing the
error at all. The suite's own comment already said so:

> The item type here is a `record` precisely because the shared fixture's models are all plain classes
> with reference equality, which is why the original suite stayed green.

The guard compares *member types*, which here are identical (`String`). The salient difference is the
type's **equality semantics**, which a shape signature deliberately does not encode — widening the
signature to capture it would make the guard miss the real copies it was built for (#258's
`CredentialsModel` / `VaultModel`). So the escape hatch #306 shipped is the right tool, used as its
own failure message directs.

### Changes

- `EqualityItem` / `EqualityItemModel`: `private` → `internal` so the guard test can name them, with
  a ⛔ comment on each saying why they must not be folded into the fixture. Visibility is not part of
  the guard's ownership rule (`IsSharedShape` tests `DeclaringType is null`), so this changes no
  behaviour — they remain nested, remain candidates, and are suppressed only by the allowlist.
- A `DeliberateLocalCopies` allowlist on `CollectionItemShapeGuardTests`, carrying the reason inline.
- **`Every_Allowlisted_Type_Should_Still_Be_An_Offender_Without_The_Allowlist`** — new. An allowlist
  entry stops suppressing anything the day its suite adopts the fixture, and a stale entry is worse
  than none: it would silently absolve a *future* re-declaration of that same type. This re-runs the
  assembly-wide scan without the allowlist and requires every entry to still be a real offender,
  naming any that is not. It is the same principle the guard's own header states — a check that has
  quietly stopped checking still reports green.

### Verification

- `dotnet build -c Release` — clean.
- `dotnet test -c Release` — **1,616 passing**, 1 skipped, 0 failing (158 Fluent / 874 core / 584 MudBlazor).
  MudBlazor goes 583→584: the previously-failing test passes and the new one is added.
- Reproduced the failure first on a clean checkout of `dev` at `65944e5`, so this is verified against
  the real break rather than an assumed one.
